### PR TITLE
Release mcan-core/0.2.2

### DIFF
--- a/mcan-core/Cargo.toml
+++ b/mcan-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcan-core"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Unofficial MCAN Hardware Abstraction Layer (integration layer)"
 keywords = ["no-std", "can"]


### PR DESCRIPTION
Version 0.2.1 did not include updated README.md. Now, both mcan/0.2.0 and mcan-core/0.2.2 should have the same welcome page on `crates.io`
