### PR TITLE
Fix gte errors

### DIFF
--- a/mcan/CHANGELOG.md
+++ b/mcan/CHANGELOG.md
@@ -3,6 +3,7 @@
 Tagging in git follows a pattern: `mcan/<version>`.
 
 ## [Unreleased]
+- Fix some issues with watermark sizes for Rx FIFOs and Tx Event FIFO (#43)
 - Add `Can::aux::initialization_mode` (#41)
 - Adhere to `filter_map_bool_then` clippy lint (#42)
 

--- a/mcan/src/bus.rs
+++ b/mcan/src/bus.rs
@@ -339,9 +339,10 @@ impl<'a, Id: mcan_core::CanId, D: mcan_core::Dependencies<Id>, C: Capacities>
         reg.rxf0.c.modify(|_, w| {
             let w = w.fom().bit(config.rx_fifo_0.mode.into());
             let mut watermark = config.rx_fifo_0.watermark;
-            // According to the spec, any value >= 64 is interpreted as watermark disabled
-            if watermark >= 64 {
-                watermark = 64;
+            // According to the spec, any value > 64 is interpreted as watermark interrupt
+            // disabled, as is 0.
+            if watermark > 64 {
+                watermark = 0;
             }
             // Safety: The value is sanitized before the write
             unsafe { w.fwm().bits(watermark) }
@@ -351,9 +352,10 @@ impl<'a, Id: mcan_core::CanId, D: mcan_core::Dependencies<Id>, C: Capacities>
         reg.rxf1.c.modify(|_, w| {
             let w = w.fom().bit(config.rx_fifo_1.mode.into());
             let mut watermark = config.rx_fifo_1.watermark;
-            // According to the spec, any value >= 64 is interpreted as watermark disabled
-            if watermark >= 64 {
-                watermark = 64;
+            // According to the spec, any value > 64 is interpreted as watermark interrupt
+            // disabled, as is 0.
+            if watermark > 64 {
+                watermark = 0;
             }
             // Safety: The value is sanitized before the write
             unsafe { w.fwm().bits(watermark) }
@@ -366,9 +368,10 @@ impl<'a, Id: mcan_core::CanId, D: mcan_core::Dependencies<Id>, C: Capacities>
         // Configure Tx Event Fifo
         reg.txefc.modify(|_, w| {
             let mut watermark = config.tx.tx_event_fifo_watermark;
-            // According to the spec, any value >= 32 is interpreted as watermark disabled
-            if watermark >= 32 {
-                watermark = 32;
+            // According to the spec, any value > 32 is interpreted as watermark interrupt
+            // disabled, as is 0.
+            if watermark > 32 {
+                watermark = 0;
             }
             // Safety: The value is sanitized before the write
             unsafe { w.efwm().bits(watermark) }


### PR DESCRIPTION
This change fixes some issues where watermark maximum sizes were interpreted the wrong way. Leading to watermarks clamping to the maximum value instead of disabling interrupts on overflow, as per the spec.

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All tests pass and in the best case you also added new tests.
- [x] `cargo +stable fmt` was run.
- [x] `cargo +stable clippy` yields no `warnings`.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You add a description of your work to this PR.
- [x] You added proper docs (in code, rustdoc and README.md) for your
      newly added features and code.
