### PR TITLE
Make "FD remote frames" unrepresentable

### DIFF
--- a/mcan/src/message/mod.rs
+++ b/mcan/src/message/mod.rs
@@ -57,8 +57,7 @@ impl<const N: usize> Frame for Message<N> {
     fn new(id: impl Into<Id>, data: &[u8]) -> Option<Self> {
         tx::MessageBuilder {
             id: id.into(),
-            frame_contents: tx::FrameContents::Data(data),
-            frame_format: tx::FrameFormat::Classic,
+            frame_type: tx::FrameType::Classic(tx::ClassicFrameType::Data(data)),
             store_tx_event: None,
         }
         .build()
@@ -72,10 +71,9 @@ impl<const N: usize> Frame for Message<N> {
         }
         tx::MessageBuilder {
             id: id.into(),
-            frame_contents: tx::FrameContents::Remote {
+            frame_type: tx::FrameType::Classic(tx::ClassicFrameType::Remote {
                 desired_len: dlc_to_len(dlc as u8, false),
-            },
-            frame_format: tx::FrameFormat::Classic,
+            }),
             store_tx_event: None,
         }
         .build()

--- a/mcan/src/message/rx.rs
+++ b/mcan/src/message/rx.rs
@@ -64,20 +64,20 @@ where
     fn as_tx_builder(&'_ self) -> tx::MessageBuilder<'_> {
         tx::MessageBuilder {
             id: self.id(),
-            frame_contents: if self.is_remote_frame() {
-                tx::FrameContents::Remote {
-                    desired_len: dlc_to_len(self.dlc(), self.fd_format()),
-                }
-            } else {
-                tx::FrameContents::Data(self.data())
-            },
-            frame_format: if self.fd_format() {
-                tx::FrameFormat::FlexibleDatarate {
+            frame_type: if self.fd_format() {
+                tx::FrameType::FlexibleDatarate {
+                    payload: self.data(),
                     bit_rate_switching: self.bit_rate_switching(),
                     force_error_state_indicator: false,
                 }
             } else {
-                tx::FrameFormat::Classic
+                tx::FrameType::Classic(if self.is_remote_frame() {
+                    tx::ClassicFrameType::Remote {
+                        desired_len: dlc_to_len(self.dlc(), self.fd_format()),
+                    }
+                } else {
+                    tx::ClassicFrameType::Data(self.data())
+                })
             },
             store_tx_event: None,
         }


### PR DESCRIPTION
Previously, `MessageBuilder` allowed for creation of "remote" CAN FD messages which are not supported by CAN protocol.