### PR TITLE
Implement Iterator for received messages

### DIFF
--- a/mcan/src/rx_dedicated_buffers.rs
+++ b/mcan/src/rx_dedicated_buffers.rs
@@ -105,3 +105,11 @@ impl<'a, P: mcan_core::CanId, M: rx::AnyMessage> RxDedicatedBuffer<'a, P, M> {
             .ok_or(nb::Error::WouldBlock)
     }
 }
+
+impl<'a, P: mcan_core::CanId, M: rx::AnyMessage> Iterator for RxDedicatedBuffer<'a, P, M> {
+    type Item = M;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.receive_any().ok()
+    }
+}


### PR DESCRIPTION
This simplifies the typical use case where the interrupt flag is not cleared without the intent to handle all messages currently in the buffer.