### PR TITLE
Release mcan/0.2.0

### DIFF
--- a/mcan/Cargo.toml
+++ b/mcan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcan"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Unofficial MCAN Hardware Abstraction Layer"
 keywords = ["no-std", "can"]


### PR DESCRIPTION
The first actual release of the `mcan` crate.
