### PR TITLE
Release mcan-core/0.1.1

### DIFF
--- a/mcan-core/Cargo.toml
+++ b/mcan-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcan-core"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Unofficial MCAN Hardware Abstraction Layer (integration layer)"
 keywords = ["no-std", "can"]


### PR DESCRIPTION
Release contains:
- fix for previously missing `#![no_std]` attribute (#8)