### PR TITLE
Fix warnings as of rust 1.73.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,4 @@ members = [
     "mcan",
     "mcan-core",
 ]
+resolver = "2"

--- a/mcan/CHANGELOG.md
+++ b/mcan/CHANGELOG.md
@@ -3,6 +3,7 @@
 Tagging in git follows a pattern: `mcan/<version>`.
 
 ## [Unreleased]
+- Adhere to `filter_map_bool_then` clippy lint (#42)
 
 ## [0.3.0] - 2023-04-24
 

--- a/mcan/src/rx_dedicated_buffers.rs
+++ b/mcan/src/rx_dedicated_buffers.rs
@@ -127,7 +127,8 @@ impl<'a, P: mcan_core::CanId, M: rx::AnyMessage> DynRxDedicatedBuffer
         self.memory
             .iter()
             .enumerate()
-            .filter_map(|(i, m)| self.has_new_data(i).then(|| (i, m.get())))
+            .filter(|&(i, _)| self.has_new_data(i))
+            .map(|(i, m)| (i, m.get()))
             .min_by_key(|(_, m)| m.id())
             .map(|(i, m)| {
                 self.mark_buffer_read(i);


### PR DESCRIPTION
All workspace members are already edition 2021 (implying resolver 2). 
Setting it on workspace to silence warnings.

Fixed clippy recommendation regarding `filter_map`, see clippy lint `filter_map_bool_then` for details.

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All tests pass and in the best case you also added new tests.
- [x] `cargo +stable fmt` was run.
- [x] `cargo +stable clippy` yields no `warnings`.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You add a description of your work to this PR.
- [x] You added proper docs (in code, rustdoc and README.md) for your
      newly added features and code.
