### PR TITLE
Demand `Message RAM` pointer through `Dependencies`

### DIFF
--- a/mcan-core/Cargo.toml
+++ b/mcan-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcan-core"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "Unofficial MCAN Hardware Abstraction Layer (integration layer)"
 keywords = ["no-std", "can"]

--- a/mcan-core/src/lib.rs
+++ b/mcan-core/src/lib.rs
@@ -210,7 +210,7 @@ pub unsafe trait CanId {
 ///     TX: TxPin<ValidFor = ID>,
 ///     CAN: OwnedPeripheral<Represents = ID>,
 /// {
-///     fn message_ram(&self) -> *const () {
+///     fn eligible_message_ram_start(&self) -> *const () {
 ///         0x2000_0000 as _
 ///     }
 ///
@@ -266,14 +266,14 @@ pub unsafe trait CanId {
 ///
 /// [`mcan`]: <https://docs.rs/crate/mcan/>
 pub unsafe trait Dependencies<Id: CanId> {
-    /// Pointer to the `Message RAM`.
+    /// Pointer to the start of memory that can be used for `Message RAM`.
     ///
     /// Only 2 most significant bytes are relevant.
     ///
     /// MCAN uses 16-bit addressing internally. In order to validate the
-    /// correctness of the `Message RAM` placement, target HAL has to provide
-    /// the information about its absolute position in RAM.
-    fn message_ram(&self) -> *const ();
+    /// correctness of the `Message RAM` placement, the target HAL has to
+    /// provide information about its absolute position in RAM.
+    fn eligible_message_ram_start(&self) -> *const ();
     /// Frequency of the host / main / CPU clock.
     ///
     /// MCAN uses the host clock for most of its internal operations and its

--- a/mcan-core/src/lib.rs
+++ b/mcan-core/src/lib.rs
@@ -210,6 +210,10 @@ pub unsafe trait CanId {
 ///     TX: TxPin<ValidFor = ID>,
 ///     CAN: OwnedPeripheral<Represents = ID>,
 /// {
+///     fn message_ram(&self) -> *const () {
+///         0x2000_0000 as _
+///     }
+///
 ///     fn host_clock(&self) -> HertzU32 {
 ///         self.host_clock_token.frequency()
 ///     }
@@ -262,6 +266,14 @@ pub unsafe trait CanId {
 ///
 /// [`mcan`]: <https://docs.rs/crate/mcan/>
 pub unsafe trait Dependencies<Id: CanId> {
+    /// Pointer to the `Message RAM`.
+    ///
+    /// Only 2 most significant bytes are relevant.
+    ///
+    /// MCAN uses 16-bit addressing internally. In order to validate the
+    /// correctness of the `Message RAM` placement, target HAL has to provide
+    /// the information about its absolute position in RAM.
+    fn message_ram(&self) -> *const ();
     /// Frequency of the host / main / CPU clock.
     ///
     /// MCAN uses the host clock for most of its internal operations and its


### PR DESCRIPTION
MCAN uses 16-bit addressing internally. In order to validate the correctness of the `Message RAM` placement, target HAL has to provide the information about its absolute position in RAM.