### PR TITLE
Release mcan/0.4.0

### DIFF
--- a/mcan/CHANGELOG.md
+++ b/mcan/CHANGELOG.md
@@ -3,8 +3,14 @@
 Tagging in git follows a pattern: `mcan/<version>`.
 
 ## [Unreleased]
-- Fix some issues with watermark sizes for Rx FIFOs and Tx Event FIFO (#43)
+
+## [0.4.0] - 2023-10-24
+
+### Added
 - Add `Can::aux::initialization_mode` (#41)
+
+### Changed
+- Fix some issues with watermark sizes for Rx FIFOs and Tx Event FIFO (#43)
 - Adhere to `filter_map_bool_then` clippy lint (#42)
 
 ## [0.3.0] - 2023-04-24

--- a/mcan/Cargo.toml
+++ b/mcan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcan"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Unofficial MCAN Hardware Abstraction Layer"
 keywords = ["no-std", "can"]


### PR DESCRIPTION
### Added
 - Add `Can::aux::initialization_mode` (#41)

### Changed
 - Fix some issues with watermark sizes for Rx FIFOs and Tx Event FIFO (#43)
 - Adhere to `filter_map_bool_then` clippy lint (#42)