### PR TITLE
Fix: repopulate mode config in `tx`

### DIFF
--- a/mcan/src/bus.rs
+++ b/mcan/src/bus.rs
@@ -289,6 +289,8 @@ impl<'a, Id: mcan_core::CanId, D: mcan_core::Dependencies<Id>, C: Capacities>
                 });
             }
         };
+        // Repopulate mode configuration in `tx`
+        self.0.tx.mode = config.mode;
 
         // Global filter configuration
         // This setting is redundant and the same behaviour is achievable through main

--- a/mcan/src/tx_buffers.rs
+++ b/mcan/src/tx_buffers.rs
@@ -27,7 +27,7 @@ pub enum Error {
 /// Transmit queue and dedicated buffers
 pub struct Tx<'a, P, C: Capacities> {
     memory: &'a mut GenericArray<VolatileCell<C::TxMessage>, C::TxBuffers>,
-    mode: Mode,
+    pub(crate) mode: Mode,
     _markers: PhantomData<P>,
 }
 


### PR DESCRIPTION
After initial construction of `tx: Tx`, mode settings never repopulated if a user decided to change them. This commit fixes it.