### PR TITLE
Relax version constraint on bitfield

### DIFF
--- a/mcan/Cargo.toml
+++ b/mcan/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 
 [dependencies]
 mcan-core = "0.1"
-bitfield = "0.14"
+bitfield = ">=0.13, <=0.14"
 embedded-can = "0.4"
 fugit = "0.3.5"
 generic-array = "0.14"


### PR DESCRIPTION
0.13.2 is still used by other crates in the ecosystem (cortex-m, atsamd-hal). Since the breaking changes in bitfield 0.14 do not affect mcan internals, the choice can be left to the user crate.