### PR TITLE
Enable bit timing configuration for bit-rate switched data

### DIFF
--- a/src/config/bus.rs
+++ b/src/config/bus.rs
@@ -1,5 +1,6 @@
 //! CAN bus configuration
 
+use crate::reg::gfc::{ANFE_A, ANFS_A};
 pub use crate::reg::{self, tscc::TSS_A as TimeStampSelect};
 use core::ops::RangeInclusive;
 use fugit::HertzU32;
@@ -151,12 +152,22 @@ pub enum NonMatchingAction {
     Reject,
 }
 
-impl From<NonMatchingAction> for u8 {
+impl From<NonMatchingAction> for ANFS_A {
     fn from(val: NonMatchingAction) -> Self {
         match val {
-            NonMatchingAction::Fifo0 => 0,
-            NonMatchingAction::Fifo1 => 1,
-            NonMatchingAction::Reject => 2,
+            NonMatchingAction::Fifo0 => ANFS_A::RXF0,
+            NonMatchingAction::Fifo1 => ANFS_A::RXF1,
+            NonMatchingAction::Reject => ANFS_A::REJECT,
+        }
+    }
+}
+
+impl From<NonMatchingAction> for ANFE_A {
+    fn from(val: NonMatchingAction) -> Self {
+        match val {
+            NonMatchingAction::Fifo0 => ANFE_A::RXF0,
+            NonMatchingAction::Fifo1 => ANFE_A::RXF1,
+            NonMatchingAction::Reject => ANFE_A::REJECT,
         }
     }
 }

--- a/src/config/bus.rs
+++ b/src/config/bus.rs
@@ -1,62 +1,147 @@
 //! CAN bus configuration
 
 pub use crate::reg::{self, tscc::TSS_A as TimeStampSelect};
+use core::ops::RangeInclusive;
+use fugit::HertzU32;
 
 /// Configuration for the CAN bus
+#[derive(Copy, Clone)]
 pub struct CanConfig {
-    /// TODO
-    pub bit_rate_switching: bool,
     /// Run peripheral in CAN-FD mode
-    pub fd_mode: CanFdMode,
+    pub fd_mode: FdFeatures,
     /// Modes of testing
     pub test: TestMode,
-    /// Bit timing parameters
-    pub timing: TimingParams,
+    /// Bit timing parameters for everything except the data phase of bit rate
+    /// switched FD frames.
+    pub nominal_timing: BitTiming,
+    /// Timestamp configuration
+    pub timestamp: Timestamp,
     /// Action when handling non-matching standard frame
     pub nm_std: NonMatchingAction,
     /// Action when handling non-matching extended frame
     pub nm_ext: NonMatchingAction,
 }
 
-/// Bit-timing parameters
-pub struct TimingParams {
+/// Bit-timing parameters. The bit time is determined by
+/// - the time quantum `t_q`, which is a fraction of the peripheral clock
+/// - the number of time quanta in a bit time, determined by `phase_seg_1` and
+///   `phase_seg_2`
+/// The configurable ranges of the parameters depend on which timing is changed.
+#[derive(Copy, Clone)]
+pub struct BitTiming {
     /// Synchronization jump width
     pub sjw: u8,
     /// Propagation time and phase time before sample point
     pub phase_seg_1: u8,
     /// Time after sample point
     pub phase_seg_2: u8,
-    /// Counting mode of time stamp timer
-    pub ts_select: TimeStampSelect,
-    /// Time stamp timer prescaler, bittimes per tic
-    /// Valid values are: 1 <= ts_prescale <= 16
-    pub ts_prescale: u8,
+    /// The bitrate of the bus. This needs to be chosen so that the clock to the
+    /// MCAN peripheral is divisible into time quanta such that the bit time
+    /// determined by `phase_seg_1` and `phase_seg_2` is a whole number of time
+    /// quanta.
+    pub bitrate: HertzU32,
 }
 
-impl TimingParams {
-    /// Create a parameter field from spec-adherent values
-    pub fn new(sjw: u8, phase_seg_1: u8, phase_seg_2: u8) -> Self {
-        assert!(sjw < 128, "sjw > 127");
-        assert!(phase_seg_1 > 0, "seg1 == 0");
-        assert!(phase_seg_2 < 128, "seg2 > 127");
+#[derive(Copy, Clone)]
+pub struct Timestamp {
+    /// Counting mode of time stamp timer
+    pub select: TimeStampSelect,
+    /// Time stamp timer prescaler, bittimes per tic
+    /// Valid values are: 1 <= ts_prescale <= 16
+    pub prescaler: u8,
+}
 
+impl Default for Timestamp {
+    fn default() -> Self {
         Self {
-            sjw,
-            phase_seg_1,
-            phase_seg_2,
-            ts_select: TimeStampSelect::ZERO,
-            ts_prescale: 1,
+            select: TimeStampSelect::ZERO,
+            prescaler: 1,
+        }
+    }
+}
+
+/// Misconfigurations of [`BitTiming`].
+#[derive(Debug)]
+pub enum BitTimingError {
+    SynchronizationJumpWidth(RangeInclusive<u32>),
+    PhaseSeg1(RangeInclusive<u32>),
+    PhaseSeg2(RangeInclusive<u32>),
+    BitTime(RangeInclusive<u32>),
+    NoValidPrescaler,
+}
+
+/// Valid values of a BitTiming struct
+#[derive(Clone)]
+pub(crate) struct BitTimingRanges {
+    sjw: RangeInclusive<u32>,
+    phase_seg_1: RangeInclusive<u32>,
+    phase_seg_2: RangeInclusive<u32>,
+    /// The bit time, in time quanta
+    time_quanta_per_bit: RangeInclusive<u32>,
+    prescaler: RangeInclusive<u32>,
+}
+pub(crate) const NOMINAL_BIT_TIMING_RANGES: BitTimingRanges = BitTimingRanges {
+    sjw: 0..=127,
+    phase_seg_1: 1..=255,
+    phase_seg_2: 1..=127,
+    time_quanta_per_bit: 4..=385,
+    prescaler: 0..=511,
+};
+pub(crate) const DATA_BIT_TIMING_RANGES: BitTimingRanges = BitTimingRanges {
+    sjw: 0..=15,
+    phase_seg_1: 0..=31,
+    phase_seg_2: 0..=15,
+    time_quanta_per_bit: 4..=49,
+    prescaler: 0..=31,
+};
+
+impl BitTiming {
+    /// Returns the number of time quanta that make up one bit time, `t_bit /
+    /// t_q`
+    pub fn time_quanta_per_bit(&self) -> u32 {
+        1 + (u32::from(self.phase_seg_1) + 1) + (u32::from(self.phase_seg_2) + 1)
+    }
+
+    fn check(&self, valid: &BitTimingRanges) -> Result<(), BitTimingError> {
+        if !valid.sjw.contains(&self.sjw.into()) {
+            Err(BitTimingError::SynchronizationJumpWidth(valid.sjw.clone()))
+        } else if !valid.phase_seg_1.contains(&self.phase_seg_1.into()) {
+            Err(BitTimingError::PhaseSeg1(valid.phase_seg_1.clone()))
+        } else if !valid.phase_seg_2.contains(&self.phase_seg_2.into()) {
+            Err(BitTimingError::PhaseSeg2(valid.phase_seg_2.clone()))
+        } else if !valid
+            .time_quanta_per_bit
+            .contains(&self.time_quanta_per_bit())
+        {
+            Err(BitTimingError::BitTime(valid.time_quanta_per_bit.clone()))
+        } else {
+            Ok(())
         }
     }
 
-    /// Get total time for quanta
-    pub fn quanta(&self) -> u16 {
-        1 + ((self.phase_seg_1 as u16) + 1) + ((self.phase_seg_2 as u16) + 1)
+    pub(crate) fn prescaler(
+        &self,
+        f_can: HertzU32,
+        valid: &BitTimingRanges,
+    ) -> Result<u16, BitTimingError> {
+        self.check(valid)?;
+        let f_out = self.bitrate;
+        let f_q = f_out * self.time_quanta_per_bit();
+        if let Some(0) = f_can.to_Hz().checked_rem(f_q.to_Hz()) {
+            let prescaler = f_can / f_q;
+            if !valid.prescaler.contains(&prescaler) {
+                Err(BitTimingError::NoValidPrescaler)
+            } else {
+                Ok(prescaler as u16)
+            }
+        } else {
+            Err(BitTimingError::NoValidPrescaler)
+        }
     }
 }
 
 /// What to do with non-matching frames
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub enum NonMatchingAction {
     /// Put frame in FIFO 0
     Fifo0,
@@ -82,26 +167,25 @@ impl Default for NonMatchingAction {
     }
 }
 
-/// Enable/disable CAN-FD on the controller
-#[derive(Clone)]
-pub enum CanFdMode {
-    /// Classic mode with 8-bytes data
-    Classic,
-    /// FD-mode with at most 64-bytes data
-    Fd,
-}
-
-impl From<CanFdMode> for bool {
-    fn from(val: CanFdMode) -> Self {
-        match val {
-            CanFdMode::Classic => false,
-            CanFdMode::Fd => true,
-        }
-    }
+/// Enable/disable CAN-FD and related features
+#[derive(Copy, Clone)]
+pub enum FdFeatures {
+    /// Classic mode with 8-bytes data. Reception of an FD frame is considered
+    /// an error.
+    ClassicOnly,
+    /// Transmission and reception of CAN FD frames (with up to 64 bytes of
+    /// data) is enabled. This does not prevent use of classic CAN frames.
+    Fd {
+        /// If `true`, FD frames can be transmitted with bit rate switching.
+        allow_bit_rate_switching: bool,
+        /// Bit timing parameters for the data phase of bit rate switched FD
+        /// frames.
+        data_phase_timing: BitTiming,
+    },
 }
 
 /// Test modes for the bus
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub enum TestMode {
     /// Do not initialize a test
     Disabled,


### PR DESCRIPTION
TimingParams is split to exploit the similarities between the bit timing configuration in NBTP and DBTP. Timestamping is just moved to a separate struct for now.

The validity of the parameters in the new BitTiming struct now checked when applying them instead of on construction. This prevents public fields in the struct allowing the user to skip the checks.

The divider (now called `prescaler` to better match the manual) calculation is changed to remove floating point operations.

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All tests pass and in the best case you also added new tests.
- [x] `cargo +nightly fmt` was run.
- [x] `cargo +stable clippy` yields no `warnings`.
- [ ] ~Your changes were added to the `CHANGELOG.md` in the proper section.~
- [x] You add a description of your work to this PR.
- [x] You added proper docs (in code, rustdoc and README.md) for your
      newly added features and code.
