### PR TITLE
Release mcan/0.3.0

### DIFF
--- a/mcan-core/CHANGELOG.md
+++ b/mcan-core/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+Tagging in git follows a pattern: `mcan-core/<version>`.
+
+## [Unreleased]
+
+## [0.2.2] - 2022-12-15
+
+_Initial tracked release._

--- a/mcan/CHANGELOG.md
+++ b/mcan/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+Tagging in git follows a pattern: `mcan/<version>`.
+
+## [Unreleased]
+
+## [0.3.0] - 2023-04-24
+
+### Added
+- Add `Default` implementation for `OwnedInterruptSet` (#37)
+- Add InterruptSet::is_empty (#36)
+- Expand interrupt API (#34)
+
+### Changed
+- *Breaking:* Refine the interrupt system (#39)
+- Make `OwnedInterruptSet` `must_use` (#33)
+
+## [0.2.0] - 2022-12-15
+
+_Initial tracked release._


### PR DESCRIPTION
### Added
- Add `Default` implementation for `OwnedInterruptSet` (#37)
- Add InterruptSet::is_empty (#36)
- Expand interrupt API (#34)

### Changed
- *Breaking:* Refine the interrupt system (#39)
- Make `OwnedInterruptSet` `must_use` (#33)
