### PR TITLE
Introduce `Dyn*` traits + rename `Internals` to `Aux`

### DIFF
--- a/mcan/src/prelude.rs
+++ b/mcan/src/prelude.rs
@@ -2,3 +2,11 @@ use crate::message::{self, rx, tx};
 pub use message::Raw as _;
 pub use rx::AnyMessage as _;
 pub use tx::AnyMessage as _;
+
+pub use crate::bus::DynAux as _;
+pub use crate::interrupt::DynInterruptConfiguration as _;
+pub use crate::interrupt::DynOwnedInterruptSet as _;
+pub use crate::rx_dedicated_buffers::DynRxDedicatedBuffer as _;
+pub use crate::rx_fifo::DynRxFifo as _;
+pub use crate::tx_buffers::DynTx as _;
+pub use crate::tx_event_fifo::DynTxEventFifo as _;


### PR DESCRIPTION
`Dyn*` traits should decrease virality of generic parameters in function signatures. Thanks to them type constraints can be more selective.

Functionality exposed previously by the `CanBus` trait and implemented by the `Can` struct was moved to `Aux` struct (previously `Internals`) in order to provide this APIs also after `Can` struct is destructured by the user.
