### PR TITLE
Add validation of transmitted messages

### DIFF
--- a/mcan/src/bus.rs
+++ b/mcan/src/bus.rs
@@ -103,10 +103,6 @@ impl From<BitTimingError> for ConfigurationError {
     }
 }
 
-/// Index is out of bounds
-#[derive(Debug)]
-pub struct OutOfBounds;
-
 /// A CAN bus that is not in configuration mode (CCE=0). Some errors (including
 /// Bus_Off) can asynchronously stop bus operation (INIT=1), which will require
 /// user intervention to reactivate the bus to resume sending and receiving

--- a/mcan/src/bus.rs
+++ b/mcan/src/bus.rs
@@ -474,6 +474,8 @@ impl<'a, Id: mcan_core::CanId, D: mcan_core::Dependencies<Id>, C: Capacities>
         let memory = memory.init();
         Self::apply_ram_config(&reg, memory);
 
+        let config = CanConfig::new(bitrate);
+
         let can = CanConfigurable(Can {
             // Safety: Since `Can::new` takes a PAC singleton, it can only be called once. Then no
             // duplicates will be constructed. The registers that are delegated to these components
@@ -485,12 +487,12 @@ impl<'a, Id: mcan_core::CanId, D: mcan_core::Dependencies<Id>, C: Capacities>
             rx_dedicated_buffers: unsafe {
                 RxDedicatedBuffer::new(&mut memory.rx_dedicated_buffers)
             },
-            tx: unsafe { Tx::new(&mut memory.tx_buffers) },
+            tx: unsafe { Tx::new(&mut memory.tx_buffers, config.mode) },
             tx_event_fifo: unsafe { TxEventFifo::new(&mut memory.tx_event_fifo) },
             aux: Aux {
                 reg,
                 dependencies,
-                config: CanConfig::new(bitrate),
+                config,
                 // Safety: The memory is zeroed by `memory.init`, so all filters are initially
                 // disabled.
                 filters_standard: unsafe { FiltersStandard::new(&mut memory.filters_standard) },

--- a/mcan/src/tx_buffers.rs
+++ b/mcan/src/tx_buffers.rs
@@ -1,3 +1,4 @@
+use crate::config::Mode;
 use crate::messageram::Capacities;
 use crate::reg;
 use core::convert::Infallible;
@@ -14,6 +15,7 @@ pub enum Error {
 /// Transmit queue and dedicated buffers
 pub struct Tx<'a, P, C: Capacities> {
     memory: &'a mut GenericArray<VolatileCell<C::TxMessage>, C::TxBuffers>,
+    mode: Mode,
     _markers: PhantomData<P>,
 }
 
@@ -114,9 +116,11 @@ impl<'a, P: mcan_core::CanId, C: Capacities> Tx<'a, P, C> {
     /// - TXBCIE
     pub(crate) unsafe fn new(
         memory: &'a mut GenericArray<VolatileCell<C::TxMessage>, C::TxBuffers>,
+        mode: Mode,
     ) -> Self {
         Self {
             memory,
+            mode,
             _markers: PhantomData,
         }
     }


### PR DESCRIPTION
Previously, user could build any message and send it, regardless of the actual CAN configuration. Now, attempt to send a FD message or bitrate switched FD message with a misconfigured CAN will yield an appropriate error.
