### PR TITLE
Implement MCAN shutdown by writing to CSR

### DIFF
--- a/mcan/CHANGELOG.md
+++ b/mcan/CHANGELOG.md
@@ -4,7 +4,7 @@ Tagging in git follows a pattern: `mcan/<version>`.
 
 ## [Unreleased]
 - *Breaking* Update the register mappings with svd2rust 0.30.2 and form 0.10.0 (#46)
-- Add `Can::aux::shutdown` to safely shutdown the bus (#45)
+- Add safe way to shutdown the bus when actively transmitting/receiving (#45)
 
 ## [0.4.0] - 2023-10-24
 

--- a/mcan/CHANGELOG.md
+++ b/mcan/CHANGELOG.md
@@ -4,7 +4,7 @@ Tagging in git follows a pattern: `mcan/<version>`.
 
 ## [Unreleased]
 - *Breaking* Update the register mappings with svd2rust 0.30.2 and form 0.10.0 (#46)
-- Add `Can::aux::shutdown` to safely shutdown the bus
+- Add `Can::aux::shutdown` to safely shutdown the bus (#45)
 
 ## [0.4.0] - 2023-10-24
 

--- a/mcan/CHANGELOG.md
+++ b/mcan/CHANGELOG.md
@@ -4,6 +4,7 @@ Tagging in git follows a pattern: `mcan/<version>`.
 
 ## [Unreleased]
 - *Breaking* Update the register mappings with svd2rust 0.30.2 and form 0.10.0 (#46)
+- Add `Can::aux::shutdown` to safely shutdown the bus
 
 ## [0.4.0] - 2023-10-24
 

--- a/mcan/src/bus.rs
+++ b/mcan/src/bus.rs
@@ -163,19 +163,19 @@ pub trait DynAux {
     /// consideration regarding clocking and message handling.
     ///
     /// It is also worth noting that this mode should not be interpreted as the
-    /// peripheral being "powered off", since it is still possible to
-    /// configure the peripheral while in this mode.
+    /// peripheral being "powered off", since it is still possible to configure
+    /// the peripheral while in this mode.
     fn power_down_mode(&self);
 
     /// Check if the transition to `Power Down (sleep mode)` is complete and
     /// that it is safe to completely disable the peripheral.
     ///
     /// Returns `false` if the peripheral is still handling outgoing or
-    /// incomming messages.
+    /// incoming messages.
     ///
-    /// If the bus is heavily congested, the peripheral
-    /// might never enter `Power Down (sleep mode)` on its own. In that case
-    /// it can be forced by calling `initialization_mode`.
+    /// If the bus is heavily congested, the peripheral might never enter
+    /// `Power Down (sleep mode)` on its own. In that case it can be forced by
+    /// calling `initialization_mode`.
     fn is_ready_for_power_off(&self) -> bool;
 
     /// Re-enters "Normal Operation" if in "Software Initialization" mode.

--- a/mcan/src/bus.rs
+++ b/mcan/src/bus.rs
@@ -157,6 +157,14 @@ pub trait DynAux {
     /// disable CAN operation.
     fn initialization_mode(&self);
 
+    /// Sets MCAN up for being shut down.
+    /// See `Power Down (sleep mode)`, in the peripheral docs, for user
+    /// consideration regarding clocking and message handling.
+    fn shutdown(&self);
+
+    /// Check if csa bit is set
+    fn ready_for_shutdown(&self) -> bool;
+
     /// Re-enters "Normal Operation" if in "Software Initialization" mode.
     /// In Software Initialization, messages are not received or transmitted.
     /// Configuration cannot be changed. In Normal Operation, messages can
@@ -204,6 +212,14 @@ impl<'a, Id: mcan_core::CanId, D: mcan_core::Dependencies<Id>> DynAux for Aux<'a
 
     fn error_counters(&self) -> ErrorCounters {
         ErrorCounters(self.reg.ecr.read())
+    }
+
+    fn shutdown(&self) {
+        self.reg.cccr.write(|w| w.csr().set_bit());
+    }
+
+    fn ready_for_shutdown(&self) -> bool {
+        self.reg.cccr.read().csa().bit_is_set()
     }
 
     fn protocol_status(&self) -> ProtocolStatus {

--- a/mcan/src/reg.rs
+++ b/mcan/src/reg.rs
@@ -35,8 +35,8 @@ impl<Id> Can<Id> {
 
 impl<Id: mcan_core::CanId> Can<Id> {
     fn set_init(&self, value: bool) {
-        // Ensure the peripheral leaves the "power down" mode properly if it previously
-        // entered.
+        // Ensure the peripheral leaves the "power down" mode properly if it was
+        // previously entered.
         if !value {
             self.cccr.modify(|_, w| w.csr().clear_bit());
             while self.cccr.read().csa().bit_is_set() {}

--- a/mcan/src/reg.rs
+++ b/mcan/src/reg.rs
@@ -35,7 +35,8 @@ impl<Id> Can<Id> {
 
 impl<Id: mcan_core::CanId> Can<Id> {
     fn set_init(&self, value: bool) {
-        // Ensure we leave the shutdown state properly if we have entered it.
+        // Ensure the peripheral leaves the "power down" mode properly if it previously
+        // entered.
         if !value {
             self.cccr.modify(|_, w| w.csr().clear_bit());
             while self.cccr.read().csa().bit_is_set() {}

--- a/mcan/src/reg.rs
+++ b/mcan/src/reg.rs
@@ -35,6 +35,12 @@ impl<Id> Can<Id> {
 
 impl<Id: mcan_core::CanId> Can<Id> {
     fn set_init(&self, value: bool) {
+        // Ensure we leave the shutdown state properly if we have entered it.
+        if !value {
+            self.cccr.modify(|_, w| w.csr().clear_bit());
+            while self.cccr.read().csa().bit_is_set() {}
+        }
+
         self.cccr.modify(|_, w| w.init().bit(value));
         while self.cccr.read().init().bit() != value {}
     }


### PR DESCRIPTION
MCAN can safely be shut down by writing to the `CCCR.CSR` register
(Clock Stop Request) and then waiting for `CCCR.CSA` (Clock Stop
Acknowledge) to become high.

This will not interrupt any ongoing transmissions/receptions and is
therefore deemed the safe way to shut down the bus.

Note: It is not stated directly, but testing has shown that issuing a
stop request will only wait for the currently ongoing transmissions
and not what is queued. These messages will be sent once we enter
operational mode again.

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All tests pass and in the best case you also added new tests.
- [x] `cargo +stable fmt` was run.
- [x] `cargo +stable clippy` yields no `warnings`.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You add a description of your work to this PR.
- [x] You added proper docs (in code, rustdoc and README.md) for your
      newly added features and code.
