### PR TITLE
Small fixes

### DIFF
--- a/mcan-core/src/lib.rs
+++ b/mcan-core/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 #![warn(missing_docs)]
 
 //! `mcan-core` provides a set of essential abstractions that serves as a thin

--- a/mcan/src/bus.rs
+++ b/mcan/src/bus.rs
@@ -91,6 +91,7 @@ impl From<BitTimingError> for ConfigurationError {
 }
 
 /// Index is out of bounds
+#[derive(Debug)]
 pub struct OutOfBounds;
 
 /// Common CANbus functionality

--- a/mcan/src/lib.rs
+++ b/mcan/src/lib.rs
@@ -8,11 +8,14 @@ pub mod filter;
 pub mod interrupt;
 pub mod message;
 pub mod messageram;
+pub mod prelude;
 pub mod reg;
 pub mod rx_dedicated_buffers;
 pub mod rx_fifo;
 pub mod tx_buffers;
 pub mod tx_event_fifo;
+
+pub use embedded_can;
 
 // For svd2rust generated code that refers to everything via `crate::...`
 use reg::generic::*;

--- a/mcan/src/prelude.rs
+++ b/mcan/src/prelude.rs
@@ -1,0 +1,4 @@
+use crate::message::{self, rx, tx};
+pub use message::Raw as _;
+pub use rx::AnyMessage as _;
+pub use tx::AnyMessage as _;


### PR DESCRIPTION
- mcan-core is missing `no_std`, so application crates for embedded targets do not compile.
- re-export `embedded-can`
- add a small prelude
- derive `Debug` for `OutOfBounds`
