### PR TITLE
Expose initialization mode

### DIFF
--- a/mcan/CHANGELOG.md
+++ b/mcan/CHANGELOG.md
@@ -3,6 +3,7 @@
 Tagging in git follows a pattern: `mcan/<version>`.
 
 ## [Unreleased]
+- Add Can::aux::initialization_mode
 - Adhere to `filter_map_bool_then` clippy lint (#42)
 
 ## [0.3.0] - 2023-04-24

--- a/mcan/CHANGELOG.md
+++ b/mcan/CHANGELOG.md
@@ -3,7 +3,7 @@
 Tagging in git follows a pattern: `mcan/<version>`.
 
 ## [Unreleased]
-- Add Can::aux::initialization_mode
+- Add `Can::aux::initialization_mode` (#41)
 - Adhere to `filter_map_bool_then` clippy lint (#42)
 
 ## [0.3.0] - 2023-04-24

--- a/mcan/src/bus.rs
+++ b/mcan/src/bus.rs
@@ -153,6 +153,10 @@ pub trait DynAux {
     /// CAN dependencies type
     type Deps;
 
+    /// Enters Initialization mode, without enabling configuration, to
+    /// disable CAN operation.
+    fn initialization_mode(&self);
+
     /// Re-enters "Normal Operation" if in "Software Initialization" mode.
     /// In Software Initialization, messages are not received or transmitted.
     /// Configuration cannot be changed. In Normal Operation, messages can
@@ -185,6 +189,10 @@ impl<'a, Id: mcan_core::CanId, D: mcan_core::Dependencies<Id>> Aux<'a, Id, D> {
 impl<'a, Id: mcan_core::CanId, D: mcan_core::Dependencies<Id>> DynAux for Aux<'a, Id, D> {
     type Id = Id;
     type Deps = D;
+
+    fn initialization_mode(&self) {
+        self.reg.initialization_mode();
+    }
 
     fn operational_mode(&self) {
         self.reg.operational_mode();

--- a/mcan/src/reg.rs
+++ b/mcan/src/reg.rs
@@ -49,6 +49,10 @@ impl<Id: mcan_core::CanId> Can<Id> {
         self.enable_cce();
     }
 
+    pub(crate) fn initialization_mode(&self) {
+        self.set_init(true);
+    }
+
     pub(crate) fn operational_mode(&self) {
         self.set_init(false);
     }


### PR DESCRIPTION
Added initialization_mode method to DynAux trait, to enable software support for disabling of the CAN bus.

Created a new method initialization_mode in reg, similar to configuration_mode but without setting the configuration bit. While CCCR.INIT is set, message transfer from and to the CAN bus is stopped. Setting CCCR.INIT does not change any configuration register.

Exposed the initialization mode by adding the initialization_mode function to the DynAux trait, with will implement a call to the initialization_mode method in reg.

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All tests pass and in the best case you also added new tests.
- [x] `cargo +stable fmt` was run.
- [x] `cargo +stable clippy` yields no `warnings`.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You add a description of your work to this PR.
- [x] You added proper docs (in code, rustdoc and README.md) for your
      newly added features and code.
