### PR TITLE
Refer to `mcan-core` via crates.io

### DIFF
--- a/mcan/Cargo.toml
+++ b/mcan/Cargo.toml
@@ -11,8 +11,7 @@ documentation = "https://docs.rs/crate/mcan/"
 readme = "../README.md"
 
 [dependencies]
-# FIXME: Switch to crates.io reference after release
-mcan-core = { path = "../mcan-core" }
+mcan-core = "0.1"
 bitfield = "0.14"
 embedded-can = "0.4"
 fugit = "0.3.5"


### PR DESCRIPTION
In order to make `mcan` releasable in the future, it should depend on `mcan-core` through crates.io registry instead of the PATH.
