### PR TITLE
Make OwnedInterruptSet must_use

### DIFF
--- a/mcan/src/interrupt.rs
+++ b/mcan/src/interrupt.rs
@@ -409,6 +409,7 @@ impl Iterator for Iter {
     }
 }
 
+#[must_use]
 /// Has exclusive access to a set of interrupts for CAN peripheral `P`. Permits
 /// safe access to the owned interrupt flags.
 pub struct OwnedInterruptSet<P>(InterruptSet, PhantomData<P>);


### PR DESCRIPTION
If `OwnedInterruptSet` is dropped, you cannot interact with the interrupts anymore. E.g. clearing them.
