### PR TITLE
Re-generate register mappings with svd2rust 0.30.2

### DIFF
--- a/mcan/CHANGELOG.md
+++ b/mcan/CHANGELOG.md
@@ -3,6 +3,7 @@
 Tagging in git follows a pattern: `mcan/<version>`.
 
 ## [Unreleased]
+- *Breaking* Update the register mappings with svd2rust 0.30.2 and form 0.10.0 (#46)
 
 ## [0.4.0] - 2023-10-24
 

--- a/mcan/src/bus.rs
+++ b/mcan/src/bus.rs
@@ -42,14 +42,14 @@ impl Debug for ProtocolStatus {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ProtocolStatus")
             .field("tdcv", &self.tdcv().bits())
-            .field("pxe", &self.pxe().bits())
-            .field("rfdf", &self.rfdf().bits())
-            .field("rbrs", &self.rbrs().bits())
-            .field("resi", &self.resi().bits())
+            .field("pxe", &self.pxe().bit())
+            .field("rfdf", &self.rfdf().bit())
+            .field("rbrs", &self.rbrs().bit())
+            .field("resi", &self.resi().bit())
             .field("dlec", &self.dlec().bits())
-            .field("bo", &self.bo().bits())
-            .field("ew", &self.ew().bits())
-            .field("ep", &self.ep().bits())
+            .field("bo", &self.bo().bit())
+            .field("ew", &self.ew().bit())
+            .field("ep", &self.ep().bit())
             .field("act", &self.act().bits())
             .field("lec", &self.lec().bits())
             .finish()
@@ -326,9 +326,9 @@ impl<'a, Id: mcan_core::CanId, D: mcan_core::Dependencies<Id>, C: Capacities>
         // filter API
         reg.gfc.write(|w| {
             w.anfs()
-                .variant(crate::reg::gfc::ANFS_A::REJECT)
+                .variant(crate::reg::gfc::ANFSSELECT_A::REJECT)
                 .anfe()
-                .variant(crate::reg::gfc::ANFE_A::REJECT)
+                .variant(crate::reg::gfc::ANFESELECT_A::REJECT)
         });
 
         // Configure test/loopback mode

--- a/mcan/src/config.rs
+++ b/mcan/src/config.rs
@@ -1,6 +1,6 @@
 //! CAN bus configuration
 
-pub use crate::reg::{self, tscc::TSS_A as TimeStampSelect};
+pub use crate::reg::{self, tscc::TSSSELECT_A as TimeStampSelect};
 use core::ops::RangeInclusive;
 use fugit::HertzU32;
 

--- a/mcan/src/reg/cccr.rs
+++ b/mcan/src/reg/cccr.rs
@@ -226,7 +226,7 @@ impl W {
         self
     }
 }
-#[doc = "CC Control\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`cccr::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`cccr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "CC Control\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`cccr::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`cccr::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CCCR_SPEC;
 impl crate::RegisterSpec for CCCR_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/cccr.rs
+++ b/mcan/src/reg/cccr.rs
@@ -1,724 +1,244 @@
 #[doc = "Register `CCCR` reader"]
-pub struct R(crate::R<CCCR_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<CCCR_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<CCCR_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<CCCR_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<CCCR_SPEC>;
 #[doc = "Register `CCCR` writer"]
-pub struct W(crate::W<CCCR_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<CCCR_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<CCCR_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<CCCR_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<CCCR_SPEC>;
 #[doc = "Field `INIT` reader - Initialization"]
-pub struct INIT_R(crate::FieldReader<bool, bool>);
-impl INIT_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        INIT_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for INIT_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type INIT_R = crate::BitReader;
 #[doc = "Field `INIT` writer - Initialization"]
-pub struct INIT_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> INIT_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x01) | (value as u32 & 0x01);
-        self.w
-    }
-}
+pub type INIT_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CCE` reader - Configuration Change Enable"]
-pub struct CCE_R(crate::FieldReader<bool, bool>);
-impl CCE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CCE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CCE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CCE_R = crate::BitReader;
 #[doc = "Field `CCE` writer - Configuration Change Enable"]
-pub struct CCE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CCE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 1)) | ((value as u32 & 0x01) << 1);
-        self.w
-    }
-}
+pub type CCE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ASM` reader - ASM Restricted Operation Mode"]
-pub struct ASM_R(crate::FieldReader<bool, bool>);
-impl ASM_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ASM_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ASM_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ASM_R = crate::BitReader;
 #[doc = "Field `ASM` writer - ASM Restricted Operation Mode"]
-pub struct ASM_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ASM_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 2)) | ((value as u32 & 0x01) << 2);
-        self.w
-    }
-}
+pub type ASM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CSA` reader - Clock Stop Acknowledge"]
-pub struct CSA_R(crate::FieldReader<bool, bool>);
-impl CSA_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CSA_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CSA_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CSA_R = crate::BitReader;
 #[doc = "Field `CSA` writer - Clock Stop Acknowledge"]
-pub struct CSA_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CSA_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 3)) | ((value as u32 & 0x01) << 3);
-        self.w
-    }
-}
+pub type CSA_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CSR` reader - Clock Stop Request"]
-pub struct CSR_R(crate::FieldReader<bool, bool>);
-impl CSR_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CSR_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CSR_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CSR_R = crate::BitReader;
 #[doc = "Field `CSR` writer - Clock Stop Request"]
-pub struct CSR_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CSR_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 4)) | ((value as u32 & 0x01) << 4);
-        self.w
-    }
-}
+pub type CSR_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `MON` reader - Bus Monitoring Mode"]
-pub struct MON_R(crate::FieldReader<bool, bool>);
-impl MON_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        MON_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for MON_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type MON_R = crate::BitReader;
 #[doc = "Field `MON` writer - Bus Monitoring Mode"]
-pub struct MON_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> MON_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 5)) | ((value as u32 & 0x01) << 5);
-        self.w
-    }
-}
+pub type MON_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `DAR` reader - Disable Automatic Retransmission"]
-pub struct DAR_R(crate::FieldReader<bool, bool>);
-impl DAR_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        DAR_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for DAR_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type DAR_R = crate::BitReader;
 #[doc = "Field `DAR` writer - Disable Automatic Retransmission"]
-pub struct DAR_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> DAR_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 6)) | ((value as u32 & 0x01) << 6);
-        self.w
-    }
-}
+pub type DAR_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TEST` reader - Test Mode Enable"]
-pub struct TEST_R(crate::FieldReader<bool, bool>);
-impl TEST_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TEST_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TEST_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TEST_R = crate::BitReader;
 #[doc = "Field `TEST` writer - Test Mode Enable"]
-pub struct TEST_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TEST_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 7)) | ((value as u32 & 0x01) << 7);
-        self.w
-    }
-}
+pub type TEST_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `FDOE` reader - FD Operation Enable"]
-pub struct FDOE_R(crate::FieldReader<bool, bool>);
-impl FDOE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        FDOE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for FDOE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type FDOE_R = crate::BitReader;
 #[doc = "Field `FDOE` writer - FD Operation Enable"]
-pub struct FDOE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> FDOE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 8)) | ((value as u32 & 0x01) << 8);
-        self.w
-    }
-}
+pub type FDOE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `BRSE` reader - Bit Rate Switch Enable"]
-pub struct BRSE_R(crate::FieldReader<bool, bool>);
-impl BRSE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        BRSE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for BRSE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type BRSE_R = crate::BitReader;
 #[doc = "Field `BRSE` writer - Bit Rate Switch Enable"]
-pub struct BRSE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> BRSE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 9)) | ((value as u32 & 0x01) << 9);
-        self.w
-    }
-}
+pub type BRSE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `PXHD` reader - Protocol Exception Handling Disable"]
-pub struct PXHD_R(crate::FieldReader<bool, bool>);
-impl PXHD_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        PXHD_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for PXHD_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type PXHD_R = crate::BitReader;
 #[doc = "Field `PXHD` writer - Protocol Exception Handling Disable"]
-pub struct PXHD_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> PXHD_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 12)) | ((value as u32 & 0x01) << 12);
-        self.w
-    }
-}
+pub type PXHD_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `EFBI` reader - Edge Filtering during Bus Integration"]
-pub struct EFBI_R(crate::FieldReader<bool, bool>);
-impl EFBI_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        EFBI_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for EFBI_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type EFBI_R = crate::BitReader;
 #[doc = "Field `EFBI` writer - Edge Filtering during Bus Integration"]
-pub struct EFBI_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> EFBI_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 13)) | ((value as u32 & 0x01) << 13);
-        self.w
-    }
-}
+pub type EFBI_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TXP` reader - Transmit Pause"]
-pub struct TXP_R(crate::FieldReader<bool, bool>);
-impl TXP_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TXP_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TXP_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TXP_R = crate::BitReader;
 #[doc = "Field `TXP` writer - Transmit Pause"]
-pub struct TXP_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TXP_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 14)) | ((value as u32 & 0x01) << 14);
-        self.w
-    }
-}
+pub type TXP_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `NISO` reader - Non ISO Operation"]
-pub struct NISO_R(crate::FieldReader<bool, bool>);
-impl NISO_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        NISO_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for NISO_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type NISO_R = crate::BitReader;
 #[doc = "Field `NISO` writer - Non ISO Operation"]
-pub struct NISO_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> NISO_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 15)) | ((value as u32 & 0x01) << 15);
-        self.w
-    }
-}
+pub type NISO_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
     #[doc = "Bit 0 - Initialization"]
     #[inline(always)]
     pub fn init(&self) -> INIT_R {
-        INIT_R::new((self.bits & 0x01) != 0)
+        INIT_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - Configuration Change Enable"]
     #[inline(always)]
     pub fn cce(&self) -> CCE_R {
-        CCE_R::new(((self.bits >> 1) & 0x01) != 0)
+        CCE_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - ASM Restricted Operation Mode"]
     #[inline(always)]
     pub fn asm(&self) -> ASM_R {
-        ASM_R::new(((self.bits >> 2) & 0x01) != 0)
+        ASM_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - Clock Stop Acknowledge"]
     #[inline(always)]
     pub fn csa(&self) -> CSA_R {
-        CSA_R::new(((self.bits >> 3) & 0x01) != 0)
+        CSA_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - Clock Stop Request"]
     #[inline(always)]
     pub fn csr(&self) -> CSR_R {
-        CSR_R::new(((self.bits >> 4) & 0x01) != 0)
+        CSR_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - Bus Monitoring Mode"]
     #[inline(always)]
     pub fn mon(&self) -> MON_R {
-        MON_R::new(((self.bits >> 5) & 0x01) != 0)
+        MON_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - Disable Automatic Retransmission"]
     #[inline(always)]
     pub fn dar(&self) -> DAR_R {
-        DAR_R::new(((self.bits >> 6) & 0x01) != 0)
+        DAR_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - Test Mode Enable"]
     #[inline(always)]
     pub fn test(&self) -> TEST_R {
-        TEST_R::new(((self.bits >> 7) & 0x01) != 0)
+        TEST_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - FD Operation Enable"]
     #[inline(always)]
     pub fn fdoe(&self) -> FDOE_R {
-        FDOE_R::new(((self.bits >> 8) & 0x01) != 0)
+        FDOE_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - Bit Rate Switch Enable"]
     #[inline(always)]
     pub fn brse(&self) -> BRSE_R {
-        BRSE_R::new(((self.bits >> 9) & 0x01) != 0)
+        BRSE_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 12 - Protocol Exception Handling Disable"]
     #[inline(always)]
     pub fn pxhd(&self) -> PXHD_R {
-        PXHD_R::new(((self.bits >> 12) & 0x01) != 0)
+        PXHD_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - Edge Filtering during Bus Integration"]
     #[inline(always)]
     pub fn efbi(&self) -> EFBI_R {
-        EFBI_R::new(((self.bits >> 13) & 0x01) != 0)
+        EFBI_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - Transmit Pause"]
     #[inline(always)]
     pub fn txp(&self) -> TXP_R {
-        TXP_R::new(((self.bits >> 14) & 0x01) != 0)
+        TXP_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - Non ISO Operation"]
     #[inline(always)]
     pub fn niso(&self) -> NISO_R {
-        NISO_R::new(((self.bits >> 15) & 0x01) != 0)
+        NISO_R::new(((self.bits >> 15) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - Initialization"]
     #[inline(always)]
-    pub fn init(&mut self) -> INIT_W {
-        INIT_W { w: self }
+    #[must_use]
+    pub fn init(&mut self) -> INIT_W<CCCR_SPEC, 0> {
+        INIT_W::new(self)
     }
     #[doc = "Bit 1 - Configuration Change Enable"]
     #[inline(always)]
-    pub fn cce(&mut self) -> CCE_W {
-        CCE_W { w: self }
+    #[must_use]
+    pub fn cce(&mut self) -> CCE_W<CCCR_SPEC, 1> {
+        CCE_W::new(self)
     }
     #[doc = "Bit 2 - ASM Restricted Operation Mode"]
     #[inline(always)]
-    pub fn asm(&mut self) -> ASM_W {
-        ASM_W { w: self }
+    #[must_use]
+    pub fn asm(&mut self) -> ASM_W<CCCR_SPEC, 2> {
+        ASM_W::new(self)
     }
     #[doc = "Bit 3 - Clock Stop Acknowledge"]
     #[inline(always)]
-    pub fn csa(&mut self) -> CSA_W {
-        CSA_W { w: self }
+    #[must_use]
+    pub fn csa(&mut self) -> CSA_W<CCCR_SPEC, 3> {
+        CSA_W::new(self)
     }
     #[doc = "Bit 4 - Clock Stop Request"]
     #[inline(always)]
-    pub fn csr(&mut self) -> CSR_W {
-        CSR_W { w: self }
+    #[must_use]
+    pub fn csr(&mut self) -> CSR_W<CCCR_SPEC, 4> {
+        CSR_W::new(self)
     }
     #[doc = "Bit 5 - Bus Monitoring Mode"]
     #[inline(always)]
-    pub fn mon(&mut self) -> MON_W {
-        MON_W { w: self }
+    #[must_use]
+    pub fn mon(&mut self) -> MON_W<CCCR_SPEC, 5> {
+        MON_W::new(self)
     }
     #[doc = "Bit 6 - Disable Automatic Retransmission"]
     #[inline(always)]
-    pub fn dar(&mut self) -> DAR_W {
-        DAR_W { w: self }
+    #[must_use]
+    pub fn dar(&mut self) -> DAR_W<CCCR_SPEC, 6> {
+        DAR_W::new(self)
     }
     #[doc = "Bit 7 - Test Mode Enable"]
     #[inline(always)]
-    pub fn test(&mut self) -> TEST_W {
-        TEST_W { w: self }
+    #[must_use]
+    pub fn test(&mut self) -> TEST_W<CCCR_SPEC, 7> {
+        TEST_W::new(self)
     }
     #[doc = "Bit 8 - FD Operation Enable"]
     #[inline(always)]
-    pub fn fdoe(&mut self) -> FDOE_W {
-        FDOE_W { w: self }
+    #[must_use]
+    pub fn fdoe(&mut self) -> FDOE_W<CCCR_SPEC, 8> {
+        FDOE_W::new(self)
     }
     #[doc = "Bit 9 - Bit Rate Switch Enable"]
     #[inline(always)]
-    pub fn brse(&mut self) -> BRSE_W {
-        BRSE_W { w: self }
+    #[must_use]
+    pub fn brse(&mut self) -> BRSE_W<CCCR_SPEC, 9> {
+        BRSE_W::new(self)
     }
     #[doc = "Bit 12 - Protocol Exception Handling Disable"]
     #[inline(always)]
-    pub fn pxhd(&mut self) -> PXHD_W {
-        PXHD_W { w: self }
+    #[must_use]
+    pub fn pxhd(&mut self) -> PXHD_W<CCCR_SPEC, 12> {
+        PXHD_W::new(self)
     }
     #[doc = "Bit 13 - Edge Filtering during Bus Integration"]
     #[inline(always)]
-    pub fn efbi(&mut self) -> EFBI_W {
-        EFBI_W { w: self }
+    #[must_use]
+    pub fn efbi(&mut self) -> EFBI_W<CCCR_SPEC, 13> {
+        EFBI_W::new(self)
     }
     #[doc = "Bit 14 - Transmit Pause"]
     #[inline(always)]
-    pub fn txp(&mut self) -> TXP_W {
-        TXP_W { w: self }
+    #[must_use]
+    pub fn txp(&mut self) -> TXP_W<CCCR_SPEC, 14> {
+        TXP_W::new(self)
     }
     #[doc = "Bit 15 - Non ISO Operation"]
     #[inline(always)]
-    pub fn niso(&mut self) -> NISO_W {
-        NISO_W { w: self }
+    #[must_use]
+    pub fn niso(&mut self) -> NISO_W<CCCR_SPEC, 15> {
+        NISO_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "CC Control\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cccr](index.html) module"]
+#[doc = "CC Control\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`cccr::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`cccr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CCCR_SPEC;
 impl crate::RegisterSpec for CCCR_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [cccr::R](R) reader structure"]
-impl crate::Readable for CCCR_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [cccr::W](W) writer structure"]
+#[doc = "`read()` method returns [`cccr::R`](R) reader structure"]
+impl crate::Readable for CCCR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`cccr::W`](W) writer structure"]
 impl crate::Writable for CCCR_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets CCCR to value 0x01"]
 impl crate::Resettable for CCCR_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0x01
-    }
+    const RESET_VALUE: Self::Ux = 0x01;
 }

--- a/mcan/src/reg/crel.rs
+++ b/mcan/src/reg/crel.rs
@@ -1,63 +1,11 @@
 #[doc = "Register `CREL` reader"]
-pub struct R(crate::R<CREL_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<CREL_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<CREL_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<CREL_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<CREL_SPEC>;
 #[doc = "Field `SUBSTEP` reader - Sub-step of Core Release"]
-pub struct SUBSTEP_R(crate::FieldReader<u8, u8>);
-impl SUBSTEP_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        SUBSTEP_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for SUBSTEP_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type SUBSTEP_R = crate::FieldReader;
 #[doc = "Field `STEP` reader - Step of Core Release"]
-pub struct STEP_R(crate::FieldReader<u8, u8>);
-impl STEP_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        STEP_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for STEP_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type STEP_R = crate::FieldReader;
 #[doc = "Field `REL` reader - Core Release"]
-pub struct REL_R(crate::FieldReader<u8, u8>);
-impl REL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        REL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for REL_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type REL_R = crate::FieldReader;
 impl R {
     #[doc = "Bits 20:23 - Sub-step of Core Release"]
     #[inline(always)]
@@ -75,19 +23,14 @@ impl R {
         REL_R::new(((self.bits >> 28) & 0x0f) as u8)
     }
 }
-#[doc = "Core Release\n\nThis register you can [`read`](crate::reg::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [crel](index.html) module"]
+#[doc = "Core Release\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`crel::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CREL_SPEC;
 impl crate::RegisterSpec for CREL_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [crel::R](R) reader structure"]
-impl crate::Readable for CREL_SPEC {
-    type Reader = R;
-}
+#[doc = "`read()` method returns [`crel::R`](R) reader structure"]
+impl crate::Readable for CREL_SPEC {}
 #[doc = "`reset()` method sets CREL to value 0x3210_0000"]
 impl crate::Resettable for CREL_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0x3210_0000
-    }
+    const RESET_VALUE: Self::Ux = 0x3210_0000;
 }

--- a/mcan/src/reg/crel.rs
+++ b/mcan/src/reg/crel.rs
@@ -23,7 +23,7 @@ impl R {
         REL_R::new(((self.bits >> 28) & 0x0f) as u8)
     }
 }
-#[doc = "Core Release\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`crel::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Core Release\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`crel::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CREL_SPEC;
 impl crate::RegisterSpec for CREL_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/cust.rs
+++ b/mcan/src/reg/cust.rs
@@ -1,130 +1,16 @@
-#[doc = "Register `MRCFG` reader"]
-pub type R = crate::R<MRCFG_SPEC>;
-#[doc = "Register `MRCFG` writer"]
-pub type W = crate::W<MRCFG_SPEC>;
-#[doc = "Field `QOS` reader - Quality of Service"]
-pub type QOS_R = crate::FieldReader<QOSSELECT_A>;
-#[doc = "Quality of Service\n\nValue on reset: 2"]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(u8)]
-pub enum QOSSELECT_A {
-    #[doc = "0: Background (no sensitive operation)"]
-    DISABLE = 0,
-    #[doc = "1: Sensitive Bandwidth"]
-    LOW = 1,
-    #[doc = "2: Sensitive Latency"]
-    MEDIUM = 2,
-    #[doc = "3: Critical Latency"]
-    HIGH = 3,
-}
-impl From<QOSSELECT_A> for u8 {
-    #[inline(always)]
-    fn from(variant: QOSSELECT_A) -> Self {
-        variant as _
-    }
-}
-impl crate::FieldSpec for QOSSELECT_A {
-    type Ux = u8;
-}
-impl QOS_R {
-    #[doc = "Get enumerated values variant"]
-    #[inline(always)]
-    pub const fn variant(&self) -> QOSSELECT_A {
-        match self.bits {
-            0 => QOSSELECT_A::DISABLE,
-            1 => QOSSELECT_A::LOW,
-            2 => QOSSELECT_A::MEDIUM,
-            3 => QOSSELECT_A::HIGH,
-            _ => unreachable!(),
-        }
-    }
-    #[doc = "Background (no sensitive operation)"]
-    #[inline(always)]
-    pub fn is_disable(&self) -> bool {
-        *self == QOSSELECT_A::DISABLE
-    }
-    #[doc = "Sensitive Bandwidth"]
-    #[inline(always)]
-    pub fn is_low(&self) -> bool {
-        *self == QOSSELECT_A::LOW
-    }
-    #[doc = "Sensitive Latency"]
-    #[inline(always)]
-    pub fn is_medium(&self) -> bool {
-        *self == QOSSELECT_A::MEDIUM
-    }
-    #[doc = "Critical Latency"]
-    #[inline(always)]
-    pub fn is_high(&self) -> bool {
-        *self == QOSSELECT_A::HIGH
-    }
-}
-#[doc = "Field `QOS` writer - Quality of Service"]
-pub type QOS_W<'a, REG, const O: u8> = crate::FieldWriterSafe<'a, REG, 2, O, QOSSELECT_A>;
-impl<'a, REG, const O: u8> QOS_W<'a, REG, O>
-where
-    REG: crate::Writable + crate::RegisterSpec,
-    REG::Ux: From<u8>,
-{
-    #[doc = "Background (no sensitive operation)"]
-    #[inline(always)]
-    pub fn disable(self) -> &'a mut crate::W<REG> {
-        self.variant(QOSSELECT_A::DISABLE)
-    }
-    #[doc = "Sensitive Bandwidth"]
-    #[inline(always)]
-    pub fn low(self) -> &'a mut crate::W<REG> {
-        self.variant(QOSSELECT_A::LOW)
-    }
-    #[doc = "Sensitive Latency"]
-    #[inline(always)]
-    pub fn medium(self) -> &'a mut crate::W<REG> {
-        self.variant(QOSSELECT_A::MEDIUM)
-    }
-    #[doc = "Critical Latency"]
-    #[inline(always)]
-    pub fn high(self) -> &'a mut crate::W<REG> {
-        self.variant(QOSSELECT_A::HIGH)
-    }
-}
-impl R {
-    #[doc = "Bits 0:1 - Quality of Service"]
-    #[inline(always)]
-    pub fn qos(&self) -> QOS_R {
-        QOS_R::new((self.bits & 3) as u8)
-    }
-}
-impl W {
-    #[doc = "Bits 0:1 - Quality of Service"]
-    #[inline(always)]
-    #[must_use]
-    pub fn qos(&mut self) -> QOS_W<MRCFG_SPEC, 0> {
-        QOS_W::new(self)
-    }
-    #[doc = r" Writes raw bits to the register."]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r""]
-    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
-    #[inline(always)]
-    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.bits = bits;
-        self
-    }
-}
-#[doc = "Message RAM Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`mrcfg::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`mrcfg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct MRCFG_SPEC;
-impl crate::RegisterSpec for MRCFG_SPEC {
+#[doc = "Register `CUST` reader"]
+pub type R = crate::R<CUST_SPEC>;
+#[doc = "Register `CUST` writer"]
+pub type W = crate::W<CUST_SPEC>;
+#[doc = "Customer Register\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`mrcfg::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`mrcfg::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CUST_SPEC;
+impl crate::RegisterSpec for CUST_SPEC {
     type Ux = u32;
 }
 #[doc = "`read()` method returns [`mrcfg::R`](R) reader structure"]
-impl crate::Readable for MRCFG_SPEC {}
+impl crate::Readable for CUST_SPEC {}
 #[doc = "`write(|w| ..)` method takes [`mrcfg::W`](W) writer structure"]
-impl crate::Writable for MRCFG_SPEC {
+impl crate::Writable for CUST_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
-}
-#[doc = "`reset()` method sets MRCFG to value 0x02"]
-impl crate::Resettable for MRCFG_SPEC {
-    const RESET_VALUE: Self::Ux = 0x02;
 }

--- a/mcan/src/reg/cust.rs
+++ b/mcan/src/reg/cust.rs
@@ -1,50 +1,130 @@
-#[doc = "Register `CUST` reader"]
-pub struct R(crate::R<CUST_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<CUST_SPEC>;
+#[doc = "Register `MRCFG` reader"]
+pub type R = crate::R<MRCFG_SPEC>;
+#[doc = "Register `MRCFG` writer"]
+pub type W = crate::W<MRCFG_SPEC>;
+#[doc = "Field `QOS` reader - Quality of Service"]
+pub type QOS_R = crate::FieldReader<QOSSELECT_A>;
+#[doc = "Quality of Service\n\nValue on reset: 2"]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum QOSSELECT_A {
+    #[doc = "0: Background (no sensitive operation)"]
+    DISABLE = 0,
+    #[doc = "1: Sensitive Bandwidth"]
+    LOW = 1,
+    #[doc = "2: Sensitive Latency"]
+    MEDIUM = 2,
+    #[doc = "3: Critical Latency"]
+    HIGH = 3,
+}
+impl From<QOSSELECT_A> for u8 {
     #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    fn from(variant: QOSSELECT_A) -> Self {
+        variant as _
     }
 }
-impl From<crate::R<CUST_SPEC>> for R {
+impl crate::FieldSpec for QOSSELECT_A {
+    type Ux = u8;
+}
+impl QOS_R {
+    #[doc = "Get enumerated values variant"]
     #[inline(always)]
-    fn from(reader: crate::R<CUST_SPEC>) -> Self {
-        R(reader)
+    pub const fn variant(&self) -> QOSSELECT_A {
+        match self.bits {
+            0 => QOSSELECT_A::DISABLE,
+            1 => QOSSELECT_A::LOW,
+            2 => QOSSELECT_A::MEDIUM,
+            3 => QOSSELECT_A::HIGH,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Background (no sensitive operation)"]
+    #[inline(always)]
+    pub fn is_disable(&self) -> bool {
+        *self == QOSSELECT_A::DISABLE
+    }
+    #[doc = "Sensitive Bandwidth"]
+    #[inline(always)]
+    pub fn is_low(&self) -> bool {
+        *self == QOSSELECT_A::LOW
+    }
+    #[doc = "Sensitive Latency"]
+    #[inline(always)]
+    pub fn is_medium(&self) -> bool {
+        *self == QOSSELECT_A::MEDIUM
+    }
+    #[doc = "Critical Latency"]
+    #[inline(always)]
+    pub fn is_high(&self) -> bool {
+        *self == QOSSELECT_A::HIGH
     }
 }
-#[doc = "Register `CUST` writer"]
-pub struct W(crate::W<CUST_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<CUST_SPEC>;
+#[doc = "Field `QOS` writer - Quality of Service"]
+pub type QOS_W<'a, REG, const O: u8> = crate::FieldWriterSafe<'a, REG, 2, O, QOSSELECT_A>;
+impl<'a, REG, const O: u8> QOS_W<'a, REG, O>
+where
+    REG: crate::Writable + crate::RegisterSpec,
+    REG::Ux: From<u8>,
+{
+    #[doc = "Background (no sensitive operation)"]
     #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    pub fn disable(self) -> &'a mut crate::W<REG> {
+        self.variant(QOSSELECT_A::DISABLE)
+    }
+    #[doc = "Sensitive Bandwidth"]
+    #[inline(always)]
+    pub fn low(self) -> &'a mut crate::W<REG> {
+        self.variant(QOSSELECT_A::LOW)
+    }
+    #[doc = "Sensitive Latency"]
+    #[inline(always)]
+    pub fn medium(self) -> &'a mut crate::W<REG> {
+        self.variant(QOSSELECT_A::MEDIUM)
+    }
+    #[doc = "Critical Latency"]
+    #[inline(always)]
+    pub fn high(self) -> &'a mut crate::W<REG> {
+        self.variant(QOSSELECT_A::HIGH)
     }
 }
-impl core::ops::DerefMut for W {
+impl R {
+    #[doc = "Bits 0:1 - Quality of Service"]
     #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+    pub fn qos(&self) -> QOS_R {
+        QOS_R::new((self.bits & 3) as u8)
     }
 }
-impl From<crate::W<CUST_SPEC>> for W {
+impl W {
+    #[doc = "Bits 0:1 - Quality of Service"]
     #[inline(always)]
-    fn from(writer: crate::W<CUST_SPEC>) -> Self {
-        W(writer)
+    #[must_use]
+    pub fn qos(&mut self) -> QOS_W<MRCFG_SPEC, 0> {
+        QOS_W::new(self)
+    }
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
     }
 }
-
-#[doc = "Customer Register\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mrcfg](index.html) module"]
-pub struct CUST_SPEC;
-impl crate::RegisterSpec for CUST_SPEC {
+#[doc = "Message RAM Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`mrcfg::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`mrcfg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct MRCFG_SPEC;
+impl crate::RegisterSpec for MRCFG_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [mrcfg::R](R) reader structure"]
-impl crate::Readable for CUST_SPEC {
-    type Reader = R;
+#[doc = "`read()` method returns [`mrcfg::R`](R) reader structure"]
+impl crate::Readable for MRCFG_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`mrcfg::W`](W) writer structure"]
+impl crate::Writable for MRCFG_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
-#[doc = "`write(|w| ..)` method takes [mrcfg::W](W) writer structure"]
-impl crate::Writable for CUST_SPEC {
-    type Writer = W;
+#[doc = "`reset()` method sets MRCFG to value 0x02"]
+impl crate::Resettable for MRCFG_SPEC {
+    const RESET_VALUE: Self::Ux = 0x02;
 }

--- a/mcan/src/reg/dbtp.rs
+++ b/mcan/src/reg/dbtp.rs
@@ -1,184 +1,27 @@
 #[doc = "Register `DBTP` reader"]
-pub struct R(crate::R<DBTP_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<DBTP_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<DBTP_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<DBTP_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<DBTP_SPEC>;
 #[doc = "Register `DBTP` writer"]
-pub struct W(crate::W<DBTP_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<DBTP_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<DBTP_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<DBTP_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<DBTP_SPEC>;
 #[doc = "Field `DSJW` reader - Data (Re)Synchronization Jump Width"]
-pub struct DSJW_R(crate::FieldReader<u8, u8>);
-impl DSJW_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        DSJW_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for DSJW_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type DSJW_R = crate::FieldReader;
 #[doc = "Field `DSJW` writer - Data (Re)Synchronization Jump Width"]
-pub struct DSJW_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> DSJW_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x0f) | (value as u32 & 0x0f);
-        self.w
-    }
-}
+pub type DSJW_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 4, O>;
 #[doc = "Field `DTSEG2` reader - Data time segment after sample point"]
-pub struct DTSEG2_R(crate::FieldReader<u8, u8>);
-impl DTSEG2_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        DTSEG2_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for DTSEG2_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type DTSEG2_R = crate::FieldReader;
 #[doc = "Field `DTSEG2` writer - Data time segment after sample point"]
-pub struct DTSEG2_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> DTSEG2_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x0f << 4)) | ((value as u32 & 0x0f) << 4);
-        self.w
-    }
-}
+pub type DTSEG2_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 4, O>;
 #[doc = "Field `DTSEG1` reader - Data time segment before sample point"]
-pub struct DTSEG1_R(crate::FieldReader<u8, u8>);
-impl DTSEG1_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        DTSEG1_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for DTSEG1_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type DTSEG1_R = crate::FieldReader;
 #[doc = "Field `DTSEG1` writer - Data time segment before sample point"]
-pub struct DTSEG1_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> DTSEG1_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x1f << 8)) | ((value as u32 & 0x1f) << 8);
-        self.w
-    }
-}
+pub type DTSEG1_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 5, O>;
 #[doc = "Field `DBRP` reader - Data Baud Rate Prescaler"]
-pub struct DBRP_R(crate::FieldReader<u8, u8>);
-impl DBRP_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        DBRP_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for DBRP_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type DBRP_R = crate::FieldReader;
 #[doc = "Field `DBRP` writer - Data Baud Rate Prescaler"]
-pub struct DBRP_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> DBRP_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x1f << 16)) | ((value as u32 & 0x1f) << 16);
-        self.w
-    }
-}
+pub type DBRP_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 5, O>;
 #[doc = "Field `TDC` reader - Tranceiver Delay Compensation"]
-pub struct TDC_R(crate::FieldReader<bool, bool>);
-impl TDC_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TDC_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TDC_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TDC_R = crate::BitReader;
 #[doc = "Field `TDC` writer - Tranceiver Delay Compensation"]
-pub struct TDC_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TDC_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 23)) | ((value as u32 & 0x01) << 23);
-        self.w
-    }
-}
+pub type TDC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
     #[doc = "Bits 0:3 - Data (Re)Synchronization Jump Width"]
     #[inline(always)]
@@ -203,59 +46,64 @@ impl R {
     #[doc = "Bit 23 - Tranceiver Delay Compensation"]
     #[inline(always)]
     pub fn tdc(&self) -> TDC_R {
-        TDC_R::new(((self.bits >> 23) & 0x01) != 0)
+        TDC_R::new(((self.bits >> 23) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bits 0:3 - Data (Re)Synchronization Jump Width"]
     #[inline(always)]
-    pub fn dsjw(&mut self) -> DSJW_W {
-        DSJW_W { w: self }
+    #[must_use]
+    pub fn dsjw(&mut self) -> DSJW_W<DBTP_SPEC, 0> {
+        DSJW_W::new(self)
     }
     #[doc = "Bits 4:7 - Data time segment after sample point"]
     #[inline(always)]
-    pub fn dtseg2(&mut self) -> DTSEG2_W {
-        DTSEG2_W { w: self }
+    #[must_use]
+    pub fn dtseg2(&mut self) -> DTSEG2_W<DBTP_SPEC, 4> {
+        DTSEG2_W::new(self)
     }
     #[doc = "Bits 8:12 - Data time segment before sample point"]
     #[inline(always)]
-    pub fn dtseg1(&mut self) -> DTSEG1_W {
-        DTSEG1_W { w: self }
+    #[must_use]
+    pub fn dtseg1(&mut self) -> DTSEG1_W<DBTP_SPEC, 8> {
+        DTSEG1_W::new(self)
     }
     #[doc = "Bits 16:20 - Data Baud Rate Prescaler"]
     #[inline(always)]
-    pub fn dbrp(&mut self) -> DBRP_W {
-        DBRP_W { w: self }
+    #[must_use]
+    pub fn dbrp(&mut self) -> DBRP_W<DBTP_SPEC, 16> {
+        DBRP_W::new(self)
     }
     #[doc = "Bit 23 - Tranceiver Delay Compensation"]
     #[inline(always)]
-    pub fn tdc(&mut self) -> TDC_W {
-        TDC_W { w: self }
+    #[must_use]
+    pub fn tdc(&mut self) -> TDC_W<DBTP_SPEC, 23> {
+        TDC_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Fast Bit Timing and Prescaler\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dbtp](index.html) module"]
+#[doc = "Fast Bit Timing and Prescaler\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`dbtp::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`dbtp::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct DBTP_SPEC;
 impl crate::RegisterSpec for DBTP_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [dbtp::R](R) reader structure"]
-impl crate::Readable for DBTP_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [dbtp::W](W) writer structure"]
+#[doc = "`read()` method returns [`dbtp::R`](R) reader structure"]
+impl crate::Readable for DBTP_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`dbtp::W`](W) writer structure"]
 impl crate::Writable for DBTP_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets DBTP to value 0x0a33"]
 impl crate::Resettable for DBTP_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0x0a33
-    }
+    const RESET_VALUE: Self::Ux = 0x0a33;
 }

--- a/mcan/src/reg/dbtp.rs
+++ b/mcan/src/reg/dbtp.rs
@@ -91,7 +91,7 @@ impl W {
         self
     }
 }
-#[doc = "Fast Bit Timing and Prescaler\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`dbtp::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`dbtp::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Fast Bit Timing and Prescaler\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`dbtp::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`dbtp::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct DBTP_SPEC;
 impl crate::RegisterSpec for DBTP_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/ecr.rs
+++ b/mcan/src/reg/ecr.rs
@@ -30,7 +30,7 @@ impl R {
         CEL_R::new(((self.bits >> 16) & 0xff) as u8)
     }
 }
-#[doc = "Error Counter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ecr::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Error Counter\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`ecr::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ECR_SPEC;
 impl crate::RegisterSpec for ECR_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/ecr.rs
+++ b/mcan/src/reg/ecr.rs
@@ -1,78 +1,13 @@
 #[doc = "Register `ECR` reader"]
-pub struct R(crate::R<ECR_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<ECR_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<ECR_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<ECR_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<ECR_SPEC>;
 #[doc = "Field `TEC` reader - Transmit Error Counter"]
-pub struct TEC_R(crate::FieldReader<u8, u8>);
-impl TEC_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        TEC_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TEC_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TEC_R = crate::FieldReader;
 #[doc = "Field `REC` reader - Receive Error Counter"]
-pub struct REC_R(crate::FieldReader<u8, u8>);
-impl REC_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        REC_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for REC_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type REC_R = crate::FieldReader;
 #[doc = "Field `RP` reader - Receive Error Passive"]
-pub struct RP_R(crate::FieldReader<bool, bool>);
-impl RP_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RP_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RP_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RP_R = crate::BitReader;
 #[doc = "Field `CEL` reader - CAN Error Logging"]
-pub struct CEL_R(crate::FieldReader<u8, u8>);
-impl CEL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        CEL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CEL_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CEL_R = crate::FieldReader;
 impl R {
     #[doc = "Bits 0:7 - Transmit Error Counter"]
     #[inline(always)]
@@ -87,7 +22,7 @@ impl R {
     #[doc = "Bit 15 - Receive Error Passive"]
     #[inline(always)]
     pub fn rp(&self) -> RP_R {
-        RP_R::new(((self.bits >> 15) & 0x01) != 0)
+        RP_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bits 16:23 - CAN Error Logging"]
     #[inline(always)]
@@ -95,19 +30,14 @@ impl R {
         CEL_R::new(((self.bits >> 16) & 0xff) as u8)
     }
 }
-#[doc = "Error Counter\n\nThis register you can [`read`](crate::reg::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ecr](index.html) module"]
+#[doc = "Error Counter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ecr::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ECR_SPEC;
 impl crate::RegisterSpec for ECR_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [ecr::R](R) reader structure"]
-impl crate::Readable for ECR_SPEC {
-    type Reader = R;
-}
+#[doc = "`read()` method returns [`ecr::R`](R) reader structure"]
+impl crate::Readable for ECR_SPEC {}
 #[doc = "`reset()` method sets ECR to value 0"]
 impl crate::Resettable for ECR_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/endn.rs
+++ b/mcan/src/reg/endn.rs
@@ -1,33 +1,7 @@
 #[doc = "Register `ENDN` reader"]
-pub struct R(crate::R<ENDN_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<ENDN_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<ENDN_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<ENDN_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<ENDN_SPEC>;
 #[doc = "Field `ETV` reader - Endianness Test Value"]
-pub struct ETV_R(crate::FieldReader<u32, u32>);
-impl ETV_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u32) -> Self {
-        ETV_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ETV_R {
-    type Target = crate::FieldReader<u32, u32>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ETV_R = crate::FieldReader<u32>;
 impl R {
     #[doc = "Bits 0:31 - Endianness Test Value"]
     #[inline(always)]
@@ -35,19 +9,14 @@ impl R {
         ETV_R::new(self.bits)
     }
 }
-#[doc = "Endian\n\nThis register you can [`read`](crate::reg::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [endn](index.html) module"]
+#[doc = "Endian\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`endn::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENDN_SPEC;
 impl crate::RegisterSpec for ENDN_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [endn::R](R) reader structure"]
-impl crate::Readable for ENDN_SPEC {
-    type Reader = R;
-}
+#[doc = "`read()` method returns [`endn::R`](R) reader structure"]
+impl crate::Readable for ENDN_SPEC {}
 #[doc = "`reset()` method sets ENDN to value 0x8765_4321"]
 impl crate::Resettable for ENDN_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0x8765_4321
-    }
+    const RESET_VALUE: Self::Ux = 0x8765_4321;
 }

--- a/mcan/src/reg/endn.rs
+++ b/mcan/src/reg/endn.rs
@@ -9,7 +9,7 @@ impl R {
         ETV_R::new(self.bits)
     }
 }
-#[doc = "Endian\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`endn::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Endian\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`endn::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENDN_SPEC;
 impl crate::RegisterSpec for ENDN_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/generic.rs
+++ b/mcan/src/reg/generic.rs
@@ -1,3 +1,4 @@
+//! Register access helpers
 use core::marker;
 #[doc = " Raw register type (`u8`, `u16`, `u32`, ...)"]
 pub trait RawReg:

--- a/mcan/src/reg/generic.rs
+++ b/mcan/src/reg/generic.rs
@@ -1,25 +1,69 @@
-//! Register access helpers
 use core::marker;
+#[doc = " Raw register type (`u8`, `u16`, `u32`, ...)"]
+pub trait RawReg:
+    Copy
+    + Default
+    + From<bool>
+    + core::ops::BitOr<Output = Self>
+    + core::ops::BitAnd<Output = Self>
+    + core::ops::BitOrAssign
+    + core::ops::BitAndAssign
+    + core::ops::Not<Output = Self>
+    + core::ops::Shl<u8, Output = Self>
+{
+    #[doc = " Mask for bits of width `WI`"]
+    fn mask<const WI: u8>() -> Self;
+    #[doc = " Mask for bits of width 1"]
+    fn one() -> Self;
+}
+macro_rules! raw_reg {
+    ($ U : ty , $ size : literal , $ mask : ident) => {
+        impl RawReg for $U {
+            #[inline(always)]
+            fn mask<const WI: u8>() -> Self {
+                $mask::<WI>()
+            }
+            #[inline(always)]
+            fn one() -> Self {
+                1
+            }
+        }
+        const fn $mask<const WI: u8>() -> $U {
+            <$U>::MAX >> ($size - WI)
+        }
+        impl FieldSpec for $U {
+            type Ux = $U;
+        }
+    };
+}
+raw_reg!(u8, 8, mask_u8);
+raw_reg!(u16, 16, mask_u16);
+raw_reg!(u32, 32, mask_u32);
+raw_reg!(u64, 64, mask_u64);
 #[doc = " Raw register type"]
 pub trait RegisterSpec {
     #[doc = " Raw register type (`u8`, `u16`, `u32`, ...)."]
-    type Ux: Copy;
+    type Ux: RawReg;
+}
+#[doc = " Raw field type"]
+pub trait FieldSpec: Sized {
+    #[doc = " Raw field type (`u8`, `u16`, `u32`, ...)."]
+    type Ux: Copy + PartialEq + From<Self>;
 }
 #[doc = " Trait implemented by readable registers to enable the `read` method."]
 #[doc = ""]
-#[doc = " Registers marked with `Writable` can be also `modify`'ed."]
-pub trait Readable: RegisterSpec {
-    #[doc = " Result from a call to `read` and argument to `modify`."]
-    type Reader: From<R<Self>> + core::ops::Deref<Target = R<Self>>;
-}
+#[doc = " Registers marked with `Writable` can be also be `modify`'ed."]
+pub trait Readable: RegisterSpec {}
 #[doc = " Trait implemented by writeable registers."]
 #[doc = ""]
 #[doc = " This enables the  `write`, `write_with_zero` and `reset` methods."]
 #[doc = ""]
-#[doc = " Registers marked with `Readable` can be also `modify`'ed."]
+#[doc = " Registers marked with `Readable` can be also be `modify`'ed."]
 pub trait Writable: RegisterSpec {
-    #[doc = " Writer type argument to `write`, et al."]
-    type Writer: From<W<Self>> + core::ops::DerefMut<Target = W<Self>>;
+    #[doc = " Specifies the register bits that are not changed if you pass `1` and are changed if you pass `0`"]
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux;
+    #[doc = " Specifies the register bits that are not changed if you pass `0` and are changed if you pass `1`"]
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux;
 }
 #[doc = " Reset value of the register."]
 #[doc = ""]
@@ -27,7 +71,12 @@ pub trait Writable: RegisterSpec {
 #[doc = " register by using the `reset` method."]
 pub trait Resettable: RegisterSpec {
     #[doc = " Reset value of the register."]
-    fn reset_value() -> Self::Ux;
+    const RESET_VALUE: Self::Ux;
+    #[doc = " Reset value of the register."]
+    #[inline(always)]
+    fn reset_value() -> Self::Ux {
+        Self::RESET_VALUE
+    }
 }
 #[doc = " This structure provides volatile access to registers."]
 #[repr(transparent)]
@@ -61,11 +110,11 @@ impl<REG: Readable> Reg<REG> {
     #[doc = " let flag = reader.field2().bit_is_set();"]
     #[doc = " ```"]
     #[inline(always)]
-    pub fn read(&self) -> REG::Reader {
-        REG::Reader::from(R {
+    pub fn read(&self) -> R<REG> {
+        R {
             bits: self.register.get(),
             _reg: marker::PhantomData,
-        })
+        }
     }
 }
 impl<REG: Resettable + Writable> Reg<REG> {
@@ -74,7 +123,7 @@ impl<REG: Resettable + Writable> Reg<REG> {
     #[doc = " Resets the register to its initial state."]
     #[inline(always)]
     pub fn reset(&self) {
-        self.register.set(REG::reset_value())
+        self.register.set(REG::RESET_VALUE)
     }
     #[doc = " Writes bits to a `Writable` register."]
     #[doc = ""]
@@ -90,38 +139,48 @@ impl<REG: Resettable + Writable> Reg<REG> {
     #[doc = "     .field3().variant(VARIANT)"]
     #[doc = " );"]
     #[doc = " ```"]
+    #[doc = " or an alternative way of saying the same:"]
+    #[doc = " ```ignore"]
+    #[doc = " periph.reg.write(|w| {"]
+    #[doc = "     w.field1().bits(newfield1bits);"]
+    #[doc = "     w.field2().set_bit();"]
+    #[doc = "     w.field3().variant(VARIANT)"]
+    #[doc = " });"]
+    #[doc = " ```"]
     #[doc = " In the latter case, other fields will be set to their reset value."]
     #[inline(always)]
     pub fn write<F>(&self, f: F)
     where
-        F: FnOnce(&mut REG::Writer) -> &mut W<REG>,
+        F: FnOnce(&mut W<REG>) -> &mut W<REG>,
     {
         self.register.set(
-            f(&mut REG::Writer::from(W {
-                bits: REG::reset_value(),
+            f(&mut W {
+                bits: REG::RESET_VALUE & !REG::ONE_TO_MODIFY_FIELDS_BITMAP
+                    | REG::ZERO_TO_MODIFY_FIELDS_BITMAP,
                 _reg: marker::PhantomData,
-            }))
+            })
             .bits,
         );
     }
 }
-impl<REG: Writable> Reg<REG>
-where
-    REG::Ux: Default,
-{
+impl<REG: Writable> Reg<REG> {
     #[doc = " Writes 0 to a `Writable` register."]
     #[doc = ""]
     #[doc = " Similar to `write`, but unused bits will contain 0."]
+    #[doc = ""]
+    #[doc = " # Safety"]
+    #[doc = ""]
+    #[doc = " Unsafe to use with registers which don't allow to write 0."]
     #[inline(always)]
     pub unsafe fn write_with_zero<F>(&self, f: F)
     where
-        F: FnOnce(&mut REG::Writer) -> &mut W<REG>,
+        F: FnOnce(&mut W<REG>) -> &mut W<REG>,
     {
         self.register.set(
-            f(&mut REG::Writer::from(W {
+            f(&mut W {
                 bits: REG::Ux::default(),
                 _reg: marker::PhantomData,
-            }))
+            })
             .bits,
         );
     }
@@ -143,119 +202,293 @@ impl<REG: Readable + Writable> Reg<REG> {
     #[doc = "     .field3().variant(VARIANT)"]
     #[doc = " );"]
     #[doc = " ```"]
+    #[doc = " or an alternative way of saying the same:"]
+    #[doc = " ```ignore"]
+    #[doc = " periph.reg.modify(|_, w| {"]
+    #[doc = "     w.field1().bits(newfield1bits);"]
+    #[doc = "     w.field2().set_bit();"]
+    #[doc = "     w.field3().variant(VARIANT)"]
+    #[doc = " });"]
+    #[doc = " ```"]
     #[doc = " Other fields will have the value they had before the call to `modify`."]
     #[inline(always)]
     pub fn modify<F>(&self, f: F)
     where
-        for<'w> F: FnOnce(&REG::Reader, &'w mut REG::Writer) -> &'w mut W<REG>,
+        for<'w> F: FnOnce(&R<REG>, &'w mut W<REG>) -> &'w mut W<REG>,
     {
         let bits = self.register.get();
         self.register.set(
             f(
-                &REG::Reader::from(R {
+                &R {
                     bits,
                     _reg: marker::PhantomData,
-                }),
-                &mut REG::Writer::from(W {
-                    bits,
+                },
+                &mut W {
+                    bits: bits & !REG::ONE_TO_MODIFY_FIELDS_BITMAP
+                        | REG::ZERO_TO_MODIFY_FIELDS_BITMAP,
                     _reg: marker::PhantomData,
-                }),
+                },
             )
             .bits,
         );
     }
 }
+#[doc(hidden)]
+pub mod raw;
 #[doc = " Register reader."]
 #[doc = ""]
 #[doc = " Result of the `read` methods of registers. Also used as a closure argument in the `modify`"]
 #[doc = " method."]
-pub struct R<REG: RegisterSpec + ?Sized> {
-    pub(crate) bits: REG::Ux,
-    _reg: marker::PhantomData<REG>,
-}
+pub type R<REG> = raw::R<REG>;
 impl<REG: RegisterSpec> R<REG> {
     #[doc = " Reads raw bits from register."]
     #[inline(always)]
-    pub fn bits(&self) -> REG::Ux {
+    pub const fn bits(&self) -> REG::Ux {
         self.bits
     }
 }
 impl<REG: RegisterSpec, FI> PartialEq<FI> for R<REG>
 where
     REG::Ux: PartialEq,
-    FI: Copy + Into<REG::Ux>,
+    FI: Copy,
+    REG::Ux: From<FI>,
 {
     #[inline(always)]
     fn eq(&self, other: &FI) -> bool {
-        self.bits.eq(&(*other).into())
+        self.bits.eq(&REG::Ux::from(*other))
     }
 }
 #[doc = " Register writer."]
 #[doc = ""]
 #[doc = " Used as an argument to the closures in the `write` and `modify` methods of the register."]
-pub struct W<REG: RegisterSpec + ?Sized> {
-    #[doc = "Writable bits"]
-    pub(crate) bits: REG::Ux,
-    _reg: marker::PhantomData<REG>,
-}
-impl<REG: RegisterSpec> W<REG> {
-    #[doc = " Writes raw bits to the register."]
-    #[inline(always)]
-    pub unsafe fn bits(&mut self, bits: REG::Ux) -> &mut Self {
-        self.bits = bits;
-        self
-    }
-}
+pub type W<REG> = raw::W<REG>;
 #[doc = " Field reader."]
 #[doc = ""]
 #[doc = " Result of the `read` methods of fields."]
-pub struct FieldReader<U, T> {
-    pub(crate) bits: U,
-    _reg: marker::PhantomData<T>,
-}
-impl<U, T> FieldReader<U, T>
-where
-    U: Copy,
-{
-    #[doc = " Creates a new instance of the reader."]
-    #[allow(unused)]
-    #[inline(always)]
-    pub(crate) fn new(bits: U) -> Self {
-        Self {
-            bits,
-            _reg: marker::PhantomData,
-        }
-    }
+pub type FieldReader<FI = u8> = raw::FieldReader<FI>;
+#[doc = " Bit-wise field reader"]
+pub type BitReader<FI = bool> = raw::BitReader<FI>;
+impl<FI: FieldSpec> FieldReader<FI> {
     #[doc = " Reads raw bits from field."]
     #[inline(always)]
-    pub fn bits(&self) -> U {
+    pub const fn bits(&self) -> FI::Ux {
         self.bits
     }
 }
-impl<U, T, FI> PartialEq<FI> for FieldReader<U, T>
+impl<FI> PartialEq<FI> for FieldReader<FI>
 where
-    U: PartialEq,
-    FI: Copy + Into<U>,
+    FI: FieldSpec + Copy,
 {
     #[inline(always)]
     fn eq(&self, other: &FI) -> bool {
-        self.bits.eq(&(*other).into())
+        self.bits.eq(&FI::Ux::from(*other))
     }
 }
-impl<FI> FieldReader<bool, FI> {
+impl<FI> PartialEq<FI> for BitReader<FI>
+where
+    FI: Copy,
+    bool: From<FI>,
+{
+    #[inline(always)]
+    fn eq(&self, other: &FI) -> bool {
+        self.bits.eq(&bool::from(*other))
+    }
+}
+impl<FI> BitReader<FI> {
     #[doc = " Value of the field as raw bits."]
     #[inline(always)]
-    pub fn bit(&self) -> bool {
+    pub const fn bit(&self) -> bool {
         self.bits
     }
     #[doc = " Returns `true` if the bit is clear (0)."]
     #[inline(always)]
-    pub fn bit_is_clear(&self) -> bool {
+    pub const fn bit_is_clear(&self) -> bool {
         !self.bit()
     }
     #[doc = " Returns `true` if the bit is set (1)."]
     #[inline(always)]
-    pub fn bit_is_set(&self) -> bool {
+    pub const fn bit_is_set(&self) -> bool {
         self.bit()
+    }
+}
+#[doc(hidden)]
+pub struct Safe;
+#[doc(hidden)]
+pub struct Unsafe;
+#[doc = " Write field Proxy with unsafe `bits`"]
+pub type FieldWriter<'a, REG, const WI: u8, const O: u8, FI = u8> =
+    raw::FieldWriter<'a, REG, WI, O, FI, Unsafe>;
+#[doc = " Write field Proxy with safe `bits`"]
+pub type FieldWriterSafe<'a, REG, const WI: u8, const O: u8, FI = u8> =
+    raw::FieldWriter<'a, REG, WI, O, FI, Safe>;
+impl<'a, REG, const WI: u8, const OF: u8, FI> FieldWriter<'a, REG, WI, OF, FI>
+where
+    REG: Writable + RegisterSpec,
+    FI: FieldSpec,
+    REG::Ux: From<FI::Ux>,
+{
+    #[doc = " Field width"]
+    pub const WIDTH: u8 = WI;
+    #[doc = " Writes raw bits to the field"]
+    #[doc = ""]
+    #[doc = " # Safety"]
+    #[doc = ""]
+    #[doc = " Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: FI::Ux) -> &'a mut W<REG> {
+        self.w.bits &= !(REG::Ux::mask::<WI>() << OF);
+        self.w.bits |= (REG::Ux::from(value) & REG::Ux::mask::<WI>()) << OF;
+        self.w
+    }
+    #[doc = " Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: FI) -> &'a mut W<REG> {
+        unsafe { self.bits(FI::Ux::from(variant)) }
+    }
+}
+impl<'a, REG, const WI: u8, const OF: u8, FI> FieldWriterSafe<'a, REG, WI, OF, FI>
+where
+    REG: Writable + RegisterSpec,
+    FI: FieldSpec,
+    REG::Ux: From<FI::Ux>,
+{
+    #[doc = " Field width"]
+    pub const WIDTH: u8 = WI;
+    #[doc = " Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: FI::Ux) -> &'a mut W<REG> {
+        self.w.bits &= !(REG::Ux::mask::<WI>() << OF);
+        self.w.bits |= (REG::Ux::from(value) & REG::Ux::mask::<WI>()) << OF;
+        self.w
+    }
+    #[doc = " Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: FI) -> &'a mut W<REG> {
+        self.bits(FI::Ux::from(variant))
+    }
+}
+macro_rules! bit_proxy {
+    ($ writer : ident , $ mwv : ident) => {
+        #[doc(hidden)]
+        pub struct $mwv;
+        #[doc = " Bit-wise write field proxy"]
+        pub type $writer<'a, REG, const O: u8, FI = bool> = raw::BitWriter<'a, REG, O, FI, $mwv>;
+        impl<'a, REG, const OF: u8, FI> $writer<'a, REG, OF, FI>
+        where
+            REG: Writable + RegisterSpec,
+            bool: From<FI>,
+        {
+            #[doc = " Field width"]
+            pub const WIDTH: u8 = 1;
+            #[doc = " Writes bit to the field"]
+            #[inline(always)]
+            pub fn bit(self, value: bool) -> &'a mut W<REG> {
+                self.w.bits &= !(REG::Ux::one() << OF);
+                self.w.bits |= (REG::Ux::from(value) & REG::Ux::one()) << OF;
+                self.w
+            }
+            #[doc = " Writes `variant` to the field"]
+            #[inline(always)]
+            pub fn variant(self, variant: FI) -> &'a mut W<REG> {
+                self.bit(bool::from(variant))
+            }
+        }
+    };
+}
+bit_proxy!(BitWriter, BitM);
+bit_proxy!(BitWriter1S, Bit1S);
+bit_proxy!(BitWriter0C, Bit0C);
+bit_proxy!(BitWriter1C, Bit1C);
+bit_proxy!(BitWriter0S, Bit0S);
+bit_proxy!(BitWriter1T, Bit1T);
+bit_proxy!(BitWriter0T, Bit0T);
+impl<'a, REG, const OF: u8, FI> BitWriter<'a, REG, OF, FI>
+where
+    REG: Writable + RegisterSpec,
+    bool: From<FI>,
+{
+    #[doc = " Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W<REG> {
+        self.w.bits |= REG::Ux::one() << OF;
+        self.w
+    }
+    #[doc = " Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W<REG> {
+        self.w.bits &= !(REG::Ux::one() << OF);
+        self.w
+    }
+}
+impl<'a, REG, const OF: u8, FI> BitWriter1S<'a, REG, OF, FI>
+where
+    REG: Writable + RegisterSpec,
+    bool: From<FI>,
+{
+    #[doc = " Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W<REG> {
+        self.w.bits |= REG::Ux::one() << OF;
+        self.w
+    }
+}
+impl<'a, REG, const OF: u8, FI> BitWriter0C<'a, REG, OF, FI>
+where
+    REG: Writable + RegisterSpec,
+    bool: From<FI>,
+{
+    #[doc = " Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W<REG> {
+        self.w.bits &= !(REG::Ux::one() << OF);
+        self.w
+    }
+}
+impl<'a, REG, const OF: u8, FI> BitWriter1C<'a, REG, OF, FI>
+where
+    REG: Writable + RegisterSpec,
+    bool: From<FI>,
+{
+    #[doc = "Clears the field bit by passing one"]
+    #[inline(always)]
+    pub fn clear_bit_by_one(self) -> &'a mut W<REG> {
+        self.w.bits |= REG::Ux::one() << OF;
+        self.w
+    }
+}
+impl<'a, REG, const OF: u8, FI> BitWriter0S<'a, REG, OF, FI>
+where
+    REG: Writable + RegisterSpec,
+    bool: From<FI>,
+{
+    #[doc = "Sets the field bit by passing zero"]
+    #[inline(always)]
+    pub fn set_bit_by_zero(self) -> &'a mut W<REG> {
+        self.w.bits &= !(REG::Ux::one() << OF);
+        self.w
+    }
+}
+impl<'a, REG, const OF: u8, FI> BitWriter1T<'a, REG, OF, FI>
+where
+    REG: Writable + RegisterSpec,
+    bool: From<FI>,
+{
+    #[doc = "Toggle the field bit by passing one"]
+    #[inline(always)]
+    pub fn toggle_bit(self) -> &'a mut W<REG> {
+        self.w.bits |= REG::Ux::one() << OF;
+        self.w
+    }
+}
+impl<'a, REG, const OF: u8, FI> BitWriter0T<'a, REG, OF, FI>
+where
+    REG: Writable + RegisterSpec,
+    bool: From<FI>,
+{
+    #[doc = "Toggle the field bit by passing zero"]
+    #[inline(always)]
+    pub fn toggle_bit(self) -> &'a mut W<REG> {
+        self.w.bits &= !(REG::Ux::one() << OF);
+        self.w
     }
 }

--- a/mcan/src/reg/generic/raw.rs
+++ b/mcan/src/reg/generic/raw.rs
@@ -1,0 +1,89 @@
+use super::{marker, BitM, FieldSpec, RegisterSpec, Unsafe, Writable};
+pub struct R<REG: RegisterSpec> {
+    pub(crate) bits: REG::Ux,
+    pub(super) _reg: marker::PhantomData<REG>,
+}
+pub struct W<REG: RegisterSpec> {
+    #[doc = "Writable bits"]
+    pub(crate) bits: REG::Ux,
+    pub(super) _reg: marker::PhantomData<REG>,
+}
+pub struct FieldReader<FI = u8>
+where
+    FI: FieldSpec,
+{
+    pub(crate) bits: FI::Ux,
+    _reg: marker::PhantomData<FI>,
+}
+impl<FI: FieldSpec> FieldReader<FI> {
+    #[doc = " Creates a new instance of the reader."]
+    #[allow(unused)]
+    #[inline(always)]
+    pub(crate) const fn new(bits: FI::Ux) -> Self {
+        Self {
+            bits,
+            _reg: marker::PhantomData,
+        }
+    }
+}
+pub struct BitReader<FI = bool> {
+    pub(crate) bits: bool,
+    _reg: marker::PhantomData<FI>,
+}
+impl<FI> BitReader<FI> {
+    #[doc = " Creates a new instance of the reader."]
+    #[allow(unused)]
+    #[inline(always)]
+    pub(crate) const fn new(bits: bool) -> Self {
+        Self {
+            bits,
+            _reg: marker::PhantomData,
+        }
+    }
+}
+pub struct FieldWriter<'a, REG, const WI: u8, const O: u8, FI = u8, Safety = Unsafe>
+where
+    REG: Writable + RegisterSpec,
+    FI: FieldSpec,
+{
+    pub(crate) w: &'a mut W<REG>,
+    _field: marker::PhantomData<(FI, Safety)>,
+}
+impl<'a, REG, const WI: u8, const O: u8, FI, Safety> FieldWriter<'a, REG, WI, O, FI, Safety>
+where
+    REG: Writable + RegisterSpec,
+    FI: FieldSpec,
+{
+    #[doc = " Creates a new instance of the writer"]
+    #[allow(unused)]
+    #[inline(always)]
+    pub(crate) fn new(w: &'a mut W<REG>) -> Self {
+        Self {
+            w,
+            _field: marker::PhantomData,
+        }
+    }
+}
+pub struct BitWriter<'a, REG, const O: u8, FI = bool, M = BitM>
+where
+    REG: Writable + RegisterSpec,
+    bool: From<FI>,
+{
+    pub(crate) w: &'a mut W<REG>,
+    _field: marker::PhantomData<(FI, M)>,
+}
+impl<'a, REG, const O: u8, FI, M> BitWriter<'a, REG, O, FI, M>
+where
+    REG: Writable + RegisterSpec,
+    bool: From<FI>,
+{
+    #[doc = " Creates a new instance of the writer"]
+    #[allow(unused)]
+    #[inline(always)]
+    pub(crate) fn new(w: &'a mut W<REG>) -> Self {
+        Self {
+            w,
+            _field: marker::PhantomData,
+        }
+    }
+}

--- a/mcan/src/reg/gfc.rs
+++ b/mcan/src/reg/gfc.rs
@@ -212,7 +212,7 @@ impl W {
         self
     }
 }
-#[doc = "Global Filter Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gfc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gfc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Global Filter Configuration\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`gfc::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`gfc::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct GFC_SPEC;
 impl crate::RegisterSpec for GFC_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/gfc.rs
+++ b/mcan/src/reg/gfc.rs
@@ -1,117 +1,21 @@
 #[doc = "Register `GFC` reader"]
-pub struct R(crate::R<GFC_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<GFC_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<GFC_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<GFC_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<GFC_SPEC>;
 #[doc = "Register `GFC` writer"]
-pub struct W(crate::W<GFC_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<GFC_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<GFC_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<GFC_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<GFC_SPEC>;
 #[doc = "Field `RRFE` reader - Reject Remote Frames Extended"]
-pub struct RRFE_R(crate::FieldReader<bool, bool>);
-impl RRFE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RRFE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RRFE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RRFE_R = crate::BitReader;
 #[doc = "Field `RRFE` writer - Reject Remote Frames Extended"]
-pub struct RRFE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RRFE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x01) | (value as u32 & 0x01);
-        self.w
-    }
-}
+pub type RRFE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `RRFS` reader - Reject Remote Frames Standard"]
-pub struct RRFS_R(crate::FieldReader<bool, bool>);
-impl RRFS_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RRFS_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RRFS_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RRFS_R = crate::BitReader;
 #[doc = "Field `RRFS` writer - Reject Remote Frames Standard"]
-pub struct RRFS_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RRFS_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 1)) | ((value as u32 & 0x01) << 1);
-        self.w
-    }
-}
+pub type RRFS_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `ANFE` reader - Accept Non-matching Frames Extended"]
+pub type ANFE_R = crate::FieldReader<ANFESELECT_A>;
 #[doc = "Accept Non-matching Frames Extended\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
-pub enum ANFE_A {
+pub enum ANFESELECT_A {
     #[doc = "0: Accept in Rx FIFO 0"]
     RXF0 = 0,
     #[doc = "1: Accept in Rx FIFO 1"]
@@ -119,88 +23,71 @@ pub enum ANFE_A {
     #[doc = "2: Reject"]
     REJECT = 2,
 }
-impl From<ANFE_A> for u8 {
+impl From<ANFESELECT_A> for u8 {
     #[inline(always)]
-    fn from(variant: ANFE_A) -> Self {
+    fn from(variant: ANFESELECT_A) -> Self {
         variant as _
     }
 }
-#[doc = "Field `ANFE` reader - Accept Non-matching Frames Extended"]
-pub struct ANFE_R(crate::FieldReader<u8, ANFE_A>);
+impl crate::FieldSpec for ANFESELECT_A {
+    type Ux = u8;
+}
 impl ANFE_R {
+    #[doc = "Get enumerated values variant"]
     #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        ANFE_R(crate::FieldReader::new(bits))
-    }
-    #[doc = r"Get enumerated values variant"]
-    #[inline(always)]
-    pub fn variant(&self) -> Option<ANFE_A> {
+    pub const fn variant(&self) -> Option<ANFESELECT_A> {
         match self.bits {
-            0 => Some(ANFE_A::RXF0),
-            1 => Some(ANFE_A::RXF1),
-            2 => Some(ANFE_A::REJECT),
+            0 => Some(ANFESELECT_A::RXF0),
+            1 => Some(ANFESELECT_A::RXF1),
+            2 => Some(ANFESELECT_A::REJECT),
             _ => None,
         }
     }
-    #[doc = "Checks if the value of the field is `RXF0`"]
+    #[doc = "Accept in Rx FIFO 0"]
     #[inline(always)]
     pub fn is_rxf0(&self) -> bool {
-        **self == ANFE_A::RXF0
+        *self == ANFESELECT_A::RXF0
     }
-    #[doc = "Checks if the value of the field is `RXF1`"]
+    #[doc = "Accept in Rx FIFO 1"]
     #[inline(always)]
     pub fn is_rxf1(&self) -> bool {
-        **self == ANFE_A::RXF1
+        *self == ANFESELECT_A::RXF1
     }
-    #[doc = "Checks if the value of the field is `REJECT`"]
+    #[doc = "Reject"]
     #[inline(always)]
     pub fn is_reject(&self) -> bool {
-        **self == ANFE_A::REJECT
-    }
-}
-impl core::ops::Deref for ANFE_R {
-    type Target = crate::FieldReader<u8, ANFE_A>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
+        *self == ANFESELECT_A::REJECT
     }
 }
 #[doc = "Field `ANFE` writer - Accept Non-matching Frames Extended"]
-pub struct ANFE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ANFE_W<'a> {
-    #[doc = r"Writes `variant` to the field"]
-    #[inline(always)]
-    pub fn variant(self, variant: ANFE_A) -> &'a mut W {
-        unsafe { self.bits(variant.into()) }
-    }
+pub type ANFE_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 2, O, ANFESELECT_A>;
+impl<'a, REG, const O: u8> ANFE_W<'a, REG, O>
+where
+    REG: crate::Writable + crate::RegisterSpec,
+    REG::Ux: From<u8>,
+{
     #[doc = "Accept in Rx FIFO 0"]
     #[inline(always)]
-    pub fn rxf0(self) -> &'a mut W {
-        self.variant(ANFE_A::RXF0)
+    pub fn rxf0(self) -> &'a mut crate::W<REG> {
+        self.variant(ANFESELECT_A::RXF0)
     }
     #[doc = "Accept in Rx FIFO 1"]
     #[inline(always)]
-    pub fn rxf1(self) -> &'a mut W {
-        self.variant(ANFE_A::RXF1)
+    pub fn rxf1(self) -> &'a mut crate::W<REG> {
+        self.variant(ANFESELECT_A::RXF1)
     }
     #[doc = "Reject"]
     #[inline(always)]
-    pub fn reject(self) -> &'a mut W {
-        self.variant(ANFE_A::REJECT)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x03 << 2)) | ((value as u32 & 0x03) << 2);
-        self.w
+    pub fn reject(self) -> &'a mut crate::W<REG> {
+        self.variant(ANFESELECT_A::REJECT)
     }
 }
+#[doc = "Field `ANFS` reader - Accept Non-matching Frames Standard"]
+pub type ANFS_R = crate::FieldReader<ANFSSELECT_A>;
 #[doc = "Accept Non-matching Frames Standard\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
-pub enum ANFS_A {
+pub enum ANFSSELECT_A {
     #[doc = "0: Accept in Rx FIFO 0"]
     RXF0 = 0,
     #[doc = "1: Accept in Rx FIFO 1"]
@@ -208,151 +95,136 @@ pub enum ANFS_A {
     #[doc = "2: Reject"]
     REJECT = 2,
 }
-impl From<ANFS_A> for u8 {
+impl From<ANFSSELECT_A> for u8 {
     #[inline(always)]
-    fn from(variant: ANFS_A) -> Self {
+    fn from(variant: ANFSSELECT_A) -> Self {
         variant as _
     }
 }
-#[doc = "Field `ANFS` reader - Accept Non-matching Frames Standard"]
-pub struct ANFS_R(crate::FieldReader<u8, ANFS_A>);
+impl crate::FieldSpec for ANFSSELECT_A {
+    type Ux = u8;
+}
 impl ANFS_R {
+    #[doc = "Get enumerated values variant"]
     #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        ANFS_R(crate::FieldReader::new(bits))
-    }
-    #[doc = r"Get enumerated values variant"]
-    #[inline(always)]
-    pub fn variant(&self) -> Option<ANFS_A> {
+    pub const fn variant(&self) -> Option<ANFSSELECT_A> {
         match self.bits {
-            0 => Some(ANFS_A::RXF0),
-            1 => Some(ANFS_A::RXF1),
-            2 => Some(ANFS_A::REJECT),
+            0 => Some(ANFSSELECT_A::RXF0),
+            1 => Some(ANFSSELECT_A::RXF1),
+            2 => Some(ANFSSELECT_A::REJECT),
             _ => None,
         }
     }
-    #[doc = "Checks if the value of the field is `RXF0`"]
-    #[inline(always)]
-    pub fn is_rxf0(&self) -> bool {
-        **self == ANFS_A::RXF0
-    }
-    #[doc = "Checks if the value of the field is `RXF1`"]
-    #[inline(always)]
-    pub fn is_rxf1(&self) -> bool {
-        **self == ANFS_A::RXF1
-    }
-    #[doc = "Checks if the value of the field is `REJECT`"]
-    #[inline(always)]
-    pub fn is_reject(&self) -> bool {
-        **self == ANFS_A::REJECT
-    }
-}
-impl core::ops::Deref for ANFS_R {
-    type Target = crate::FieldReader<u8, ANFS_A>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[doc = "Field `ANFS` writer - Accept Non-matching Frames Standard"]
-pub struct ANFS_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ANFS_W<'a> {
-    #[doc = r"Writes `variant` to the field"]
-    #[inline(always)]
-    pub fn variant(self, variant: ANFS_A) -> &'a mut W {
-        unsafe { self.bits(variant.into()) }
-    }
     #[doc = "Accept in Rx FIFO 0"]
     #[inline(always)]
-    pub fn rxf0(self) -> &'a mut W {
-        self.variant(ANFS_A::RXF0)
+    pub fn is_rxf0(&self) -> bool {
+        *self == ANFSSELECT_A::RXF0
     }
     #[doc = "Accept in Rx FIFO 1"]
     #[inline(always)]
-    pub fn rxf1(self) -> &'a mut W {
-        self.variant(ANFS_A::RXF1)
+    pub fn is_rxf1(&self) -> bool {
+        *self == ANFSSELECT_A::RXF1
     }
     #[doc = "Reject"]
     #[inline(always)]
-    pub fn reject(self) -> &'a mut W {
-        self.variant(ANFS_A::REJECT)
+    pub fn is_reject(&self) -> bool {
+        *self == ANFSSELECT_A::REJECT
     }
-    #[doc = r"Writes raw bits to the field"]
+}
+#[doc = "Field `ANFS` writer - Accept Non-matching Frames Standard"]
+pub type ANFS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 2, O, ANFSSELECT_A>;
+impl<'a, REG, const O: u8> ANFS_W<'a, REG, O>
+where
+    REG: crate::Writable + crate::RegisterSpec,
+    REG::Ux: From<u8>,
+{
+    #[doc = "Accept in Rx FIFO 0"]
     #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x03 << 4)) | ((value as u32 & 0x03) << 4);
-        self.w
+    pub fn rxf0(self) -> &'a mut crate::W<REG> {
+        self.variant(ANFSSELECT_A::RXF0)
+    }
+    #[doc = "Accept in Rx FIFO 1"]
+    #[inline(always)]
+    pub fn rxf1(self) -> &'a mut crate::W<REG> {
+        self.variant(ANFSSELECT_A::RXF1)
+    }
+    #[doc = "Reject"]
+    #[inline(always)]
+    pub fn reject(self) -> &'a mut crate::W<REG> {
+        self.variant(ANFSSELECT_A::REJECT)
     }
 }
 impl R {
     #[doc = "Bit 0 - Reject Remote Frames Extended"]
     #[inline(always)]
     pub fn rrfe(&self) -> RRFE_R {
-        RRFE_R::new((self.bits & 0x01) != 0)
+        RRFE_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - Reject Remote Frames Standard"]
     #[inline(always)]
     pub fn rrfs(&self) -> RRFS_R {
-        RRFS_R::new(((self.bits >> 1) & 0x01) != 0)
+        RRFS_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bits 2:3 - Accept Non-matching Frames Extended"]
     #[inline(always)]
     pub fn anfe(&self) -> ANFE_R {
-        ANFE_R::new(((self.bits >> 2) & 0x03) as u8)
+        ANFE_R::new(((self.bits >> 2) & 3) as u8)
     }
     #[doc = "Bits 4:5 - Accept Non-matching Frames Standard"]
     #[inline(always)]
     pub fn anfs(&self) -> ANFS_R {
-        ANFS_R::new(((self.bits >> 4) & 0x03) as u8)
+        ANFS_R::new(((self.bits >> 4) & 3) as u8)
     }
 }
 impl W {
     #[doc = "Bit 0 - Reject Remote Frames Extended"]
     #[inline(always)]
-    pub fn rrfe(&mut self) -> RRFE_W {
-        RRFE_W { w: self }
+    #[must_use]
+    pub fn rrfe(&mut self) -> RRFE_W<GFC_SPEC, 0> {
+        RRFE_W::new(self)
     }
     #[doc = "Bit 1 - Reject Remote Frames Standard"]
     #[inline(always)]
-    pub fn rrfs(&mut self) -> RRFS_W {
-        RRFS_W { w: self }
+    #[must_use]
+    pub fn rrfs(&mut self) -> RRFS_W<GFC_SPEC, 1> {
+        RRFS_W::new(self)
     }
     #[doc = "Bits 2:3 - Accept Non-matching Frames Extended"]
     #[inline(always)]
-    pub fn anfe(&mut self) -> ANFE_W {
-        ANFE_W { w: self }
+    #[must_use]
+    pub fn anfe(&mut self) -> ANFE_W<GFC_SPEC, 2> {
+        ANFE_W::new(self)
     }
     #[doc = "Bits 4:5 - Accept Non-matching Frames Standard"]
     #[inline(always)]
-    pub fn anfs(&mut self) -> ANFS_W {
-        ANFS_W { w: self }
+    #[must_use]
+    pub fn anfs(&mut self) -> ANFS_W<GFC_SPEC, 4> {
+        ANFS_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Global Filter Configuration\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [gfc](index.html) module"]
+#[doc = "Global Filter Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gfc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gfc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct GFC_SPEC;
 impl crate::RegisterSpec for GFC_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [gfc::R](R) reader structure"]
-impl crate::Readable for GFC_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [gfc::W](W) writer structure"]
+#[doc = "`read()` method returns [`gfc::R`](R) reader structure"]
+impl crate::Readable for GFC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gfc::W`](W) writer structure"]
 impl crate::Writable for GFC_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets GFC to value 0"]
 impl crate::Resettable for GFC_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/hpms.rs
+++ b/mcan/src/reg/hpms.rs
@@ -1,37 +1,13 @@
 #[doc = "Register `HPMS` reader"]
-pub struct R(crate::R<HPMS_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<HPMS_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<HPMS_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<HPMS_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<HPMS_SPEC>;
 #[doc = "Field `BIDX` reader - Buffer Index"]
-pub struct BIDX_R(crate::FieldReader<u8, u8>);
-impl BIDX_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        BIDX_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for BIDX_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type BIDX_R = crate::FieldReader;
+#[doc = "Field `MSI` reader - Message Storage Indicator"]
+pub type MSI_R = crate::FieldReader<MSISELECT_A>;
 #[doc = "Message Storage Indicator\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
-pub enum MSI_A {
+pub enum MSISELECT_A {
     #[doc = "0: No FIFO selected"]
     NONE = 0,
     #[doc = "1: FIFO message lost"]
@@ -41,88 +17,52 @@ pub enum MSI_A {
     #[doc = "3: Message stored in FIFO 1"]
     FIFO1 = 3,
 }
-impl From<MSI_A> for u8 {
+impl From<MSISELECT_A> for u8 {
     #[inline(always)]
-    fn from(variant: MSI_A) -> Self {
+    fn from(variant: MSISELECT_A) -> Self {
         variant as _
     }
 }
-#[doc = "Field `MSI` reader - Message Storage Indicator"]
-pub struct MSI_R(crate::FieldReader<u8, MSI_A>);
+impl crate::FieldSpec for MSISELECT_A {
+    type Ux = u8;
+}
 impl MSI_R {
+    #[doc = "Get enumerated values variant"]
     #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        MSI_R(crate::FieldReader::new(bits))
-    }
-    #[doc = r"Get enumerated values variant"]
-    #[inline(always)]
-    pub fn variant(&self) -> MSI_A {
+    pub const fn variant(&self) -> MSISELECT_A {
         match self.bits {
-            0 => MSI_A::NONE,
-            1 => MSI_A::LOST,
-            2 => MSI_A::FIFO0,
-            3 => MSI_A::FIFO1,
+            0 => MSISELECT_A::NONE,
+            1 => MSISELECT_A::LOST,
+            2 => MSISELECT_A::FIFO0,
+            3 => MSISELECT_A::FIFO1,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `NONE`"]
+    #[doc = "No FIFO selected"]
     #[inline(always)]
     pub fn is_none(&self) -> bool {
-        **self == MSI_A::NONE
+        *self == MSISELECT_A::NONE
     }
-    #[doc = "Checks if the value of the field is `LOST`"]
+    #[doc = "FIFO message lost"]
     #[inline(always)]
     pub fn is_lost(&self) -> bool {
-        **self == MSI_A::LOST
+        *self == MSISELECT_A::LOST
     }
-    #[doc = "Checks if the value of the field is `FIFO0`"]
+    #[doc = "Message stored in FIFO 0"]
     #[inline(always)]
     pub fn is_fifo0(&self) -> bool {
-        **self == MSI_A::FIFO0
+        *self == MSISELECT_A::FIFO0
     }
-    #[doc = "Checks if the value of the field is `FIFO1`"]
+    #[doc = "Message stored in FIFO 1"]
     #[inline(always)]
     pub fn is_fifo1(&self) -> bool {
-        **self == MSI_A::FIFO1
-    }
-}
-impl core::ops::Deref for MSI_R {
-    type Target = crate::FieldReader<u8, MSI_A>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
+        *self == MSISELECT_A::FIFO1
     }
 }
 #[doc = "Field `FIDX` reader - Filter Index"]
-pub struct FIDX_R(crate::FieldReader<u8, u8>);
-impl FIDX_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        FIDX_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for FIDX_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type FIDX_R = crate::FieldReader;
 #[doc = "Field `FLST` reader - Filter List"]
-pub struct FLST_R(crate::FieldReader<bool, bool>);
-impl FLST_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        FLST_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for FLST_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type FLST_R = crate::BitReader;
 impl R {
     #[doc = "Bits 0:5 - Buffer Index"]
     #[inline(always)]
@@ -132,7 +72,7 @@ impl R {
     #[doc = "Bits 6:7 - Message Storage Indicator"]
     #[inline(always)]
     pub fn msi(&self) -> MSI_R {
-        MSI_R::new(((self.bits >> 6) & 0x03) as u8)
+        MSI_R::new(((self.bits >> 6) & 3) as u8)
     }
     #[doc = "Bits 8:14 - Filter Index"]
     #[inline(always)]
@@ -142,22 +82,17 @@ impl R {
     #[doc = "Bit 15 - Filter List"]
     #[inline(always)]
     pub fn flst(&self) -> FLST_R {
-        FLST_R::new(((self.bits >> 15) & 0x01) != 0)
+        FLST_R::new(((self.bits >> 15) & 1) != 0)
     }
 }
-#[doc = "High Priority Message Status\n\nThis register you can [`read`](crate::reg::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hpms](index.html) module"]
+#[doc = "High Priority Message Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hpms::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct HPMS_SPEC;
 impl crate::RegisterSpec for HPMS_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [hpms::R](R) reader structure"]
-impl crate::Readable for HPMS_SPEC {
-    type Reader = R;
-}
+#[doc = "`read()` method returns [`hpms::R`](R) reader structure"]
+impl crate::Readable for HPMS_SPEC {}
 #[doc = "`reset()` method sets HPMS to value 0"]
 impl crate::Resettable for HPMS_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/hpms.rs
+++ b/mcan/src/reg/hpms.rs
@@ -85,7 +85,7 @@ impl R {
         FLST_R::new(((self.bits >> 15) & 1) != 0)
     }
 }
-#[doc = "High Priority Message Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hpms::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "High Priority Message Status\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`hpms::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct HPMS_SPEC;
 impl crate::RegisterSpec for HPMS_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/ie.rs
+++ b/mcan/src/reg/ie.rs
@@ -1,1476 +1,484 @@
 #[doc = "Register `IE` reader"]
-pub struct R(crate::R<IE_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<IE_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<IE_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<IE_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<IE_SPEC>;
 #[doc = "Register `IE` writer"]
-pub struct W(crate::W<IE_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<IE_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<IE_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<IE_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<IE_SPEC>;
 #[doc = "Field `RF0NE` reader - Rx FIFO 0 New Message Interrupt Enable"]
-pub struct RF0NE_R(crate::FieldReader<bool, bool>);
-impl RF0NE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF0NE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF0NE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF0NE_R = crate::BitReader;
 #[doc = "Field `RF0NE` writer - Rx FIFO 0 New Message Interrupt Enable"]
-pub struct RF0NE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF0NE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x01) | (value as u32 & 0x01);
-        self.w
-    }
-}
+pub type RF0NE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `RF0WE` reader - Rx FIFO 0 Watermark Reached Interrupt Enable"]
-pub struct RF0WE_R(crate::FieldReader<bool, bool>);
-impl RF0WE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF0WE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF0WE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF0WE_R = crate::BitReader;
 #[doc = "Field `RF0WE` writer - Rx FIFO 0 Watermark Reached Interrupt Enable"]
-pub struct RF0WE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF0WE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 1)) | ((value as u32 & 0x01) << 1);
-        self.w
-    }
-}
+pub type RF0WE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `RF0FE` reader - Rx FIFO 0 Full Interrupt Enable"]
-pub struct RF0FE_R(crate::FieldReader<bool, bool>);
-impl RF0FE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF0FE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF0FE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF0FE_R = crate::BitReader;
 #[doc = "Field `RF0FE` writer - Rx FIFO 0 Full Interrupt Enable"]
-pub struct RF0FE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF0FE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 2)) | ((value as u32 & 0x01) << 2);
-        self.w
-    }
-}
+pub type RF0FE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `RF0LE` reader - Rx FIFO 0 Message Lost Interrupt Enable"]
-pub struct RF0LE_R(crate::FieldReader<bool, bool>);
-impl RF0LE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF0LE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF0LE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF0LE_R = crate::BitReader;
 #[doc = "Field `RF0LE` writer - Rx FIFO 0 Message Lost Interrupt Enable"]
-pub struct RF0LE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF0LE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 3)) | ((value as u32 & 0x01) << 3);
-        self.w
-    }
-}
+pub type RF0LE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `RF1NE` reader - Rx FIFO 1 New Message Interrupt Enable"]
-pub struct RF1NE_R(crate::FieldReader<bool, bool>);
-impl RF1NE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF1NE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF1NE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF1NE_R = crate::BitReader;
 #[doc = "Field `RF1NE` writer - Rx FIFO 1 New Message Interrupt Enable"]
-pub struct RF1NE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF1NE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 4)) | ((value as u32 & 0x01) << 4);
-        self.w
-    }
-}
+pub type RF1NE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `RF1WE` reader - Rx FIFO 1 Watermark Reached Interrupt Enable"]
-pub struct RF1WE_R(crate::FieldReader<bool, bool>);
-impl RF1WE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF1WE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF1WE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF1WE_R = crate::BitReader;
 #[doc = "Field `RF1WE` writer - Rx FIFO 1 Watermark Reached Interrupt Enable"]
-pub struct RF1WE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF1WE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 5)) | ((value as u32 & 0x01) << 5);
-        self.w
-    }
-}
+pub type RF1WE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `RF1FE` reader - Rx FIFO 1 FIFO Full Interrupt Enable"]
-pub struct RF1FE_R(crate::FieldReader<bool, bool>);
-impl RF1FE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF1FE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF1FE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF1FE_R = crate::BitReader;
 #[doc = "Field `RF1FE` writer - Rx FIFO 1 FIFO Full Interrupt Enable"]
-pub struct RF1FE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF1FE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 6)) | ((value as u32 & 0x01) << 6);
-        self.w
-    }
-}
+pub type RF1FE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `RF1LE` reader - Rx FIFO 1 Message Lost Interrupt Enable"]
-pub struct RF1LE_R(crate::FieldReader<bool, bool>);
-impl RF1LE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF1LE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF1LE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF1LE_R = crate::BitReader;
 #[doc = "Field `RF1LE` writer - Rx FIFO 1 Message Lost Interrupt Enable"]
-pub struct RF1LE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF1LE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 7)) | ((value as u32 & 0x01) << 7);
-        self.w
-    }
-}
+pub type RF1LE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `HPME` reader - High Priority Message Interrupt Enable"]
-pub struct HPME_R(crate::FieldReader<bool, bool>);
-impl HPME_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        HPME_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for HPME_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type HPME_R = crate::BitReader;
 #[doc = "Field `HPME` writer - High Priority Message Interrupt Enable"]
-pub struct HPME_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> HPME_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 8)) | ((value as u32 & 0x01) << 8);
-        self.w
-    }
-}
+pub type HPME_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TCE` reader - Timestamp Completed Interrupt Enable"]
-pub struct TCE_R(crate::FieldReader<bool, bool>);
-impl TCE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TCE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TCE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TCE_R = crate::BitReader;
 #[doc = "Field `TCE` writer - Timestamp Completed Interrupt Enable"]
-pub struct TCE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TCE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 9)) | ((value as u32 & 0x01) << 9);
-        self.w
-    }
-}
+pub type TCE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TCFE` reader - Transmission Cancellation Finished Interrupt Enable"]
-pub struct TCFE_R(crate::FieldReader<bool, bool>);
-impl TCFE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TCFE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TCFE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TCFE_R = crate::BitReader;
 #[doc = "Field `TCFE` writer - Transmission Cancellation Finished Interrupt Enable"]
-pub struct TCFE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TCFE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 10)) | ((value as u32 & 0x01) << 10);
-        self.w
-    }
-}
+pub type TCFE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TFEE` reader - Tx FIFO Empty Interrupt Enable"]
-pub struct TFEE_R(crate::FieldReader<bool, bool>);
-impl TFEE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TFEE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TFEE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TFEE_R = crate::BitReader;
 #[doc = "Field `TFEE` writer - Tx FIFO Empty Interrupt Enable"]
-pub struct TFEE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TFEE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 11)) | ((value as u32 & 0x01) << 11);
-        self.w
-    }
-}
+pub type TFEE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TEFNE` reader - Tx Event FIFO New Entry Interrupt Enable"]
-pub struct TEFNE_R(crate::FieldReader<bool, bool>);
-impl TEFNE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TEFNE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TEFNE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TEFNE_R = crate::BitReader;
 #[doc = "Field `TEFNE` writer - Tx Event FIFO New Entry Interrupt Enable"]
-pub struct TEFNE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TEFNE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 12)) | ((value as u32 & 0x01) << 12);
-        self.w
-    }
-}
+pub type TEFNE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TEFWE` reader - Tx Event FIFO Watermark Reached Interrupt Enable"]
-pub struct TEFWE_R(crate::FieldReader<bool, bool>);
-impl TEFWE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TEFWE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TEFWE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TEFWE_R = crate::BitReader;
 #[doc = "Field `TEFWE` writer - Tx Event FIFO Watermark Reached Interrupt Enable"]
-pub struct TEFWE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TEFWE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 13)) | ((value as u32 & 0x01) << 13);
-        self.w
-    }
-}
+pub type TEFWE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TEFFE` reader - Tx Event FIFO Full Interrupt Enable"]
-pub struct TEFFE_R(crate::FieldReader<bool, bool>);
-impl TEFFE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TEFFE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TEFFE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TEFFE_R = crate::BitReader;
 #[doc = "Field `TEFFE` writer - Tx Event FIFO Full Interrupt Enable"]
-pub struct TEFFE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TEFFE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 14)) | ((value as u32 & 0x01) << 14);
-        self.w
-    }
-}
+pub type TEFFE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TEFLE` reader - Tx Event FIFO Element Lost Interrupt Enable"]
-pub struct TEFLE_R(crate::FieldReader<bool, bool>);
-impl TEFLE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TEFLE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TEFLE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TEFLE_R = crate::BitReader;
 #[doc = "Field `TEFLE` writer - Tx Event FIFO Element Lost Interrupt Enable"]
-pub struct TEFLE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TEFLE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 15)) | ((value as u32 & 0x01) << 15);
-        self.w
-    }
-}
+pub type TEFLE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TSWE` reader - Timestamp Wraparound Interrupt Enable"]
-pub struct TSWE_R(crate::FieldReader<bool, bool>);
-impl TSWE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TSWE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TSWE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TSWE_R = crate::BitReader;
 #[doc = "Field `TSWE` writer - Timestamp Wraparound Interrupt Enable"]
-pub struct TSWE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TSWE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 16)) | ((value as u32 & 0x01) << 16);
-        self.w
-    }
-}
+pub type TSWE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `MRAFE` reader - Message RAM Access Failure Interrupt Enable"]
-pub struct MRAFE_R(crate::FieldReader<bool, bool>);
-impl MRAFE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        MRAFE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for MRAFE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type MRAFE_R = crate::BitReader;
 #[doc = "Field `MRAFE` writer - Message RAM Access Failure Interrupt Enable"]
-pub struct MRAFE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> MRAFE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 17)) | ((value as u32 & 0x01) << 17);
-        self.w
-    }
-}
+pub type MRAFE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TOOE` reader - Timeout Occurred Interrupt Enable"]
-pub struct TOOE_R(crate::FieldReader<bool, bool>);
-impl TOOE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TOOE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TOOE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TOOE_R = crate::BitReader;
 #[doc = "Field `TOOE` writer - Timeout Occurred Interrupt Enable"]
-pub struct TOOE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TOOE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 18)) | ((value as u32 & 0x01) << 18);
-        self.w
-    }
-}
+pub type TOOE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `DRXE` reader - Message stored to Dedicated Rx Buffer Interrupt Enable"]
-pub struct DRXE_R(crate::FieldReader<bool, bool>);
-impl DRXE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        DRXE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for DRXE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type DRXE_R = crate::BitReader;
 #[doc = "Field `DRXE` writer - Message stored to Dedicated Rx Buffer Interrupt Enable"]
-pub struct DRXE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> DRXE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 19)) | ((value as u32 & 0x01) << 19);
-        self.w
-    }
-}
+pub type DRXE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `BECE` reader - Bit Error Corrected Interrupt Enable"]
-pub struct BECE_R(crate::FieldReader<bool, bool>);
-impl BECE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        BECE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for BECE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type BECE_R = crate::BitReader;
 #[doc = "Field `BECE` writer - Bit Error Corrected Interrupt Enable"]
-pub struct BECE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> BECE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 20)) | ((value as u32 & 0x01) << 20);
-        self.w
-    }
-}
+pub type BECE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `BEUE` reader - Bit Error Uncorrected Interrupt Enable"]
-pub struct BEUE_R(crate::FieldReader<bool, bool>);
-impl BEUE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        BEUE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for BEUE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type BEUE_R = crate::BitReader;
 #[doc = "Field `BEUE` writer - Bit Error Uncorrected Interrupt Enable"]
-pub struct BEUE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> BEUE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 21)) | ((value as u32 & 0x01) << 21);
-        self.w
-    }
-}
+pub type BEUE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ELOE` reader - Error Logging Overflow Interrupt Enable"]
-pub struct ELOE_R(crate::FieldReader<bool, bool>);
-impl ELOE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ELOE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ELOE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ELOE_R = crate::BitReader;
 #[doc = "Field `ELOE` writer - Error Logging Overflow Interrupt Enable"]
-pub struct ELOE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ELOE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 22)) | ((value as u32 & 0x01) << 22);
-        self.w
-    }
-}
+pub type ELOE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `EPE` reader - Error Passive Interrupt Enable"]
-pub struct EPE_R(crate::FieldReader<bool, bool>);
-impl EPE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        EPE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for EPE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type EPE_R = crate::BitReader;
 #[doc = "Field `EPE` writer - Error Passive Interrupt Enable"]
-pub struct EPE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> EPE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 23)) | ((value as u32 & 0x01) << 23);
-        self.w
-    }
-}
+pub type EPE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `EWE` reader - Warning Status Interrupt Enable"]
-pub struct EWE_R(crate::FieldReader<bool, bool>);
-impl EWE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        EWE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for EWE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type EWE_R = crate::BitReader;
 #[doc = "Field `EWE` writer - Warning Status Interrupt Enable"]
-pub struct EWE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> EWE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 24)) | ((value as u32 & 0x01) << 24);
-        self.w
-    }
-}
+pub type EWE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `BOE` reader - Bus_Off Status Interrupt Enable"]
-pub struct BOE_R(crate::FieldReader<bool, bool>);
-impl BOE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        BOE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for BOE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type BOE_R = crate::BitReader;
 #[doc = "Field `BOE` writer - Bus_Off Status Interrupt Enable"]
-pub struct BOE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> BOE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 25)) | ((value as u32 & 0x01) << 25);
-        self.w
-    }
-}
+pub type BOE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `WDIE` reader - Watchdog Interrupt Interrupt Enable"]
-pub struct WDIE_R(crate::FieldReader<bool, bool>);
-impl WDIE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        WDIE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for WDIE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type WDIE_R = crate::BitReader;
 #[doc = "Field `WDIE` writer - Watchdog Interrupt Interrupt Enable"]
-pub struct WDIE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> WDIE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 26)) | ((value as u32 & 0x01) << 26);
-        self.w
-    }
-}
+pub type WDIE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `PEAE` reader - Protocol Error in Arbitration Phase Enable"]
-pub struct PEAE_R(crate::FieldReader<bool, bool>);
-impl PEAE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        PEAE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for PEAE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type PEAE_R = crate::BitReader;
 #[doc = "Field `PEAE` writer - Protocol Error in Arbitration Phase Enable"]
-pub struct PEAE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> PEAE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 27)) | ((value as u32 & 0x01) << 27);
-        self.w
-    }
-}
+pub type PEAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `PEDE` reader - Protocol Error in Data Phase Enable"]
-pub struct PEDE_R(crate::FieldReader<bool, bool>);
-impl PEDE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        PEDE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for PEDE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type PEDE_R = crate::BitReader;
 #[doc = "Field `PEDE` writer - Protocol Error in Data Phase Enable"]
-pub struct PEDE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> PEDE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 28)) | ((value as u32 & 0x01) << 28);
-        self.w
-    }
-}
+pub type PEDE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ARAE` reader - Access to Reserved Address Enable"]
-pub struct ARAE_R(crate::FieldReader<bool, bool>);
-impl ARAE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ARAE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ARAE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ARAE_R = crate::BitReader;
 #[doc = "Field `ARAE` writer - Access to Reserved Address Enable"]
-pub struct ARAE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ARAE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 29)) | ((value as u32 & 0x01) << 29);
-        self.w
-    }
-}
+pub type ARAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
     #[doc = "Bit 0 - Rx FIFO 0 New Message Interrupt Enable"]
     #[inline(always)]
     pub fn rf0ne(&self) -> RF0NE_R {
-        RF0NE_R::new((self.bits & 0x01) != 0)
+        RF0NE_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - Rx FIFO 0 Watermark Reached Interrupt Enable"]
     #[inline(always)]
     pub fn rf0we(&self) -> RF0WE_R {
-        RF0WE_R::new(((self.bits >> 1) & 0x01) != 0)
+        RF0WE_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - Rx FIFO 0 Full Interrupt Enable"]
     #[inline(always)]
     pub fn rf0fe(&self) -> RF0FE_R {
-        RF0FE_R::new(((self.bits >> 2) & 0x01) != 0)
+        RF0FE_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - Rx FIFO 0 Message Lost Interrupt Enable"]
     #[inline(always)]
     pub fn rf0le(&self) -> RF0LE_R {
-        RF0LE_R::new(((self.bits >> 3) & 0x01) != 0)
+        RF0LE_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - Rx FIFO 1 New Message Interrupt Enable"]
     #[inline(always)]
     pub fn rf1ne(&self) -> RF1NE_R {
-        RF1NE_R::new(((self.bits >> 4) & 0x01) != 0)
+        RF1NE_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - Rx FIFO 1 Watermark Reached Interrupt Enable"]
     #[inline(always)]
     pub fn rf1we(&self) -> RF1WE_R {
-        RF1WE_R::new(((self.bits >> 5) & 0x01) != 0)
+        RF1WE_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - Rx FIFO 1 FIFO Full Interrupt Enable"]
     #[inline(always)]
     pub fn rf1fe(&self) -> RF1FE_R {
-        RF1FE_R::new(((self.bits >> 6) & 0x01) != 0)
+        RF1FE_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - Rx FIFO 1 Message Lost Interrupt Enable"]
     #[inline(always)]
     pub fn rf1le(&self) -> RF1LE_R {
-        RF1LE_R::new(((self.bits >> 7) & 0x01) != 0)
+        RF1LE_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - High Priority Message Interrupt Enable"]
     #[inline(always)]
     pub fn hpme(&self) -> HPME_R {
-        HPME_R::new(((self.bits >> 8) & 0x01) != 0)
+        HPME_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - Timestamp Completed Interrupt Enable"]
     #[inline(always)]
     pub fn tce(&self) -> TCE_R {
-        TCE_R::new(((self.bits >> 9) & 0x01) != 0)
+        TCE_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - Transmission Cancellation Finished Interrupt Enable"]
     #[inline(always)]
     pub fn tcfe(&self) -> TCFE_R {
-        TCFE_R::new(((self.bits >> 10) & 0x01) != 0)
+        TCFE_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Tx FIFO Empty Interrupt Enable"]
     #[inline(always)]
     pub fn tfee(&self) -> TFEE_R {
-        TFEE_R::new(((self.bits >> 11) & 0x01) != 0)
+        TFEE_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - Tx Event FIFO New Entry Interrupt Enable"]
     #[inline(always)]
     pub fn tefne(&self) -> TEFNE_R {
-        TEFNE_R::new(((self.bits >> 12) & 0x01) != 0)
+        TEFNE_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - Tx Event FIFO Watermark Reached Interrupt Enable"]
     #[inline(always)]
     pub fn tefwe(&self) -> TEFWE_R {
-        TEFWE_R::new(((self.bits >> 13) & 0x01) != 0)
+        TEFWE_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - Tx Event FIFO Full Interrupt Enable"]
     #[inline(always)]
     pub fn teffe(&self) -> TEFFE_R {
-        TEFFE_R::new(((self.bits >> 14) & 0x01) != 0)
+        TEFFE_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - Tx Event FIFO Element Lost Interrupt Enable"]
     #[inline(always)]
     pub fn tefle(&self) -> TEFLE_R {
-        TEFLE_R::new(((self.bits >> 15) & 0x01) != 0)
+        TEFLE_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - Timestamp Wraparound Interrupt Enable"]
     #[inline(always)]
     pub fn tswe(&self) -> TSWE_R {
-        TSWE_R::new(((self.bits >> 16) & 0x01) != 0)
+        TSWE_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - Message RAM Access Failure Interrupt Enable"]
     #[inline(always)]
     pub fn mrafe(&self) -> MRAFE_R {
-        MRAFE_R::new(((self.bits >> 17) & 0x01) != 0)
+        MRAFE_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - Timeout Occurred Interrupt Enable"]
     #[inline(always)]
     pub fn tooe(&self) -> TOOE_R {
-        TOOE_R::new(((self.bits >> 18) & 0x01) != 0)
+        TOOE_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - Message stored to Dedicated Rx Buffer Interrupt Enable"]
     #[inline(always)]
     pub fn drxe(&self) -> DRXE_R {
-        DRXE_R::new(((self.bits >> 19) & 0x01) != 0)
+        DRXE_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - Bit Error Corrected Interrupt Enable"]
     #[inline(always)]
     pub fn bece(&self) -> BECE_R {
-        BECE_R::new(((self.bits >> 20) & 0x01) != 0)
+        BECE_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - Bit Error Uncorrected Interrupt Enable"]
     #[inline(always)]
     pub fn beue(&self) -> BEUE_R {
-        BEUE_R::new(((self.bits >> 21) & 0x01) != 0)
+        BEUE_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - Error Logging Overflow Interrupt Enable"]
     #[inline(always)]
     pub fn eloe(&self) -> ELOE_R {
-        ELOE_R::new(((self.bits >> 22) & 0x01) != 0)
+        ELOE_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - Error Passive Interrupt Enable"]
     #[inline(always)]
     pub fn epe(&self) -> EPE_R {
-        EPE_R::new(((self.bits >> 23) & 0x01) != 0)
+        EPE_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - Warning Status Interrupt Enable"]
     #[inline(always)]
     pub fn ewe(&self) -> EWE_R {
-        EWE_R::new(((self.bits >> 24) & 0x01) != 0)
+        EWE_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - Bus_Off Status Interrupt Enable"]
     #[inline(always)]
     pub fn boe(&self) -> BOE_R {
-        BOE_R::new(((self.bits >> 25) & 0x01) != 0)
+        BOE_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - Watchdog Interrupt Interrupt Enable"]
     #[inline(always)]
     pub fn wdie(&self) -> WDIE_R {
-        WDIE_R::new(((self.bits >> 26) & 0x01) != 0)
+        WDIE_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - Protocol Error in Arbitration Phase Enable"]
     #[inline(always)]
     pub fn peae(&self) -> PEAE_R {
-        PEAE_R::new(((self.bits >> 27) & 0x01) != 0)
+        PEAE_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - Protocol Error in Data Phase Enable"]
     #[inline(always)]
     pub fn pede(&self) -> PEDE_R {
-        PEDE_R::new(((self.bits >> 28) & 0x01) != 0)
+        PEDE_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - Access to Reserved Address Enable"]
     #[inline(always)]
     pub fn arae(&self) -> ARAE_R {
-        ARAE_R::new(((self.bits >> 29) & 0x01) != 0)
+        ARAE_R::new(((self.bits >> 29) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - Rx FIFO 0 New Message Interrupt Enable"]
     #[inline(always)]
-    pub fn rf0ne(&mut self) -> RF0NE_W {
-        RF0NE_W { w: self }
+    #[must_use]
+    pub fn rf0ne(&mut self) -> RF0NE_W<IE_SPEC, 0> {
+        RF0NE_W::new(self)
     }
     #[doc = "Bit 1 - Rx FIFO 0 Watermark Reached Interrupt Enable"]
     #[inline(always)]
-    pub fn rf0we(&mut self) -> RF0WE_W {
-        RF0WE_W { w: self }
+    #[must_use]
+    pub fn rf0we(&mut self) -> RF0WE_W<IE_SPEC, 1> {
+        RF0WE_W::new(self)
     }
     #[doc = "Bit 2 - Rx FIFO 0 Full Interrupt Enable"]
     #[inline(always)]
-    pub fn rf0fe(&mut self) -> RF0FE_W {
-        RF0FE_W { w: self }
+    #[must_use]
+    pub fn rf0fe(&mut self) -> RF0FE_W<IE_SPEC, 2> {
+        RF0FE_W::new(self)
     }
     #[doc = "Bit 3 - Rx FIFO 0 Message Lost Interrupt Enable"]
     #[inline(always)]
-    pub fn rf0le(&mut self) -> RF0LE_W {
-        RF0LE_W { w: self }
+    #[must_use]
+    pub fn rf0le(&mut self) -> RF0LE_W<IE_SPEC, 3> {
+        RF0LE_W::new(self)
     }
     #[doc = "Bit 4 - Rx FIFO 1 New Message Interrupt Enable"]
     #[inline(always)]
-    pub fn rf1ne(&mut self) -> RF1NE_W {
-        RF1NE_W { w: self }
+    #[must_use]
+    pub fn rf1ne(&mut self) -> RF1NE_W<IE_SPEC, 4> {
+        RF1NE_W::new(self)
     }
     #[doc = "Bit 5 - Rx FIFO 1 Watermark Reached Interrupt Enable"]
     #[inline(always)]
-    pub fn rf1we(&mut self) -> RF1WE_W {
-        RF1WE_W { w: self }
+    #[must_use]
+    pub fn rf1we(&mut self) -> RF1WE_W<IE_SPEC, 5> {
+        RF1WE_W::new(self)
     }
     #[doc = "Bit 6 - Rx FIFO 1 FIFO Full Interrupt Enable"]
     #[inline(always)]
-    pub fn rf1fe(&mut self) -> RF1FE_W {
-        RF1FE_W { w: self }
+    #[must_use]
+    pub fn rf1fe(&mut self) -> RF1FE_W<IE_SPEC, 6> {
+        RF1FE_W::new(self)
     }
     #[doc = "Bit 7 - Rx FIFO 1 Message Lost Interrupt Enable"]
     #[inline(always)]
-    pub fn rf1le(&mut self) -> RF1LE_W {
-        RF1LE_W { w: self }
+    #[must_use]
+    pub fn rf1le(&mut self) -> RF1LE_W<IE_SPEC, 7> {
+        RF1LE_W::new(self)
     }
     #[doc = "Bit 8 - High Priority Message Interrupt Enable"]
     #[inline(always)]
-    pub fn hpme(&mut self) -> HPME_W {
-        HPME_W { w: self }
+    #[must_use]
+    pub fn hpme(&mut self) -> HPME_W<IE_SPEC, 8> {
+        HPME_W::new(self)
     }
     #[doc = "Bit 9 - Timestamp Completed Interrupt Enable"]
     #[inline(always)]
-    pub fn tce(&mut self) -> TCE_W {
-        TCE_W { w: self }
+    #[must_use]
+    pub fn tce(&mut self) -> TCE_W<IE_SPEC, 9> {
+        TCE_W::new(self)
     }
     #[doc = "Bit 10 - Transmission Cancellation Finished Interrupt Enable"]
     #[inline(always)]
-    pub fn tcfe(&mut self) -> TCFE_W {
-        TCFE_W { w: self }
+    #[must_use]
+    pub fn tcfe(&mut self) -> TCFE_W<IE_SPEC, 10> {
+        TCFE_W::new(self)
     }
     #[doc = "Bit 11 - Tx FIFO Empty Interrupt Enable"]
     #[inline(always)]
-    pub fn tfee(&mut self) -> TFEE_W {
-        TFEE_W { w: self }
+    #[must_use]
+    pub fn tfee(&mut self) -> TFEE_W<IE_SPEC, 11> {
+        TFEE_W::new(self)
     }
     #[doc = "Bit 12 - Tx Event FIFO New Entry Interrupt Enable"]
     #[inline(always)]
-    pub fn tefne(&mut self) -> TEFNE_W {
-        TEFNE_W { w: self }
+    #[must_use]
+    pub fn tefne(&mut self) -> TEFNE_W<IE_SPEC, 12> {
+        TEFNE_W::new(self)
     }
     #[doc = "Bit 13 - Tx Event FIFO Watermark Reached Interrupt Enable"]
     #[inline(always)]
-    pub fn tefwe(&mut self) -> TEFWE_W {
-        TEFWE_W { w: self }
+    #[must_use]
+    pub fn tefwe(&mut self) -> TEFWE_W<IE_SPEC, 13> {
+        TEFWE_W::new(self)
     }
     #[doc = "Bit 14 - Tx Event FIFO Full Interrupt Enable"]
     #[inline(always)]
-    pub fn teffe(&mut self) -> TEFFE_W {
-        TEFFE_W { w: self }
+    #[must_use]
+    pub fn teffe(&mut self) -> TEFFE_W<IE_SPEC, 14> {
+        TEFFE_W::new(self)
     }
     #[doc = "Bit 15 - Tx Event FIFO Element Lost Interrupt Enable"]
     #[inline(always)]
-    pub fn tefle(&mut self) -> TEFLE_W {
-        TEFLE_W { w: self }
+    #[must_use]
+    pub fn tefle(&mut self) -> TEFLE_W<IE_SPEC, 15> {
+        TEFLE_W::new(self)
     }
     #[doc = "Bit 16 - Timestamp Wraparound Interrupt Enable"]
     #[inline(always)]
-    pub fn tswe(&mut self) -> TSWE_W {
-        TSWE_W { w: self }
+    #[must_use]
+    pub fn tswe(&mut self) -> TSWE_W<IE_SPEC, 16> {
+        TSWE_W::new(self)
     }
     #[doc = "Bit 17 - Message RAM Access Failure Interrupt Enable"]
     #[inline(always)]
-    pub fn mrafe(&mut self) -> MRAFE_W {
-        MRAFE_W { w: self }
+    #[must_use]
+    pub fn mrafe(&mut self) -> MRAFE_W<IE_SPEC, 17> {
+        MRAFE_W::new(self)
     }
     #[doc = "Bit 18 - Timeout Occurred Interrupt Enable"]
     #[inline(always)]
-    pub fn tooe(&mut self) -> TOOE_W {
-        TOOE_W { w: self }
+    #[must_use]
+    pub fn tooe(&mut self) -> TOOE_W<IE_SPEC, 18> {
+        TOOE_W::new(self)
     }
     #[doc = "Bit 19 - Message stored to Dedicated Rx Buffer Interrupt Enable"]
     #[inline(always)]
-    pub fn drxe(&mut self) -> DRXE_W {
-        DRXE_W { w: self }
+    #[must_use]
+    pub fn drxe(&mut self) -> DRXE_W<IE_SPEC, 19> {
+        DRXE_W::new(self)
     }
     #[doc = "Bit 20 - Bit Error Corrected Interrupt Enable"]
     #[inline(always)]
-    pub fn bece(&mut self) -> BECE_W {
-        BECE_W { w: self }
+    #[must_use]
+    pub fn bece(&mut self) -> BECE_W<IE_SPEC, 20> {
+        BECE_W::new(self)
     }
     #[doc = "Bit 21 - Bit Error Uncorrected Interrupt Enable"]
     #[inline(always)]
-    pub fn beue(&mut self) -> BEUE_W {
-        BEUE_W { w: self }
+    #[must_use]
+    pub fn beue(&mut self) -> BEUE_W<IE_SPEC, 21> {
+        BEUE_W::new(self)
     }
     #[doc = "Bit 22 - Error Logging Overflow Interrupt Enable"]
     #[inline(always)]
-    pub fn eloe(&mut self) -> ELOE_W {
-        ELOE_W { w: self }
+    #[must_use]
+    pub fn eloe(&mut self) -> ELOE_W<IE_SPEC, 22> {
+        ELOE_W::new(self)
     }
     #[doc = "Bit 23 - Error Passive Interrupt Enable"]
     #[inline(always)]
-    pub fn epe(&mut self) -> EPE_W {
-        EPE_W { w: self }
+    #[must_use]
+    pub fn epe(&mut self) -> EPE_W<IE_SPEC, 23> {
+        EPE_W::new(self)
     }
     #[doc = "Bit 24 - Warning Status Interrupt Enable"]
     #[inline(always)]
-    pub fn ewe(&mut self) -> EWE_W {
-        EWE_W { w: self }
+    #[must_use]
+    pub fn ewe(&mut self) -> EWE_W<IE_SPEC, 24> {
+        EWE_W::new(self)
     }
     #[doc = "Bit 25 - Bus_Off Status Interrupt Enable"]
     #[inline(always)]
-    pub fn boe(&mut self) -> BOE_W {
-        BOE_W { w: self }
+    #[must_use]
+    pub fn boe(&mut self) -> BOE_W<IE_SPEC, 25> {
+        BOE_W::new(self)
     }
     #[doc = "Bit 26 - Watchdog Interrupt Interrupt Enable"]
     #[inline(always)]
-    pub fn wdie(&mut self) -> WDIE_W {
-        WDIE_W { w: self }
+    #[must_use]
+    pub fn wdie(&mut self) -> WDIE_W<IE_SPEC, 26> {
+        WDIE_W::new(self)
     }
     #[doc = "Bit 27 - Protocol Error in Arbitration Phase Enable"]
     #[inline(always)]
-    pub fn peae(&mut self) -> PEAE_W {
-        PEAE_W { w: self }
+    #[must_use]
+    pub fn peae(&mut self) -> PEAE_W<IE_SPEC, 27> {
+        PEAE_W::new(self)
     }
     #[doc = "Bit 28 - Protocol Error in Data Phase Enable"]
     #[inline(always)]
-    pub fn pede(&mut self) -> PEDE_W {
-        PEDE_W { w: self }
+    #[must_use]
+    pub fn pede(&mut self) -> PEDE_W<IE_SPEC, 28> {
+        PEDE_W::new(self)
     }
     #[doc = "Bit 29 - Access to Reserved Address Enable"]
     #[inline(always)]
-    pub fn arae(&mut self) -> ARAE_W {
-        ARAE_W { w: self }
+    #[must_use]
+    pub fn arae(&mut self) -> ARAE_W<IE_SPEC, 29> {
+        ARAE_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Interrupt Enable\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ie](index.html) module"]
+#[doc = "Interrupt Enable\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ie::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ie::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct IE_SPEC;
 impl crate::RegisterSpec for IE_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [ie::R](R) reader structure"]
-impl crate::Readable for IE_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [ie::W](W) writer structure"]
+#[doc = "`read()` method returns [`ie::R`](R) reader structure"]
+impl crate::Readable for IE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ie::W`](W) writer structure"]
 impl crate::Writable for IE_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets IE to value 0"]
 impl crate::Resettable for IE_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/ie.rs
+++ b/mcan/src/reg/ie.rs
@@ -466,7 +466,7 @@ impl W {
         self
     }
 }
-#[doc = "Interrupt Enable\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ie::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ie::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Interrupt Enable\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`ie::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`ie::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct IE_SPEC;
 impl crate::RegisterSpec for IE_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/ile.rs
+++ b/mcan/src/reg/ile.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Interrupt Line Enable\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ile::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ile::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Interrupt Line Enable\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`ile::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`ile::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ILE_SPEC;
 impl crate::RegisterSpec for ILE_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/ile.rs
+++ b/mcan/src/reg/ile.rs
@@ -1,160 +1,64 @@
 #[doc = "Register `ILE` reader"]
-pub struct R(crate::R<ILE_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<ILE_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<ILE_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<ILE_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<ILE_SPEC>;
 #[doc = "Register `ILE` writer"]
-pub struct W(crate::W<ILE_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<ILE_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<ILE_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<ILE_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<ILE_SPEC>;
 #[doc = "Field `EINT0` reader - Enable Interrupt Line 0"]
-pub struct EINT0_R(crate::FieldReader<bool, bool>);
-impl EINT0_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        EINT0_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for EINT0_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type EINT0_R = crate::BitReader;
 #[doc = "Field `EINT0` writer - Enable Interrupt Line 0"]
-pub struct EINT0_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> EINT0_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x01) | (value as u32 & 0x01);
-        self.w
-    }
-}
+pub type EINT0_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `EINT1` reader - Enable Interrupt Line 1"]
-pub struct EINT1_R(crate::FieldReader<bool, bool>);
-impl EINT1_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        EINT1_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for EINT1_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type EINT1_R = crate::BitReader;
 #[doc = "Field `EINT1` writer - Enable Interrupt Line 1"]
-pub struct EINT1_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> EINT1_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 1)) | ((value as u32 & 0x01) << 1);
-        self.w
-    }
-}
+pub type EINT1_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
     #[doc = "Bit 0 - Enable Interrupt Line 0"]
     #[inline(always)]
     pub fn eint0(&self) -> EINT0_R {
-        EINT0_R::new((self.bits & 0x01) != 0)
+        EINT0_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - Enable Interrupt Line 1"]
     #[inline(always)]
     pub fn eint1(&self) -> EINT1_R {
-        EINT1_R::new(((self.bits >> 1) & 0x01) != 0)
+        EINT1_R::new(((self.bits >> 1) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - Enable Interrupt Line 0"]
     #[inline(always)]
-    pub fn eint0(&mut self) -> EINT0_W {
-        EINT0_W { w: self }
+    #[must_use]
+    pub fn eint0(&mut self) -> EINT0_W<ILE_SPEC, 0> {
+        EINT0_W::new(self)
     }
     #[doc = "Bit 1 - Enable Interrupt Line 1"]
     #[inline(always)]
-    pub fn eint1(&mut self) -> EINT1_W {
-        EINT1_W { w: self }
+    #[must_use]
+    pub fn eint1(&mut self) -> EINT1_W<ILE_SPEC, 1> {
+        EINT1_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Interrupt Line Enable\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ile](index.html) module"]
+#[doc = "Interrupt Line Enable\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ile::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ile::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ILE_SPEC;
 impl crate::RegisterSpec for ILE_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [ile::R](R) reader structure"]
-impl crate::Readable for ILE_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [ile::W](W) writer structure"]
+#[doc = "`read()` method returns [`ile::R`](R) reader structure"]
+impl crate::Readable for ILE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ile::W`](W) writer structure"]
 impl crate::Writable for ILE_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets ILE to value 0"]
 impl crate::Resettable for ILE_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/ils.rs
+++ b/mcan/src/reg/ils.rs
@@ -1,1476 +1,484 @@
 #[doc = "Register `ILS` reader"]
-pub struct R(crate::R<ILS_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<ILS_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<ILS_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<ILS_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<ILS_SPEC>;
 #[doc = "Register `ILS` writer"]
-pub struct W(crate::W<ILS_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<ILS_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<ILS_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<ILS_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<ILS_SPEC>;
 #[doc = "Field `RF0NL` reader - Rx FIFO 0 New Message Interrupt Line"]
-pub struct RF0NL_R(crate::FieldReader<bool, bool>);
-impl RF0NL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF0NL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF0NL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF0NL_R = crate::BitReader;
 #[doc = "Field `RF0NL` writer - Rx FIFO 0 New Message Interrupt Line"]
-pub struct RF0NL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF0NL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x01) | (value as u32 & 0x01);
-        self.w
-    }
-}
+pub type RF0NL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `RF0WL` reader - Rx FIFO 0 Watermark Reached Interrupt Line"]
-pub struct RF0WL_R(crate::FieldReader<bool, bool>);
-impl RF0WL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF0WL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF0WL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF0WL_R = crate::BitReader;
 #[doc = "Field `RF0WL` writer - Rx FIFO 0 Watermark Reached Interrupt Line"]
-pub struct RF0WL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF0WL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 1)) | ((value as u32 & 0x01) << 1);
-        self.w
-    }
-}
+pub type RF0WL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `RF0FL` reader - Rx FIFO 0 Full Interrupt Line"]
-pub struct RF0FL_R(crate::FieldReader<bool, bool>);
-impl RF0FL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF0FL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF0FL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF0FL_R = crate::BitReader;
 #[doc = "Field `RF0FL` writer - Rx FIFO 0 Full Interrupt Line"]
-pub struct RF0FL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF0FL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 2)) | ((value as u32 & 0x01) << 2);
-        self.w
-    }
-}
+pub type RF0FL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `RF0LL` reader - Rx FIFO 0 Message Lost Interrupt Line"]
-pub struct RF0LL_R(crate::FieldReader<bool, bool>);
-impl RF0LL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF0LL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF0LL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF0LL_R = crate::BitReader;
 #[doc = "Field `RF0LL` writer - Rx FIFO 0 Message Lost Interrupt Line"]
-pub struct RF0LL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF0LL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 3)) | ((value as u32 & 0x01) << 3);
-        self.w
-    }
-}
+pub type RF0LL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `RF1NL` reader - Rx FIFO 1 New Message Interrupt Line"]
-pub struct RF1NL_R(crate::FieldReader<bool, bool>);
-impl RF1NL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF1NL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF1NL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF1NL_R = crate::BitReader;
 #[doc = "Field `RF1NL` writer - Rx FIFO 1 New Message Interrupt Line"]
-pub struct RF1NL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF1NL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 4)) | ((value as u32 & 0x01) << 4);
-        self.w
-    }
-}
+pub type RF1NL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `RF1WL` reader - Rx FIFO 1 Watermark Reached Interrupt Line"]
-pub struct RF1WL_R(crate::FieldReader<bool, bool>);
-impl RF1WL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF1WL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF1WL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF1WL_R = crate::BitReader;
 #[doc = "Field `RF1WL` writer - Rx FIFO 1 Watermark Reached Interrupt Line"]
-pub struct RF1WL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF1WL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 5)) | ((value as u32 & 0x01) << 5);
-        self.w
-    }
-}
+pub type RF1WL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `RF1FL` reader - Rx FIFO 1 FIFO Full Interrupt Line"]
-pub struct RF1FL_R(crate::FieldReader<bool, bool>);
-impl RF1FL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF1FL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF1FL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF1FL_R = crate::BitReader;
 #[doc = "Field `RF1FL` writer - Rx FIFO 1 FIFO Full Interrupt Line"]
-pub struct RF1FL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF1FL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 6)) | ((value as u32 & 0x01) << 6);
-        self.w
-    }
-}
+pub type RF1FL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `RF1LL` reader - Rx FIFO 1 Message Lost Interrupt Line"]
-pub struct RF1LL_R(crate::FieldReader<bool, bool>);
-impl RF1LL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF1LL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF1LL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF1LL_R = crate::BitReader;
 #[doc = "Field `RF1LL` writer - Rx FIFO 1 Message Lost Interrupt Line"]
-pub struct RF1LL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF1LL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 7)) | ((value as u32 & 0x01) << 7);
-        self.w
-    }
-}
+pub type RF1LL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `HPML` reader - High Priority Message Interrupt Line"]
-pub struct HPML_R(crate::FieldReader<bool, bool>);
-impl HPML_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        HPML_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for HPML_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type HPML_R = crate::BitReader;
 #[doc = "Field `HPML` writer - High Priority Message Interrupt Line"]
-pub struct HPML_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> HPML_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 8)) | ((value as u32 & 0x01) << 8);
-        self.w
-    }
-}
+pub type HPML_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TCL` reader - Timestamp Completed Interrupt Line"]
-pub struct TCL_R(crate::FieldReader<bool, bool>);
-impl TCL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TCL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TCL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TCL_R = crate::BitReader;
 #[doc = "Field `TCL` writer - Timestamp Completed Interrupt Line"]
-pub struct TCL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TCL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 9)) | ((value as u32 & 0x01) << 9);
-        self.w
-    }
-}
+pub type TCL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TCFL` reader - Transmission Cancellation Finished Interrupt Line"]
-pub struct TCFL_R(crate::FieldReader<bool, bool>);
-impl TCFL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TCFL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TCFL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TCFL_R = crate::BitReader;
 #[doc = "Field `TCFL` writer - Transmission Cancellation Finished Interrupt Line"]
-pub struct TCFL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TCFL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 10)) | ((value as u32 & 0x01) << 10);
-        self.w
-    }
-}
+pub type TCFL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TFEL` reader - Tx FIFO Empty Interrupt Line"]
-pub struct TFEL_R(crate::FieldReader<bool, bool>);
-impl TFEL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TFEL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TFEL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TFEL_R = crate::BitReader;
 #[doc = "Field `TFEL` writer - Tx FIFO Empty Interrupt Line"]
-pub struct TFEL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TFEL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 11)) | ((value as u32 & 0x01) << 11);
-        self.w
-    }
-}
+pub type TFEL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TEFNL` reader - Tx Event FIFO New Entry Interrupt Line"]
-pub struct TEFNL_R(crate::FieldReader<bool, bool>);
-impl TEFNL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TEFNL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TEFNL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TEFNL_R = crate::BitReader;
 #[doc = "Field `TEFNL` writer - Tx Event FIFO New Entry Interrupt Line"]
-pub struct TEFNL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TEFNL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 12)) | ((value as u32 & 0x01) << 12);
-        self.w
-    }
-}
+pub type TEFNL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TEFWL` reader - Tx Event FIFO Watermark Reached Interrupt Line"]
-pub struct TEFWL_R(crate::FieldReader<bool, bool>);
-impl TEFWL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TEFWL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TEFWL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TEFWL_R = crate::BitReader;
 #[doc = "Field `TEFWL` writer - Tx Event FIFO Watermark Reached Interrupt Line"]
-pub struct TEFWL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TEFWL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 13)) | ((value as u32 & 0x01) << 13);
-        self.w
-    }
-}
+pub type TEFWL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TEFFL` reader - Tx Event FIFO Full Interrupt Line"]
-pub struct TEFFL_R(crate::FieldReader<bool, bool>);
-impl TEFFL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TEFFL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TEFFL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TEFFL_R = crate::BitReader;
 #[doc = "Field `TEFFL` writer - Tx Event FIFO Full Interrupt Line"]
-pub struct TEFFL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TEFFL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 14)) | ((value as u32 & 0x01) << 14);
-        self.w
-    }
-}
+pub type TEFFL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TEFLL` reader - Tx Event FIFO Element Lost Interrupt Line"]
-pub struct TEFLL_R(crate::FieldReader<bool, bool>);
-impl TEFLL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TEFLL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TEFLL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TEFLL_R = crate::BitReader;
 #[doc = "Field `TEFLL` writer - Tx Event FIFO Element Lost Interrupt Line"]
-pub struct TEFLL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TEFLL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 15)) | ((value as u32 & 0x01) << 15);
-        self.w
-    }
-}
+pub type TEFLL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TSWL` reader - Timestamp Wraparound Interrupt Line"]
-pub struct TSWL_R(crate::FieldReader<bool, bool>);
-impl TSWL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TSWL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TSWL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TSWL_R = crate::BitReader;
 #[doc = "Field `TSWL` writer - Timestamp Wraparound Interrupt Line"]
-pub struct TSWL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TSWL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 16)) | ((value as u32 & 0x01) << 16);
-        self.w
-    }
-}
+pub type TSWL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `MRAFL` reader - Message RAM Access Failure Interrupt Line"]
-pub struct MRAFL_R(crate::FieldReader<bool, bool>);
-impl MRAFL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        MRAFL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for MRAFL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type MRAFL_R = crate::BitReader;
 #[doc = "Field `MRAFL` writer - Message RAM Access Failure Interrupt Line"]
-pub struct MRAFL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> MRAFL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 17)) | ((value as u32 & 0x01) << 17);
-        self.w
-    }
-}
+pub type MRAFL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TOOL` reader - Timeout Occurred Interrupt Line"]
-pub struct TOOL_R(crate::FieldReader<bool, bool>);
-impl TOOL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TOOL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TOOL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TOOL_R = crate::BitReader;
 #[doc = "Field `TOOL` writer - Timeout Occurred Interrupt Line"]
-pub struct TOOL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TOOL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 18)) | ((value as u32 & 0x01) << 18);
-        self.w
-    }
-}
+pub type TOOL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `DRXL` reader - Message stored to Dedicated Rx Buffer Interrupt Line"]
-pub struct DRXL_R(crate::FieldReader<bool, bool>);
-impl DRXL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        DRXL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for DRXL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type DRXL_R = crate::BitReader;
 #[doc = "Field `DRXL` writer - Message stored to Dedicated Rx Buffer Interrupt Line"]
-pub struct DRXL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> DRXL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 19)) | ((value as u32 & 0x01) << 19);
-        self.w
-    }
-}
+pub type DRXL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `BECL` reader - Bit Error Corrected Interrupt Line"]
-pub struct BECL_R(crate::FieldReader<bool, bool>);
-impl BECL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        BECL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for BECL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type BECL_R = crate::BitReader;
 #[doc = "Field `BECL` writer - Bit Error Corrected Interrupt Line"]
-pub struct BECL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> BECL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 20)) | ((value as u32 & 0x01) << 20);
-        self.w
-    }
-}
+pub type BECL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `BEUL` reader - Bit Error Uncorrected Interrupt Line"]
-pub struct BEUL_R(crate::FieldReader<bool, bool>);
-impl BEUL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        BEUL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for BEUL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type BEUL_R = crate::BitReader;
 #[doc = "Field `BEUL` writer - Bit Error Uncorrected Interrupt Line"]
-pub struct BEUL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> BEUL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 21)) | ((value as u32 & 0x01) << 21);
-        self.w
-    }
-}
+pub type BEUL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ELOL` reader - Error Logging Overflow Interrupt Line"]
-pub struct ELOL_R(crate::FieldReader<bool, bool>);
-impl ELOL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ELOL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ELOL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ELOL_R = crate::BitReader;
 #[doc = "Field `ELOL` writer - Error Logging Overflow Interrupt Line"]
-pub struct ELOL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ELOL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 22)) | ((value as u32 & 0x01) << 22);
-        self.w
-    }
-}
+pub type ELOL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `EPL` reader - Error Passive Interrupt Line"]
-pub struct EPL_R(crate::FieldReader<bool, bool>);
-impl EPL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        EPL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for EPL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type EPL_R = crate::BitReader;
 #[doc = "Field `EPL` writer - Error Passive Interrupt Line"]
-pub struct EPL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> EPL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 23)) | ((value as u32 & 0x01) << 23);
-        self.w
-    }
-}
+pub type EPL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `EWL` reader - Warning Status Interrupt Line"]
-pub struct EWL_R(crate::FieldReader<bool, bool>);
-impl EWL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        EWL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for EWL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type EWL_R = crate::BitReader;
 #[doc = "Field `EWL` writer - Warning Status Interrupt Line"]
-pub struct EWL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> EWL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 24)) | ((value as u32 & 0x01) << 24);
-        self.w
-    }
-}
+pub type EWL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `BOL` reader - Bus_Off Status Interrupt Line"]
-pub struct BOL_R(crate::FieldReader<bool, bool>);
-impl BOL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        BOL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for BOL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type BOL_R = crate::BitReader;
 #[doc = "Field `BOL` writer - Bus_Off Status Interrupt Line"]
-pub struct BOL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> BOL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 25)) | ((value as u32 & 0x01) << 25);
-        self.w
-    }
-}
+pub type BOL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `WDIL` reader - Watchdog Interrupt Interrupt Line"]
-pub struct WDIL_R(crate::FieldReader<bool, bool>);
-impl WDIL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        WDIL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for WDIL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type WDIL_R = crate::BitReader;
 #[doc = "Field `WDIL` writer - Watchdog Interrupt Interrupt Line"]
-pub struct WDIL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> WDIL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 26)) | ((value as u32 & 0x01) << 26);
-        self.w
-    }
-}
+pub type WDIL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `PEAL` reader - Protocol Error in Arbitration Phase Line"]
-pub struct PEAL_R(crate::FieldReader<bool, bool>);
-impl PEAL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        PEAL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for PEAL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type PEAL_R = crate::BitReader;
 #[doc = "Field `PEAL` writer - Protocol Error in Arbitration Phase Line"]
-pub struct PEAL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> PEAL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 27)) | ((value as u32 & 0x01) << 27);
-        self.w
-    }
-}
+pub type PEAL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `PEDL` reader - Protocol Error in Data Phase Line"]
-pub struct PEDL_R(crate::FieldReader<bool, bool>);
-impl PEDL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        PEDL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for PEDL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type PEDL_R = crate::BitReader;
 #[doc = "Field `PEDL` writer - Protocol Error in Data Phase Line"]
-pub struct PEDL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> PEDL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 28)) | ((value as u32 & 0x01) << 28);
-        self.w
-    }
-}
+pub type PEDL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ARAL` reader - Access to Reserved Address Line"]
-pub struct ARAL_R(crate::FieldReader<bool, bool>);
-impl ARAL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ARAL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ARAL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ARAL_R = crate::BitReader;
 #[doc = "Field `ARAL` writer - Access to Reserved Address Line"]
-pub struct ARAL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ARAL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 29)) | ((value as u32 & 0x01) << 29);
-        self.w
-    }
-}
+pub type ARAL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
     #[doc = "Bit 0 - Rx FIFO 0 New Message Interrupt Line"]
     #[inline(always)]
     pub fn rf0nl(&self) -> RF0NL_R {
-        RF0NL_R::new((self.bits & 0x01) != 0)
+        RF0NL_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - Rx FIFO 0 Watermark Reached Interrupt Line"]
     #[inline(always)]
     pub fn rf0wl(&self) -> RF0WL_R {
-        RF0WL_R::new(((self.bits >> 1) & 0x01) != 0)
+        RF0WL_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - Rx FIFO 0 Full Interrupt Line"]
     #[inline(always)]
     pub fn rf0fl(&self) -> RF0FL_R {
-        RF0FL_R::new(((self.bits >> 2) & 0x01) != 0)
+        RF0FL_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - Rx FIFO 0 Message Lost Interrupt Line"]
     #[inline(always)]
     pub fn rf0ll(&self) -> RF0LL_R {
-        RF0LL_R::new(((self.bits >> 3) & 0x01) != 0)
+        RF0LL_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - Rx FIFO 1 New Message Interrupt Line"]
     #[inline(always)]
     pub fn rf1nl(&self) -> RF1NL_R {
-        RF1NL_R::new(((self.bits >> 4) & 0x01) != 0)
+        RF1NL_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - Rx FIFO 1 Watermark Reached Interrupt Line"]
     #[inline(always)]
     pub fn rf1wl(&self) -> RF1WL_R {
-        RF1WL_R::new(((self.bits >> 5) & 0x01) != 0)
+        RF1WL_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - Rx FIFO 1 FIFO Full Interrupt Line"]
     #[inline(always)]
     pub fn rf1fl(&self) -> RF1FL_R {
-        RF1FL_R::new(((self.bits >> 6) & 0x01) != 0)
+        RF1FL_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - Rx FIFO 1 Message Lost Interrupt Line"]
     #[inline(always)]
     pub fn rf1ll(&self) -> RF1LL_R {
-        RF1LL_R::new(((self.bits >> 7) & 0x01) != 0)
+        RF1LL_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - High Priority Message Interrupt Line"]
     #[inline(always)]
     pub fn hpml(&self) -> HPML_R {
-        HPML_R::new(((self.bits >> 8) & 0x01) != 0)
+        HPML_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - Timestamp Completed Interrupt Line"]
     #[inline(always)]
     pub fn tcl(&self) -> TCL_R {
-        TCL_R::new(((self.bits >> 9) & 0x01) != 0)
+        TCL_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - Transmission Cancellation Finished Interrupt Line"]
     #[inline(always)]
     pub fn tcfl(&self) -> TCFL_R {
-        TCFL_R::new(((self.bits >> 10) & 0x01) != 0)
+        TCFL_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Tx FIFO Empty Interrupt Line"]
     #[inline(always)]
     pub fn tfel(&self) -> TFEL_R {
-        TFEL_R::new(((self.bits >> 11) & 0x01) != 0)
+        TFEL_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - Tx Event FIFO New Entry Interrupt Line"]
     #[inline(always)]
     pub fn tefnl(&self) -> TEFNL_R {
-        TEFNL_R::new(((self.bits >> 12) & 0x01) != 0)
+        TEFNL_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - Tx Event FIFO Watermark Reached Interrupt Line"]
     #[inline(always)]
     pub fn tefwl(&self) -> TEFWL_R {
-        TEFWL_R::new(((self.bits >> 13) & 0x01) != 0)
+        TEFWL_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - Tx Event FIFO Full Interrupt Line"]
     #[inline(always)]
     pub fn teffl(&self) -> TEFFL_R {
-        TEFFL_R::new(((self.bits >> 14) & 0x01) != 0)
+        TEFFL_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - Tx Event FIFO Element Lost Interrupt Line"]
     #[inline(always)]
     pub fn tefll(&self) -> TEFLL_R {
-        TEFLL_R::new(((self.bits >> 15) & 0x01) != 0)
+        TEFLL_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - Timestamp Wraparound Interrupt Line"]
     #[inline(always)]
     pub fn tswl(&self) -> TSWL_R {
-        TSWL_R::new(((self.bits >> 16) & 0x01) != 0)
+        TSWL_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - Message RAM Access Failure Interrupt Line"]
     #[inline(always)]
     pub fn mrafl(&self) -> MRAFL_R {
-        MRAFL_R::new(((self.bits >> 17) & 0x01) != 0)
+        MRAFL_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - Timeout Occurred Interrupt Line"]
     #[inline(always)]
     pub fn tool(&self) -> TOOL_R {
-        TOOL_R::new(((self.bits >> 18) & 0x01) != 0)
+        TOOL_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - Message stored to Dedicated Rx Buffer Interrupt Line"]
     #[inline(always)]
     pub fn drxl(&self) -> DRXL_R {
-        DRXL_R::new(((self.bits >> 19) & 0x01) != 0)
+        DRXL_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - Bit Error Corrected Interrupt Line"]
     #[inline(always)]
     pub fn becl(&self) -> BECL_R {
-        BECL_R::new(((self.bits >> 20) & 0x01) != 0)
+        BECL_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - Bit Error Uncorrected Interrupt Line"]
     #[inline(always)]
     pub fn beul(&self) -> BEUL_R {
-        BEUL_R::new(((self.bits >> 21) & 0x01) != 0)
+        BEUL_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - Error Logging Overflow Interrupt Line"]
     #[inline(always)]
     pub fn elol(&self) -> ELOL_R {
-        ELOL_R::new(((self.bits >> 22) & 0x01) != 0)
+        ELOL_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - Error Passive Interrupt Line"]
     #[inline(always)]
     pub fn epl(&self) -> EPL_R {
-        EPL_R::new(((self.bits >> 23) & 0x01) != 0)
+        EPL_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - Warning Status Interrupt Line"]
     #[inline(always)]
     pub fn ewl(&self) -> EWL_R {
-        EWL_R::new(((self.bits >> 24) & 0x01) != 0)
+        EWL_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - Bus_Off Status Interrupt Line"]
     #[inline(always)]
     pub fn bol(&self) -> BOL_R {
-        BOL_R::new(((self.bits >> 25) & 0x01) != 0)
+        BOL_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - Watchdog Interrupt Interrupt Line"]
     #[inline(always)]
     pub fn wdil(&self) -> WDIL_R {
-        WDIL_R::new(((self.bits >> 26) & 0x01) != 0)
+        WDIL_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - Protocol Error in Arbitration Phase Line"]
     #[inline(always)]
     pub fn peal(&self) -> PEAL_R {
-        PEAL_R::new(((self.bits >> 27) & 0x01) != 0)
+        PEAL_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - Protocol Error in Data Phase Line"]
     #[inline(always)]
     pub fn pedl(&self) -> PEDL_R {
-        PEDL_R::new(((self.bits >> 28) & 0x01) != 0)
+        PEDL_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - Access to Reserved Address Line"]
     #[inline(always)]
     pub fn aral(&self) -> ARAL_R {
-        ARAL_R::new(((self.bits >> 29) & 0x01) != 0)
+        ARAL_R::new(((self.bits >> 29) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - Rx FIFO 0 New Message Interrupt Line"]
     #[inline(always)]
-    pub fn rf0nl(&mut self) -> RF0NL_W {
-        RF0NL_W { w: self }
+    #[must_use]
+    pub fn rf0nl(&mut self) -> RF0NL_W<ILS_SPEC, 0> {
+        RF0NL_W::new(self)
     }
     #[doc = "Bit 1 - Rx FIFO 0 Watermark Reached Interrupt Line"]
     #[inline(always)]
-    pub fn rf0wl(&mut self) -> RF0WL_W {
-        RF0WL_W { w: self }
+    #[must_use]
+    pub fn rf0wl(&mut self) -> RF0WL_W<ILS_SPEC, 1> {
+        RF0WL_W::new(self)
     }
     #[doc = "Bit 2 - Rx FIFO 0 Full Interrupt Line"]
     #[inline(always)]
-    pub fn rf0fl(&mut self) -> RF0FL_W {
-        RF0FL_W { w: self }
+    #[must_use]
+    pub fn rf0fl(&mut self) -> RF0FL_W<ILS_SPEC, 2> {
+        RF0FL_W::new(self)
     }
     #[doc = "Bit 3 - Rx FIFO 0 Message Lost Interrupt Line"]
     #[inline(always)]
-    pub fn rf0ll(&mut self) -> RF0LL_W {
-        RF0LL_W { w: self }
+    #[must_use]
+    pub fn rf0ll(&mut self) -> RF0LL_W<ILS_SPEC, 3> {
+        RF0LL_W::new(self)
     }
     #[doc = "Bit 4 - Rx FIFO 1 New Message Interrupt Line"]
     #[inline(always)]
-    pub fn rf1nl(&mut self) -> RF1NL_W {
-        RF1NL_W { w: self }
+    #[must_use]
+    pub fn rf1nl(&mut self) -> RF1NL_W<ILS_SPEC, 4> {
+        RF1NL_W::new(self)
     }
     #[doc = "Bit 5 - Rx FIFO 1 Watermark Reached Interrupt Line"]
     #[inline(always)]
-    pub fn rf1wl(&mut self) -> RF1WL_W {
-        RF1WL_W { w: self }
+    #[must_use]
+    pub fn rf1wl(&mut self) -> RF1WL_W<ILS_SPEC, 5> {
+        RF1WL_W::new(self)
     }
     #[doc = "Bit 6 - Rx FIFO 1 FIFO Full Interrupt Line"]
     #[inline(always)]
-    pub fn rf1fl(&mut self) -> RF1FL_W {
-        RF1FL_W { w: self }
+    #[must_use]
+    pub fn rf1fl(&mut self) -> RF1FL_W<ILS_SPEC, 6> {
+        RF1FL_W::new(self)
     }
     #[doc = "Bit 7 - Rx FIFO 1 Message Lost Interrupt Line"]
     #[inline(always)]
-    pub fn rf1ll(&mut self) -> RF1LL_W {
-        RF1LL_W { w: self }
+    #[must_use]
+    pub fn rf1ll(&mut self) -> RF1LL_W<ILS_SPEC, 7> {
+        RF1LL_W::new(self)
     }
     #[doc = "Bit 8 - High Priority Message Interrupt Line"]
     #[inline(always)]
-    pub fn hpml(&mut self) -> HPML_W {
-        HPML_W { w: self }
+    #[must_use]
+    pub fn hpml(&mut self) -> HPML_W<ILS_SPEC, 8> {
+        HPML_W::new(self)
     }
     #[doc = "Bit 9 - Timestamp Completed Interrupt Line"]
     #[inline(always)]
-    pub fn tcl(&mut self) -> TCL_W {
-        TCL_W { w: self }
+    #[must_use]
+    pub fn tcl(&mut self) -> TCL_W<ILS_SPEC, 9> {
+        TCL_W::new(self)
     }
     #[doc = "Bit 10 - Transmission Cancellation Finished Interrupt Line"]
     #[inline(always)]
-    pub fn tcfl(&mut self) -> TCFL_W {
-        TCFL_W { w: self }
+    #[must_use]
+    pub fn tcfl(&mut self) -> TCFL_W<ILS_SPEC, 10> {
+        TCFL_W::new(self)
     }
     #[doc = "Bit 11 - Tx FIFO Empty Interrupt Line"]
     #[inline(always)]
-    pub fn tfel(&mut self) -> TFEL_W {
-        TFEL_W { w: self }
+    #[must_use]
+    pub fn tfel(&mut self) -> TFEL_W<ILS_SPEC, 11> {
+        TFEL_W::new(self)
     }
     #[doc = "Bit 12 - Tx Event FIFO New Entry Interrupt Line"]
     #[inline(always)]
-    pub fn tefnl(&mut self) -> TEFNL_W {
-        TEFNL_W { w: self }
+    #[must_use]
+    pub fn tefnl(&mut self) -> TEFNL_W<ILS_SPEC, 12> {
+        TEFNL_W::new(self)
     }
     #[doc = "Bit 13 - Tx Event FIFO Watermark Reached Interrupt Line"]
     #[inline(always)]
-    pub fn tefwl(&mut self) -> TEFWL_W {
-        TEFWL_W { w: self }
+    #[must_use]
+    pub fn tefwl(&mut self) -> TEFWL_W<ILS_SPEC, 13> {
+        TEFWL_W::new(self)
     }
     #[doc = "Bit 14 - Tx Event FIFO Full Interrupt Line"]
     #[inline(always)]
-    pub fn teffl(&mut self) -> TEFFL_W {
-        TEFFL_W { w: self }
+    #[must_use]
+    pub fn teffl(&mut self) -> TEFFL_W<ILS_SPEC, 14> {
+        TEFFL_W::new(self)
     }
     #[doc = "Bit 15 - Tx Event FIFO Element Lost Interrupt Line"]
     #[inline(always)]
-    pub fn tefll(&mut self) -> TEFLL_W {
-        TEFLL_W { w: self }
+    #[must_use]
+    pub fn tefll(&mut self) -> TEFLL_W<ILS_SPEC, 15> {
+        TEFLL_W::new(self)
     }
     #[doc = "Bit 16 - Timestamp Wraparound Interrupt Line"]
     #[inline(always)]
-    pub fn tswl(&mut self) -> TSWL_W {
-        TSWL_W { w: self }
+    #[must_use]
+    pub fn tswl(&mut self) -> TSWL_W<ILS_SPEC, 16> {
+        TSWL_W::new(self)
     }
     #[doc = "Bit 17 - Message RAM Access Failure Interrupt Line"]
     #[inline(always)]
-    pub fn mrafl(&mut self) -> MRAFL_W {
-        MRAFL_W { w: self }
+    #[must_use]
+    pub fn mrafl(&mut self) -> MRAFL_W<ILS_SPEC, 17> {
+        MRAFL_W::new(self)
     }
     #[doc = "Bit 18 - Timeout Occurred Interrupt Line"]
     #[inline(always)]
-    pub fn tool(&mut self) -> TOOL_W {
-        TOOL_W { w: self }
+    #[must_use]
+    pub fn tool(&mut self) -> TOOL_W<ILS_SPEC, 18> {
+        TOOL_W::new(self)
     }
     #[doc = "Bit 19 - Message stored to Dedicated Rx Buffer Interrupt Line"]
     #[inline(always)]
-    pub fn drxl(&mut self) -> DRXL_W {
-        DRXL_W { w: self }
+    #[must_use]
+    pub fn drxl(&mut self) -> DRXL_W<ILS_SPEC, 19> {
+        DRXL_W::new(self)
     }
     #[doc = "Bit 20 - Bit Error Corrected Interrupt Line"]
     #[inline(always)]
-    pub fn becl(&mut self) -> BECL_W {
-        BECL_W { w: self }
+    #[must_use]
+    pub fn becl(&mut self) -> BECL_W<ILS_SPEC, 20> {
+        BECL_W::new(self)
     }
     #[doc = "Bit 21 - Bit Error Uncorrected Interrupt Line"]
     #[inline(always)]
-    pub fn beul(&mut self) -> BEUL_W {
-        BEUL_W { w: self }
+    #[must_use]
+    pub fn beul(&mut self) -> BEUL_W<ILS_SPEC, 21> {
+        BEUL_W::new(self)
     }
     #[doc = "Bit 22 - Error Logging Overflow Interrupt Line"]
     #[inline(always)]
-    pub fn elol(&mut self) -> ELOL_W {
-        ELOL_W { w: self }
+    #[must_use]
+    pub fn elol(&mut self) -> ELOL_W<ILS_SPEC, 22> {
+        ELOL_W::new(self)
     }
     #[doc = "Bit 23 - Error Passive Interrupt Line"]
     #[inline(always)]
-    pub fn epl(&mut self) -> EPL_W {
-        EPL_W { w: self }
+    #[must_use]
+    pub fn epl(&mut self) -> EPL_W<ILS_SPEC, 23> {
+        EPL_W::new(self)
     }
     #[doc = "Bit 24 - Warning Status Interrupt Line"]
     #[inline(always)]
-    pub fn ewl(&mut self) -> EWL_W {
-        EWL_W { w: self }
+    #[must_use]
+    pub fn ewl(&mut self) -> EWL_W<ILS_SPEC, 24> {
+        EWL_W::new(self)
     }
     #[doc = "Bit 25 - Bus_Off Status Interrupt Line"]
     #[inline(always)]
-    pub fn bol(&mut self) -> BOL_W {
-        BOL_W { w: self }
+    #[must_use]
+    pub fn bol(&mut self) -> BOL_W<ILS_SPEC, 25> {
+        BOL_W::new(self)
     }
     #[doc = "Bit 26 - Watchdog Interrupt Interrupt Line"]
     #[inline(always)]
-    pub fn wdil(&mut self) -> WDIL_W {
-        WDIL_W { w: self }
+    #[must_use]
+    pub fn wdil(&mut self) -> WDIL_W<ILS_SPEC, 26> {
+        WDIL_W::new(self)
     }
     #[doc = "Bit 27 - Protocol Error in Arbitration Phase Line"]
     #[inline(always)]
-    pub fn peal(&mut self) -> PEAL_W {
-        PEAL_W { w: self }
+    #[must_use]
+    pub fn peal(&mut self) -> PEAL_W<ILS_SPEC, 27> {
+        PEAL_W::new(self)
     }
     #[doc = "Bit 28 - Protocol Error in Data Phase Line"]
     #[inline(always)]
-    pub fn pedl(&mut self) -> PEDL_W {
-        PEDL_W { w: self }
+    #[must_use]
+    pub fn pedl(&mut self) -> PEDL_W<ILS_SPEC, 28> {
+        PEDL_W::new(self)
     }
     #[doc = "Bit 29 - Access to Reserved Address Line"]
     #[inline(always)]
-    pub fn aral(&mut self) -> ARAL_W {
-        ARAL_W { w: self }
+    #[must_use]
+    pub fn aral(&mut self) -> ARAL_W<ILS_SPEC, 29> {
+        ARAL_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Interrupt Line Select\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ils](index.html) module"]
+#[doc = "Interrupt Line Select\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ils::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ils::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ILS_SPEC;
 impl crate::RegisterSpec for ILS_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [ils::R](R) reader structure"]
-impl crate::Readable for ILS_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [ils::W](W) writer structure"]
+#[doc = "`read()` method returns [`ils::R`](R) reader structure"]
+impl crate::Readable for ILS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ils::W`](W) writer structure"]
 impl crate::Writable for ILS_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets ILS to value 0"]
 impl crate::Resettable for ILS_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/ils.rs
+++ b/mcan/src/reg/ils.rs
@@ -466,7 +466,7 @@ impl W {
         self
     }
 }
-#[doc = "Interrupt Line Select\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ils::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ils::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Interrupt Line Select\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`ils::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`ils::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ILS_SPEC;
 impl crate::RegisterSpec for ILS_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/ir.rs
+++ b/mcan/src/reg/ir.rs
@@ -1,1476 +1,484 @@
 #[doc = "Register `IR` reader"]
-pub struct R(crate::R<IR_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<IR_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<IR_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<IR_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<IR_SPEC>;
 #[doc = "Register `IR` writer"]
-pub struct W(crate::W<IR_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<IR_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<IR_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<IR_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<IR_SPEC>;
 #[doc = "Field `RF0N` reader - Rx FIFO 0 New Message"]
-pub struct RF0N_R(crate::FieldReader<bool, bool>);
-impl RF0N_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF0N_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF0N_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF0N_R = crate::BitReader;
 #[doc = "Field `RF0N` writer - Rx FIFO 0 New Message"]
-pub struct RF0N_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF0N_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x01) | (value as u32 & 0x01);
-        self.w
-    }
-}
+pub type RF0N_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `RF0W` reader - Rx FIFO 0 Watermark Reached"]
-pub struct RF0W_R(crate::FieldReader<bool, bool>);
-impl RF0W_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF0W_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF0W_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF0W_R = crate::BitReader;
 #[doc = "Field `RF0W` writer - Rx FIFO 0 Watermark Reached"]
-pub struct RF0W_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF0W_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 1)) | ((value as u32 & 0x01) << 1);
-        self.w
-    }
-}
+pub type RF0W_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `RF0F` reader - Rx FIFO 0 Full"]
-pub struct RF0F_R(crate::FieldReader<bool, bool>);
-impl RF0F_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF0F_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF0F_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF0F_R = crate::BitReader;
 #[doc = "Field `RF0F` writer - Rx FIFO 0 Full"]
-pub struct RF0F_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF0F_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 2)) | ((value as u32 & 0x01) << 2);
-        self.w
-    }
-}
+pub type RF0F_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `RF0L` reader - Rx FIFO 0 Message Lost"]
-pub struct RF0L_R(crate::FieldReader<bool, bool>);
-impl RF0L_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF0L_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF0L_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF0L_R = crate::BitReader;
 #[doc = "Field `RF0L` writer - Rx FIFO 0 Message Lost"]
-pub struct RF0L_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF0L_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 3)) | ((value as u32 & 0x01) << 3);
-        self.w
-    }
-}
+pub type RF0L_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `RF1N` reader - Rx FIFO 1 New Message"]
-pub struct RF1N_R(crate::FieldReader<bool, bool>);
-impl RF1N_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF1N_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF1N_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF1N_R = crate::BitReader;
 #[doc = "Field `RF1N` writer - Rx FIFO 1 New Message"]
-pub struct RF1N_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF1N_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 4)) | ((value as u32 & 0x01) << 4);
-        self.w
-    }
-}
+pub type RF1N_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `RF1W` reader - Rx FIFO 1 Watermark Reached"]
-pub struct RF1W_R(crate::FieldReader<bool, bool>);
-impl RF1W_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF1W_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF1W_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF1W_R = crate::BitReader;
 #[doc = "Field `RF1W` writer - Rx FIFO 1 Watermark Reached"]
-pub struct RF1W_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF1W_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 5)) | ((value as u32 & 0x01) << 5);
-        self.w
-    }
-}
+pub type RF1W_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `RF1F` reader - Rx FIFO 1 FIFO Full"]
-pub struct RF1F_R(crate::FieldReader<bool, bool>);
-impl RF1F_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF1F_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF1F_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF1F_R = crate::BitReader;
 #[doc = "Field `RF1F` writer - Rx FIFO 1 FIFO Full"]
-pub struct RF1F_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF1F_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 6)) | ((value as u32 & 0x01) << 6);
-        self.w
-    }
-}
+pub type RF1F_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `RF1L` reader - Rx FIFO 1 Message Lost"]
-pub struct RF1L_R(crate::FieldReader<bool, bool>);
-impl RF1L_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF1L_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF1L_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF1L_R = crate::BitReader;
 #[doc = "Field `RF1L` writer - Rx FIFO 1 Message Lost"]
-pub struct RF1L_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RF1L_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 7)) | ((value as u32 & 0x01) << 7);
-        self.w
-    }
-}
+pub type RF1L_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `HPM` reader - High Priority Message"]
-pub struct HPM_R(crate::FieldReader<bool, bool>);
-impl HPM_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        HPM_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for HPM_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type HPM_R = crate::BitReader;
 #[doc = "Field `HPM` writer - High Priority Message"]
-pub struct HPM_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> HPM_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 8)) | ((value as u32 & 0x01) << 8);
-        self.w
-    }
-}
+pub type HPM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TC` reader - Timestamp Completed"]
-pub struct TC_R(crate::FieldReader<bool, bool>);
-impl TC_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TC_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TC_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TC_R = crate::BitReader;
 #[doc = "Field `TC` writer - Timestamp Completed"]
-pub struct TC_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TC_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 9)) | ((value as u32 & 0x01) << 9);
-        self.w
-    }
-}
+pub type TC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TCF` reader - Transmission Cancellation Finished"]
-pub struct TCF_R(crate::FieldReader<bool, bool>);
-impl TCF_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TCF_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TCF_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TCF_R = crate::BitReader;
 #[doc = "Field `TCF` writer - Transmission Cancellation Finished"]
-pub struct TCF_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TCF_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 10)) | ((value as u32 & 0x01) << 10);
-        self.w
-    }
-}
+pub type TCF_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TFE` reader - Tx FIFO Empty"]
-pub struct TFE_R(crate::FieldReader<bool, bool>);
-impl TFE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TFE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TFE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TFE_R = crate::BitReader;
 #[doc = "Field `TFE` writer - Tx FIFO Empty"]
-pub struct TFE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TFE_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 11)) | ((value as u32 & 0x01) << 11);
-        self.w
-    }
-}
+pub type TFE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TEFN` reader - Tx Event FIFO New Entry"]
-pub struct TEFN_R(crate::FieldReader<bool, bool>);
-impl TEFN_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TEFN_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TEFN_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TEFN_R = crate::BitReader;
 #[doc = "Field `TEFN` writer - Tx Event FIFO New Entry"]
-pub struct TEFN_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TEFN_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 12)) | ((value as u32 & 0x01) << 12);
-        self.w
-    }
-}
+pub type TEFN_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TEFW` reader - Tx Event FIFO Watermark Reached"]
-pub struct TEFW_R(crate::FieldReader<bool, bool>);
-impl TEFW_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TEFW_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TEFW_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TEFW_R = crate::BitReader;
 #[doc = "Field `TEFW` writer - Tx Event FIFO Watermark Reached"]
-pub struct TEFW_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TEFW_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 13)) | ((value as u32 & 0x01) << 13);
-        self.w
-    }
-}
+pub type TEFW_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TEFF` reader - Tx Event FIFO Full"]
-pub struct TEFF_R(crate::FieldReader<bool, bool>);
-impl TEFF_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TEFF_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TEFF_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TEFF_R = crate::BitReader;
 #[doc = "Field `TEFF` writer - Tx Event FIFO Full"]
-pub struct TEFF_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TEFF_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 14)) | ((value as u32 & 0x01) << 14);
-        self.w
-    }
-}
+pub type TEFF_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TEFL` reader - Tx Event FIFO Element Lost"]
-pub struct TEFL_R(crate::FieldReader<bool, bool>);
-impl TEFL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TEFL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TEFL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TEFL_R = crate::BitReader;
 #[doc = "Field `TEFL` writer - Tx Event FIFO Element Lost"]
-pub struct TEFL_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TEFL_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 15)) | ((value as u32 & 0x01) << 15);
-        self.w
-    }
-}
+pub type TEFL_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TSW` reader - Timestamp Wraparound"]
-pub struct TSW_R(crate::FieldReader<bool, bool>);
-impl TSW_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TSW_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TSW_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TSW_R = crate::BitReader;
 #[doc = "Field `TSW` writer - Timestamp Wraparound"]
-pub struct TSW_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TSW_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 16)) | ((value as u32 & 0x01) << 16);
-        self.w
-    }
-}
+pub type TSW_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `MRAF` reader - Message RAM Access Failure"]
-pub struct MRAF_R(crate::FieldReader<bool, bool>);
-impl MRAF_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        MRAF_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for MRAF_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type MRAF_R = crate::BitReader;
 #[doc = "Field `MRAF` writer - Message RAM Access Failure"]
-pub struct MRAF_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> MRAF_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 17)) | ((value as u32 & 0x01) << 17);
-        self.w
-    }
-}
+pub type MRAF_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TOO` reader - Timeout Occurred"]
-pub struct TOO_R(crate::FieldReader<bool, bool>);
-impl TOO_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TOO_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TOO_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TOO_R = crate::BitReader;
 #[doc = "Field `TOO` writer - Timeout Occurred"]
-pub struct TOO_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TOO_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 18)) | ((value as u32 & 0x01) << 18);
-        self.w
-    }
-}
+pub type TOO_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `DRX` reader - Message stored to Dedicated Rx Buffer"]
-pub struct DRX_R(crate::FieldReader<bool, bool>);
-impl DRX_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        DRX_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for DRX_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type DRX_R = crate::BitReader;
 #[doc = "Field `DRX` writer - Message stored to Dedicated Rx Buffer"]
-pub struct DRX_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> DRX_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 19)) | ((value as u32 & 0x01) << 19);
-        self.w
-    }
-}
+pub type DRX_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `BEC` reader - Bit Error Corrected"]
-pub struct BEC_R(crate::FieldReader<bool, bool>);
-impl BEC_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        BEC_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for BEC_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type BEC_R = crate::BitReader;
 #[doc = "Field `BEC` writer - Bit Error Corrected"]
-pub struct BEC_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> BEC_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 20)) | ((value as u32 & 0x01) << 20);
-        self.w
-    }
-}
+pub type BEC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `BEU` reader - Bit Error Uncorrected"]
-pub struct BEU_R(crate::FieldReader<bool, bool>);
-impl BEU_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        BEU_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for BEU_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type BEU_R = crate::BitReader;
 #[doc = "Field `BEU` writer - Bit Error Uncorrected"]
-pub struct BEU_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> BEU_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 21)) | ((value as u32 & 0x01) << 21);
-        self.w
-    }
-}
+pub type BEU_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ELO` reader - Error Logging Overflow"]
-pub struct ELO_R(crate::FieldReader<bool, bool>);
-impl ELO_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ELO_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ELO_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ELO_R = crate::BitReader;
 #[doc = "Field `ELO` writer - Error Logging Overflow"]
-pub struct ELO_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ELO_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 22)) | ((value as u32 & 0x01) << 22);
-        self.w
-    }
-}
+pub type ELO_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `EP` reader - Error Passive"]
-pub struct EP_R(crate::FieldReader<bool, bool>);
-impl EP_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        EP_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for EP_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type EP_R = crate::BitReader;
 #[doc = "Field `EP` writer - Error Passive"]
-pub struct EP_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> EP_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 23)) | ((value as u32 & 0x01) << 23);
-        self.w
-    }
-}
+pub type EP_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `EW` reader - Warning Status"]
-pub struct EW_R(crate::FieldReader<bool, bool>);
-impl EW_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        EW_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for EW_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type EW_R = crate::BitReader;
 #[doc = "Field `EW` writer - Warning Status"]
-pub struct EW_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> EW_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 24)) | ((value as u32 & 0x01) << 24);
-        self.w
-    }
-}
+pub type EW_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `BO` reader - Bus_Off Status"]
-pub struct BO_R(crate::FieldReader<bool, bool>);
-impl BO_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        BO_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for BO_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type BO_R = crate::BitReader;
 #[doc = "Field `BO` writer - Bus_Off Status"]
-pub struct BO_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> BO_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 25)) | ((value as u32 & 0x01) << 25);
-        self.w
-    }
-}
+pub type BO_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `WDI` reader - Watchdog Interrupt"]
-pub struct WDI_R(crate::FieldReader<bool, bool>);
-impl WDI_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        WDI_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for WDI_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type WDI_R = crate::BitReader;
 #[doc = "Field `WDI` writer - Watchdog Interrupt"]
-pub struct WDI_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> WDI_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 26)) | ((value as u32 & 0x01) << 26);
-        self.w
-    }
-}
+pub type WDI_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `PEA` reader - Protocol Error in Arbitration Phase"]
-pub struct PEA_R(crate::FieldReader<bool, bool>);
-impl PEA_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        PEA_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for PEA_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type PEA_R = crate::BitReader;
 #[doc = "Field `PEA` writer - Protocol Error in Arbitration Phase"]
-pub struct PEA_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> PEA_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 27)) | ((value as u32 & 0x01) << 27);
-        self.w
-    }
-}
+pub type PEA_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `PED` reader - Protocol Error in Data Phase"]
-pub struct PED_R(crate::FieldReader<bool, bool>);
-impl PED_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        PED_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for PED_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type PED_R = crate::BitReader;
 #[doc = "Field `PED` writer - Protocol Error in Data Phase"]
-pub struct PED_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> PED_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 28)) | ((value as u32 & 0x01) << 28);
-        self.w
-    }
-}
+pub type PED_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ARA` reader - Access to Reserved Address"]
-pub struct ARA_R(crate::FieldReader<bool, bool>);
-impl ARA_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ARA_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ARA_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ARA_R = crate::BitReader;
 #[doc = "Field `ARA` writer - Access to Reserved Address"]
-pub struct ARA_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ARA_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 29)) | ((value as u32 & 0x01) << 29);
-        self.w
-    }
-}
+pub type ARA_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
     #[doc = "Bit 0 - Rx FIFO 0 New Message"]
     #[inline(always)]
     pub fn rf0n(&self) -> RF0N_R {
-        RF0N_R::new((self.bits & 0x01) != 0)
+        RF0N_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - Rx FIFO 0 Watermark Reached"]
     #[inline(always)]
     pub fn rf0w(&self) -> RF0W_R {
-        RF0W_R::new(((self.bits >> 1) & 0x01) != 0)
+        RF0W_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - Rx FIFO 0 Full"]
     #[inline(always)]
     pub fn rf0f(&self) -> RF0F_R {
-        RF0F_R::new(((self.bits >> 2) & 0x01) != 0)
+        RF0F_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - Rx FIFO 0 Message Lost"]
     #[inline(always)]
     pub fn rf0l(&self) -> RF0L_R {
-        RF0L_R::new(((self.bits >> 3) & 0x01) != 0)
+        RF0L_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - Rx FIFO 1 New Message"]
     #[inline(always)]
     pub fn rf1n(&self) -> RF1N_R {
-        RF1N_R::new(((self.bits >> 4) & 0x01) != 0)
+        RF1N_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - Rx FIFO 1 Watermark Reached"]
     #[inline(always)]
     pub fn rf1w(&self) -> RF1W_R {
-        RF1W_R::new(((self.bits >> 5) & 0x01) != 0)
+        RF1W_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - Rx FIFO 1 FIFO Full"]
     #[inline(always)]
     pub fn rf1f(&self) -> RF1F_R {
-        RF1F_R::new(((self.bits >> 6) & 0x01) != 0)
+        RF1F_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - Rx FIFO 1 Message Lost"]
     #[inline(always)]
     pub fn rf1l(&self) -> RF1L_R {
-        RF1L_R::new(((self.bits >> 7) & 0x01) != 0)
+        RF1L_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - High Priority Message"]
     #[inline(always)]
     pub fn hpm(&self) -> HPM_R {
-        HPM_R::new(((self.bits >> 8) & 0x01) != 0)
+        HPM_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - Timestamp Completed"]
     #[inline(always)]
     pub fn tc(&self) -> TC_R {
-        TC_R::new(((self.bits >> 9) & 0x01) != 0)
+        TC_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - Transmission Cancellation Finished"]
     #[inline(always)]
     pub fn tcf(&self) -> TCF_R {
-        TCF_R::new(((self.bits >> 10) & 0x01) != 0)
+        TCF_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Tx FIFO Empty"]
     #[inline(always)]
     pub fn tfe(&self) -> TFE_R {
-        TFE_R::new(((self.bits >> 11) & 0x01) != 0)
+        TFE_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - Tx Event FIFO New Entry"]
     #[inline(always)]
     pub fn tefn(&self) -> TEFN_R {
-        TEFN_R::new(((self.bits >> 12) & 0x01) != 0)
+        TEFN_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - Tx Event FIFO Watermark Reached"]
     #[inline(always)]
     pub fn tefw(&self) -> TEFW_R {
-        TEFW_R::new(((self.bits >> 13) & 0x01) != 0)
+        TEFW_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - Tx Event FIFO Full"]
     #[inline(always)]
     pub fn teff(&self) -> TEFF_R {
-        TEFF_R::new(((self.bits >> 14) & 0x01) != 0)
+        TEFF_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - Tx Event FIFO Element Lost"]
     #[inline(always)]
     pub fn tefl(&self) -> TEFL_R {
-        TEFL_R::new(((self.bits >> 15) & 0x01) != 0)
+        TEFL_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - Timestamp Wraparound"]
     #[inline(always)]
     pub fn tsw(&self) -> TSW_R {
-        TSW_R::new(((self.bits >> 16) & 0x01) != 0)
+        TSW_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - Message RAM Access Failure"]
     #[inline(always)]
     pub fn mraf(&self) -> MRAF_R {
-        MRAF_R::new(((self.bits >> 17) & 0x01) != 0)
+        MRAF_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - Timeout Occurred"]
     #[inline(always)]
     pub fn too(&self) -> TOO_R {
-        TOO_R::new(((self.bits >> 18) & 0x01) != 0)
+        TOO_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - Message stored to Dedicated Rx Buffer"]
     #[inline(always)]
     pub fn drx(&self) -> DRX_R {
-        DRX_R::new(((self.bits >> 19) & 0x01) != 0)
+        DRX_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - Bit Error Corrected"]
     #[inline(always)]
     pub fn bec(&self) -> BEC_R {
-        BEC_R::new(((self.bits >> 20) & 0x01) != 0)
+        BEC_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - Bit Error Uncorrected"]
     #[inline(always)]
     pub fn beu(&self) -> BEU_R {
-        BEU_R::new(((self.bits >> 21) & 0x01) != 0)
+        BEU_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - Error Logging Overflow"]
     #[inline(always)]
     pub fn elo(&self) -> ELO_R {
-        ELO_R::new(((self.bits >> 22) & 0x01) != 0)
+        ELO_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - Error Passive"]
     #[inline(always)]
     pub fn ep(&self) -> EP_R {
-        EP_R::new(((self.bits >> 23) & 0x01) != 0)
+        EP_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - Warning Status"]
     #[inline(always)]
     pub fn ew(&self) -> EW_R {
-        EW_R::new(((self.bits >> 24) & 0x01) != 0)
+        EW_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - Bus_Off Status"]
     #[inline(always)]
     pub fn bo(&self) -> BO_R {
-        BO_R::new(((self.bits >> 25) & 0x01) != 0)
+        BO_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - Watchdog Interrupt"]
     #[inline(always)]
     pub fn wdi(&self) -> WDI_R {
-        WDI_R::new(((self.bits >> 26) & 0x01) != 0)
+        WDI_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - Protocol Error in Arbitration Phase"]
     #[inline(always)]
     pub fn pea(&self) -> PEA_R {
-        PEA_R::new(((self.bits >> 27) & 0x01) != 0)
+        PEA_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - Protocol Error in Data Phase"]
     #[inline(always)]
     pub fn ped(&self) -> PED_R {
-        PED_R::new(((self.bits >> 28) & 0x01) != 0)
+        PED_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - Access to Reserved Address"]
     #[inline(always)]
     pub fn ara(&self) -> ARA_R {
-        ARA_R::new(((self.bits >> 29) & 0x01) != 0)
+        ARA_R::new(((self.bits >> 29) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - Rx FIFO 0 New Message"]
     #[inline(always)]
-    pub fn rf0n(&mut self) -> RF0N_W {
-        RF0N_W { w: self }
+    #[must_use]
+    pub fn rf0n(&mut self) -> RF0N_W<IR_SPEC, 0> {
+        RF0N_W::new(self)
     }
     #[doc = "Bit 1 - Rx FIFO 0 Watermark Reached"]
     #[inline(always)]
-    pub fn rf0w(&mut self) -> RF0W_W {
-        RF0W_W { w: self }
+    #[must_use]
+    pub fn rf0w(&mut self) -> RF0W_W<IR_SPEC, 1> {
+        RF0W_W::new(self)
     }
     #[doc = "Bit 2 - Rx FIFO 0 Full"]
     #[inline(always)]
-    pub fn rf0f(&mut self) -> RF0F_W {
-        RF0F_W { w: self }
+    #[must_use]
+    pub fn rf0f(&mut self) -> RF0F_W<IR_SPEC, 2> {
+        RF0F_W::new(self)
     }
     #[doc = "Bit 3 - Rx FIFO 0 Message Lost"]
     #[inline(always)]
-    pub fn rf0l(&mut self) -> RF0L_W {
-        RF0L_W { w: self }
+    #[must_use]
+    pub fn rf0l(&mut self) -> RF0L_W<IR_SPEC, 3> {
+        RF0L_W::new(self)
     }
     #[doc = "Bit 4 - Rx FIFO 1 New Message"]
     #[inline(always)]
-    pub fn rf1n(&mut self) -> RF1N_W {
-        RF1N_W { w: self }
+    #[must_use]
+    pub fn rf1n(&mut self) -> RF1N_W<IR_SPEC, 4> {
+        RF1N_W::new(self)
     }
     #[doc = "Bit 5 - Rx FIFO 1 Watermark Reached"]
     #[inline(always)]
-    pub fn rf1w(&mut self) -> RF1W_W {
-        RF1W_W { w: self }
+    #[must_use]
+    pub fn rf1w(&mut self) -> RF1W_W<IR_SPEC, 5> {
+        RF1W_W::new(self)
     }
     #[doc = "Bit 6 - Rx FIFO 1 FIFO Full"]
     #[inline(always)]
-    pub fn rf1f(&mut self) -> RF1F_W {
-        RF1F_W { w: self }
+    #[must_use]
+    pub fn rf1f(&mut self) -> RF1F_W<IR_SPEC, 6> {
+        RF1F_W::new(self)
     }
     #[doc = "Bit 7 - Rx FIFO 1 Message Lost"]
     #[inline(always)]
-    pub fn rf1l(&mut self) -> RF1L_W {
-        RF1L_W { w: self }
+    #[must_use]
+    pub fn rf1l(&mut self) -> RF1L_W<IR_SPEC, 7> {
+        RF1L_W::new(self)
     }
     #[doc = "Bit 8 - High Priority Message"]
     #[inline(always)]
-    pub fn hpm(&mut self) -> HPM_W {
-        HPM_W { w: self }
+    #[must_use]
+    pub fn hpm(&mut self) -> HPM_W<IR_SPEC, 8> {
+        HPM_W::new(self)
     }
     #[doc = "Bit 9 - Timestamp Completed"]
     #[inline(always)]
-    pub fn tc(&mut self) -> TC_W {
-        TC_W { w: self }
+    #[must_use]
+    pub fn tc(&mut self) -> TC_W<IR_SPEC, 9> {
+        TC_W::new(self)
     }
     #[doc = "Bit 10 - Transmission Cancellation Finished"]
     #[inline(always)]
-    pub fn tcf(&mut self) -> TCF_W {
-        TCF_W { w: self }
+    #[must_use]
+    pub fn tcf(&mut self) -> TCF_W<IR_SPEC, 10> {
+        TCF_W::new(self)
     }
     #[doc = "Bit 11 - Tx FIFO Empty"]
     #[inline(always)]
-    pub fn tfe(&mut self) -> TFE_W {
-        TFE_W { w: self }
+    #[must_use]
+    pub fn tfe(&mut self) -> TFE_W<IR_SPEC, 11> {
+        TFE_W::new(self)
     }
     #[doc = "Bit 12 - Tx Event FIFO New Entry"]
     #[inline(always)]
-    pub fn tefn(&mut self) -> TEFN_W {
-        TEFN_W { w: self }
+    #[must_use]
+    pub fn tefn(&mut self) -> TEFN_W<IR_SPEC, 12> {
+        TEFN_W::new(self)
     }
     #[doc = "Bit 13 - Tx Event FIFO Watermark Reached"]
     #[inline(always)]
-    pub fn tefw(&mut self) -> TEFW_W {
-        TEFW_W { w: self }
+    #[must_use]
+    pub fn tefw(&mut self) -> TEFW_W<IR_SPEC, 13> {
+        TEFW_W::new(self)
     }
     #[doc = "Bit 14 - Tx Event FIFO Full"]
     #[inline(always)]
-    pub fn teff(&mut self) -> TEFF_W {
-        TEFF_W { w: self }
+    #[must_use]
+    pub fn teff(&mut self) -> TEFF_W<IR_SPEC, 14> {
+        TEFF_W::new(self)
     }
     #[doc = "Bit 15 - Tx Event FIFO Element Lost"]
     #[inline(always)]
-    pub fn tefl(&mut self) -> TEFL_W {
-        TEFL_W { w: self }
+    #[must_use]
+    pub fn tefl(&mut self) -> TEFL_W<IR_SPEC, 15> {
+        TEFL_W::new(self)
     }
     #[doc = "Bit 16 - Timestamp Wraparound"]
     #[inline(always)]
-    pub fn tsw(&mut self) -> TSW_W {
-        TSW_W { w: self }
+    #[must_use]
+    pub fn tsw(&mut self) -> TSW_W<IR_SPEC, 16> {
+        TSW_W::new(self)
     }
     #[doc = "Bit 17 - Message RAM Access Failure"]
     #[inline(always)]
-    pub fn mraf(&mut self) -> MRAF_W {
-        MRAF_W { w: self }
+    #[must_use]
+    pub fn mraf(&mut self) -> MRAF_W<IR_SPEC, 17> {
+        MRAF_W::new(self)
     }
     #[doc = "Bit 18 - Timeout Occurred"]
     #[inline(always)]
-    pub fn too(&mut self) -> TOO_W {
-        TOO_W { w: self }
+    #[must_use]
+    pub fn too(&mut self) -> TOO_W<IR_SPEC, 18> {
+        TOO_W::new(self)
     }
     #[doc = "Bit 19 - Message stored to Dedicated Rx Buffer"]
     #[inline(always)]
-    pub fn drx(&mut self) -> DRX_W {
-        DRX_W { w: self }
+    #[must_use]
+    pub fn drx(&mut self) -> DRX_W<IR_SPEC, 19> {
+        DRX_W::new(self)
     }
     #[doc = "Bit 20 - Bit Error Corrected"]
     #[inline(always)]
-    pub fn bec(&mut self) -> BEC_W {
-        BEC_W { w: self }
+    #[must_use]
+    pub fn bec(&mut self) -> BEC_W<IR_SPEC, 20> {
+        BEC_W::new(self)
     }
     #[doc = "Bit 21 - Bit Error Uncorrected"]
     #[inline(always)]
-    pub fn beu(&mut self) -> BEU_W {
-        BEU_W { w: self }
+    #[must_use]
+    pub fn beu(&mut self) -> BEU_W<IR_SPEC, 21> {
+        BEU_W::new(self)
     }
     #[doc = "Bit 22 - Error Logging Overflow"]
     #[inline(always)]
-    pub fn elo(&mut self) -> ELO_W {
-        ELO_W { w: self }
+    #[must_use]
+    pub fn elo(&mut self) -> ELO_W<IR_SPEC, 22> {
+        ELO_W::new(self)
     }
     #[doc = "Bit 23 - Error Passive"]
     #[inline(always)]
-    pub fn ep(&mut self) -> EP_W {
-        EP_W { w: self }
+    #[must_use]
+    pub fn ep(&mut self) -> EP_W<IR_SPEC, 23> {
+        EP_W::new(self)
     }
     #[doc = "Bit 24 - Warning Status"]
     #[inline(always)]
-    pub fn ew(&mut self) -> EW_W {
-        EW_W { w: self }
+    #[must_use]
+    pub fn ew(&mut self) -> EW_W<IR_SPEC, 24> {
+        EW_W::new(self)
     }
     #[doc = "Bit 25 - Bus_Off Status"]
     #[inline(always)]
-    pub fn bo(&mut self) -> BO_W {
-        BO_W { w: self }
+    #[must_use]
+    pub fn bo(&mut self) -> BO_W<IR_SPEC, 25> {
+        BO_W::new(self)
     }
     #[doc = "Bit 26 - Watchdog Interrupt"]
     #[inline(always)]
-    pub fn wdi(&mut self) -> WDI_W {
-        WDI_W { w: self }
+    #[must_use]
+    pub fn wdi(&mut self) -> WDI_W<IR_SPEC, 26> {
+        WDI_W::new(self)
     }
     #[doc = "Bit 27 - Protocol Error in Arbitration Phase"]
     #[inline(always)]
-    pub fn pea(&mut self) -> PEA_W {
-        PEA_W { w: self }
+    #[must_use]
+    pub fn pea(&mut self) -> PEA_W<IR_SPEC, 27> {
+        PEA_W::new(self)
     }
     #[doc = "Bit 28 - Protocol Error in Data Phase"]
     #[inline(always)]
-    pub fn ped(&mut self) -> PED_W {
-        PED_W { w: self }
+    #[must_use]
+    pub fn ped(&mut self) -> PED_W<IR_SPEC, 28> {
+        PED_W::new(self)
     }
     #[doc = "Bit 29 - Access to Reserved Address"]
     #[inline(always)]
-    pub fn ara(&mut self) -> ARA_W {
-        ARA_W { w: self }
+    #[must_use]
+    pub fn ara(&mut self) -> ARA_W<IR_SPEC, 29> {
+        ARA_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Interrupt\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ir](index.html) module"]
+#[doc = "Interrupt\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ir::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ir::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct IR_SPEC;
 impl crate::RegisterSpec for IR_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [ir::R](R) reader structure"]
-impl crate::Readable for IR_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [ir::W](W) writer structure"]
+#[doc = "`read()` method returns [`ir::R`](R) reader structure"]
+impl crate::Readable for IR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ir::W`](W) writer structure"]
 impl crate::Writable for IR_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets IR to value 0"]
 impl crate::Resettable for IR_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/ir.rs
+++ b/mcan/src/reg/ir.rs
@@ -466,7 +466,7 @@ impl W {
         self
     }
 }
-#[doc = "Interrupt\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ir::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ir::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Interrupt\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`ir::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`ir::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct IR_SPEC;
 impl crate::RegisterSpec for IR_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/nbtp.rs
+++ b/mcan/src/reg/nbtp.rs
@@ -1,147 +1,23 @@
 #[doc = "Register `NBTP` reader"]
-pub struct R(crate::R<NBTP_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<NBTP_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<NBTP_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<NBTP_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<NBTP_SPEC>;
 #[doc = "Register `NBTP` writer"]
-pub struct W(crate::W<NBTP_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<NBTP_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<NBTP_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<NBTP_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<NBTP_SPEC>;
 #[doc = "Field `NTSEG2` reader - Nominal Time segment after sample point"]
-pub struct NTSEG2_R(crate::FieldReader<u8, u8>);
-impl NTSEG2_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        NTSEG2_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for NTSEG2_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type NTSEG2_R = crate::FieldReader;
 #[doc = "Field `NTSEG2` writer - Nominal Time segment after sample point"]
-pub struct NTSEG2_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> NTSEG2_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x7f) | (value as u32 & 0x7f);
-        self.w
-    }
-}
+pub type NTSEG2_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
 #[doc = "Field `NTSEG1` reader - Nominal Time segment before sample point"]
-pub struct NTSEG1_R(crate::FieldReader<u8, u8>);
-impl NTSEG1_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        NTSEG1_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for NTSEG1_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type NTSEG1_R = crate::FieldReader;
 #[doc = "Field `NTSEG1` writer - Nominal Time segment before sample point"]
-pub struct NTSEG1_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> NTSEG1_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0xff << 8)) | ((value as u32 & 0xff) << 8);
-        self.w
-    }
-}
+pub type NTSEG1_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
 #[doc = "Field `NBRP` reader - Nominal Baud Rate Prescaler"]
-pub struct NBRP_R(crate::FieldReader<u16, u16>);
-impl NBRP_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u16) -> Self {
-        NBRP_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for NBRP_R {
-    type Target = crate::FieldReader<u16, u16>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type NBRP_R = crate::FieldReader<u16>;
 #[doc = "Field `NBRP` writer - Nominal Baud Rate Prescaler"]
-pub struct NBRP_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> NBRP_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u16) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01ff << 16)) | ((value as u32 & 0x01ff) << 16);
-        self.w
-    }
-}
+pub type NBRP_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 9, O, u16>;
 #[doc = "Field `NSJW` reader - Nominal (Re)Synchronization Jump Width"]
-pub struct NSJW_R(crate::FieldReader<u8, u8>);
-impl NSJW_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        NSJW_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for NSJW_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type NSJW_R = crate::FieldReader;
 #[doc = "Field `NSJW` writer - Nominal (Re)Synchronization Jump Width"]
-pub struct NSJW_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> NSJW_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x7f << 25)) | ((value as u32 & 0x7f) << 25);
-        self.w
-    }
-}
+pub type NSJW_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
 impl R {
     #[doc = "Bits 0:6 - Nominal Time segment after sample point"]
     #[inline(always)]
@@ -167,48 +43,52 @@ impl R {
 impl W {
     #[doc = "Bits 0:6 - Nominal Time segment after sample point"]
     #[inline(always)]
-    pub fn ntseg2(&mut self) -> NTSEG2_W {
-        NTSEG2_W { w: self }
+    #[must_use]
+    pub fn ntseg2(&mut self) -> NTSEG2_W<NBTP_SPEC, 0> {
+        NTSEG2_W::new(self)
     }
     #[doc = "Bits 8:15 - Nominal Time segment before sample point"]
     #[inline(always)]
-    pub fn ntseg1(&mut self) -> NTSEG1_W {
-        NTSEG1_W { w: self }
+    #[must_use]
+    pub fn ntseg1(&mut self) -> NTSEG1_W<NBTP_SPEC, 8> {
+        NTSEG1_W::new(self)
     }
     #[doc = "Bits 16:24 - Nominal Baud Rate Prescaler"]
     #[inline(always)]
-    pub fn nbrp(&mut self) -> NBRP_W {
-        NBRP_W { w: self }
+    #[must_use]
+    pub fn nbrp(&mut self) -> NBRP_W<NBTP_SPEC, 16> {
+        NBRP_W::new(self)
     }
     #[doc = "Bits 25:31 - Nominal (Re)Synchronization Jump Width"]
     #[inline(always)]
-    pub fn nsjw(&mut self) -> NSJW_W {
-        NSJW_W { w: self }
+    #[must_use]
+    pub fn nsjw(&mut self) -> NSJW_W<NBTP_SPEC, 25> {
+        NSJW_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Nominal Bit Timing and Prescaler\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [nbtp](index.html) module"]
+#[doc = "Nominal Bit Timing and Prescaler\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`nbtp::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`nbtp::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct NBTP_SPEC;
 impl crate::RegisterSpec for NBTP_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [nbtp::R](R) reader structure"]
-impl crate::Readable for NBTP_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [nbtp::W](W) writer structure"]
+#[doc = "`read()` method returns [`nbtp::R`](R) reader structure"]
+impl crate::Readable for NBTP_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`nbtp::W`](W) writer structure"]
 impl crate::Writable for NBTP_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets NBTP to value 0x0600_0a03"]
 impl crate::Resettable for NBTP_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0x0600_0a03
-    }
+    const RESET_VALUE: Self::Ux = 0x0600_0a03;
 }

--- a/mcan/src/reg/nbtp.rs
+++ b/mcan/src/reg/nbtp.rs
@@ -76,7 +76,7 @@ impl W {
         self
     }
 }
-#[doc = "Nominal Bit Timing and Prescaler\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`nbtp::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`nbtp::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Nominal Bit Timing and Prescaler\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`nbtp::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`nbtp::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct NBTP_SPEC;
 impl crate::RegisterSpec for NBTP_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/ndat1.rs
+++ b/mcan/src/reg/ndat1.rs
@@ -496,7 +496,7 @@ impl W {
         self
     }
 }
-#[doc = "New Data 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ndat1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ndat1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "New Data 1\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`ndat1::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`ndat1::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct NDAT1_SPEC;
 impl crate::RegisterSpec for NDAT1_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/ndat1.rs
+++ b/mcan/src/reg/ndat1.rs
@@ -1,1570 +1,514 @@
 #[doc = "Register `NDAT1` reader"]
-pub struct R(crate::R<NDAT1_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<NDAT1_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<NDAT1_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<NDAT1_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<NDAT1_SPEC>;
 #[doc = "Register `NDAT1` writer"]
-pub struct W(crate::W<NDAT1_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<NDAT1_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<NDAT1_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<NDAT1_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<NDAT1_SPEC>;
 #[doc = "Field `ND0` reader - New Data 0"]
-pub struct ND0_R(crate::FieldReader<bool, bool>);
-impl ND0_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND0_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND0_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND0_R = crate::BitReader;
 #[doc = "Field `ND0` writer - New Data 0"]
-pub struct ND0_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND0_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x01) | (value as u32 & 0x01);
-        self.w
-    }
-}
+pub type ND0_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND1` reader - New Data 1"]
-pub struct ND1_R(crate::FieldReader<bool, bool>);
-impl ND1_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND1_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND1_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND1_R = crate::BitReader;
 #[doc = "Field `ND1` writer - New Data 1"]
-pub struct ND1_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND1_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 1)) | ((value as u32 & 0x01) << 1);
-        self.w
-    }
-}
+pub type ND1_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND2` reader - New Data 2"]
-pub struct ND2_R(crate::FieldReader<bool, bool>);
-impl ND2_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND2_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND2_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND2_R = crate::BitReader;
 #[doc = "Field `ND2` writer - New Data 2"]
-pub struct ND2_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND2_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 2)) | ((value as u32 & 0x01) << 2);
-        self.w
-    }
-}
+pub type ND2_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND3` reader - New Data 3"]
-pub struct ND3_R(crate::FieldReader<bool, bool>);
-impl ND3_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND3_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND3_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND3_R = crate::BitReader;
 #[doc = "Field `ND3` writer - New Data 3"]
-pub struct ND3_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND3_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 3)) | ((value as u32 & 0x01) << 3);
-        self.w
-    }
-}
+pub type ND3_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND4` reader - New Data 4"]
-pub struct ND4_R(crate::FieldReader<bool, bool>);
-impl ND4_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND4_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND4_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND4_R = crate::BitReader;
 #[doc = "Field `ND4` writer - New Data 4"]
-pub struct ND4_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND4_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 4)) | ((value as u32 & 0x01) << 4);
-        self.w
-    }
-}
+pub type ND4_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND5` reader - New Data 5"]
-pub struct ND5_R(crate::FieldReader<bool, bool>);
-impl ND5_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND5_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND5_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND5_R = crate::BitReader;
 #[doc = "Field `ND5` writer - New Data 5"]
-pub struct ND5_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND5_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 5)) | ((value as u32 & 0x01) << 5);
-        self.w
-    }
-}
+pub type ND5_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND6` reader - New Data 6"]
-pub struct ND6_R(crate::FieldReader<bool, bool>);
-impl ND6_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND6_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND6_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND6_R = crate::BitReader;
 #[doc = "Field `ND6` writer - New Data 6"]
-pub struct ND6_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND6_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 6)) | ((value as u32 & 0x01) << 6);
-        self.w
-    }
-}
+pub type ND6_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND7` reader - New Data 7"]
-pub struct ND7_R(crate::FieldReader<bool, bool>);
-impl ND7_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND7_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND7_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND7_R = crate::BitReader;
 #[doc = "Field `ND7` writer - New Data 7"]
-pub struct ND7_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND7_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 7)) | ((value as u32 & 0x01) << 7);
-        self.w
-    }
-}
+pub type ND7_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND8` reader - New Data 8"]
-pub struct ND8_R(crate::FieldReader<bool, bool>);
-impl ND8_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND8_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND8_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND8_R = crate::BitReader;
 #[doc = "Field `ND8` writer - New Data 8"]
-pub struct ND8_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND8_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 8)) | ((value as u32 & 0x01) << 8);
-        self.w
-    }
-}
+pub type ND8_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND9` reader - New Data 9"]
-pub struct ND9_R(crate::FieldReader<bool, bool>);
-impl ND9_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND9_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND9_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND9_R = crate::BitReader;
 #[doc = "Field `ND9` writer - New Data 9"]
-pub struct ND9_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND9_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 9)) | ((value as u32 & 0x01) << 9);
-        self.w
-    }
-}
+pub type ND9_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND10` reader - New Data 10"]
-pub struct ND10_R(crate::FieldReader<bool, bool>);
-impl ND10_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND10_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND10_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND10_R = crate::BitReader;
 #[doc = "Field `ND10` writer - New Data 10"]
-pub struct ND10_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND10_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 10)) | ((value as u32 & 0x01) << 10);
-        self.w
-    }
-}
+pub type ND10_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND11` reader - New Data 11"]
-pub struct ND11_R(crate::FieldReader<bool, bool>);
-impl ND11_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND11_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND11_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND11_R = crate::BitReader;
 #[doc = "Field `ND11` writer - New Data 11"]
-pub struct ND11_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND11_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 11)) | ((value as u32 & 0x01) << 11);
-        self.w
-    }
-}
+pub type ND11_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND12` reader - New Data 12"]
-pub struct ND12_R(crate::FieldReader<bool, bool>);
-impl ND12_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND12_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND12_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND12_R = crate::BitReader;
 #[doc = "Field `ND12` writer - New Data 12"]
-pub struct ND12_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND12_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 12)) | ((value as u32 & 0x01) << 12);
-        self.w
-    }
-}
+pub type ND12_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND13` reader - New Data 13"]
-pub struct ND13_R(crate::FieldReader<bool, bool>);
-impl ND13_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND13_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND13_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND13_R = crate::BitReader;
 #[doc = "Field `ND13` writer - New Data 13"]
-pub struct ND13_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND13_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 13)) | ((value as u32 & 0x01) << 13);
-        self.w
-    }
-}
+pub type ND13_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND14` reader - New Data 14"]
-pub struct ND14_R(crate::FieldReader<bool, bool>);
-impl ND14_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND14_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND14_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND14_R = crate::BitReader;
 #[doc = "Field `ND14` writer - New Data 14"]
-pub struct ND14_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND14_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 14)) | ((value as u32 & 0x01) << 14);
-        self.w
-    }
-}
+pub type ND14_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND15` reader - New Data 15"]
-pub struct ND15_R(crate::FieldReader<bool, bool>);
-impl ND15_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND15_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND15_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND15_R = crate::BitReader;
 #[doc = "Field `ND15` writer - New Data 15"]
-pub struct ND15_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND15_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 15)) | ((value as u32 & 0x01) << 15);
-        self.w
-    }
-}
+pub type ND15_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND16` reader - New Data 16"]
-pub struct ND16_R(crate::FieldReader<bool, bool>);
-impl ND16_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND16_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND16_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND16_R = crate::BitReader;
 #[doc = "Field `ND16` writer - New Data 16"]
-pub struct ND16_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND16_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 16)) | ((value as u32 & 0x01) << 16);
-        self.w
-    }
-}
+pub type ND16_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND17` reader - New Data 17"]
-pub struct ND17_R(crate::FieldReader<bool, bool>);
-impl ND17_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND17_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND17_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND17_R = crate::BitReader;
 #[doc = "Field `ND17` writer - New Data 17"]
-pub struct ND17_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND17_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 17)) | ((value as u32 & 0x01) << 17);
-        self.w
-    }
-}
+pub type ND17_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND18` reader - New Data 18"]
-pub struct ND18_R(crate::FieldReader<bool, bool>);
-impl ND18_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND18_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND18_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND18_R = crate::BitReader;
 #[doc = "Field `ND18` writer - New Data 18"]
-pub struct ND18_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND18_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 18)) | ((value as u32 & 0x01) << 18);
-        self.w
-    }
-}
+pub type ND18_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND19` reader - New Data 19"]
-pub struct ND19_R(crate::FieldReader<bool, bool>);
-impl ND19_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND19_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND19_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND19_R = crate::BitReader;
 #[doc = "Field `ND19` writer - New Data 19"]
-pub struct ND19_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND19_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 19)) | ((value as u32 & 0x01) << 19);
-        self.w
-    }
-}
+pub type ND19_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND20` reader - New Data 20"]
-pub struct ND20_R(crate::FieldReader<bool, bool>);
-impl ND20_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND20_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND20_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND20_R = crate::BitReader;
 #[doc = "Field `ND20` writer - New Data 20"]
-pub struct ND20_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND20_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 20)) | ((value as u32 & 0x01) << 20);
-        self.w
-    }
-}
+pub type ND20_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND21` reader - New Data 21"]
-pub struct ND21_R(crate::FieldReader<bool, bool>);
-impl ND21_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND21_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND21_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND21_R = crate::BitReader;
 #[doc = "Field `ND21` writer - New Data 21"]
-pub struct ND21_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND21_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 21)) | ((value as u32 & 0x01) << 21);
-        self.w
-    }
-}
+pub type ND21_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND22` reader - New Data 22"]
-pub struct ND22_R(crate::FieldReader<bool, bool>);
-impl ND22_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND22_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND22_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND22_R = crate::BitReader;
 #[doc = "Field `ND22` writer - New Data 22"]
-pub struct ND22_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND22_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 22)) | ((value as u32 & 0x01) << 22);
-        self.w
-    }
-}
+pub type ND22_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND23` reader - New Data 23"]
-pub struct ND23_R(crate::FieldReader<bool, bool>);
-impl ND23_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND23_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND23_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND23_R = crate::BitReader;
 #[doc = "Field `ND23` writer - New Data 23"]
-pub struct ND23_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND23_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 23)) | ((value as u32 & 0x01) << 23);
-        self.w
-    }
-}
+pub type ND23_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND24` reader - New Data 24"]
-pub struct ND24_R(crate::FieldReader<bool, bool>);
-impl ND24_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND24_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND24_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND24_R = crate::BitReader;
 #[doc = "Field `ND24` writer - New Data 24"]
-pub struct ND24_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND24_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 24)) | ((value as u32 & 0x01) << 24);
-        self.w
-    }
-}
+pub type ND24_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND25` reader - New Data 25"]
-pub struct ND25_R(crate::FieldReader<bool, bool>);
-impl ND25_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND25_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND25_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND25_R = crate::BitReader;
 #[doc = "Field `ND25` writer - New Data 25"]
-pub struct ND25_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND25_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 25)) | ((value as u32 & 0x01) << 25);
-        self.w
-    }
-}
+pub type ND25_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND26` reader - New Data 26"]
-pub struct ND26_R(crate::FieldReader<bool, bool>);
-impl ND26_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND26_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND26_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND26_R = crate::BitReader;
 #[doc = "Field `ND26` writer - New Data 26"]
-pub struct ND26_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND26_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 26)) | ((value as u32 & 0x01) << 26);
-        self.w
-    }
-}
+pub type ND26_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND27` reader - New Data 27"]
-pub struct ND27_R(crate::FieldReader<bool, bool>);
-impl ND27_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND27_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND27_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND27_R = crate::BitReader;
 #[doc = "Field `ND27` writer - New Data 27"]
-pub struct ND27_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND27_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 27)) | ((value as u32 & 0x01) << 27);
-        self.w
-    }
-}
+pub type ND27_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND28` reader - New Data 28"]
-pub struct ND28_R(crate::FieldReader<bool, bool>);
-impl ND28_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND28_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND28_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND28_R = crate::BitReader;
 #[doc = "Field `ND28` writer - New Data 28"]
-pub struct ND28_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND28_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 28)) | ((value as u32 & 0x01) << 28);
-        self.w
-    }
-}
+pub type ND28_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND29` reader - New Data 29"]
-pub struct ND29_R(crate::FieldReader<bool, bool>);
-impl ND29_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND29_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND29_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND29_R = crate::BitReader;
 #[doc = "Field `ND29` writer - New Data 29"]
-pub struct ND29_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND29_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 29)) | ((value as u32 & 0x01) << 29);
-        self.w
-    }
-}
+pub type ND29_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND30` reader - New Data 30"]
-pub struct ND30_R(crate::FieldReader<bool, bool>);
-impl ND30_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND30_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND30_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND30_R = crate::BitReader;
 #[doc = "Field `ND30` writer - New Data 30"]
-pub struct ND30_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND30_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 30)) | ((value as u32 & 0x01) << 30);
-        self.w
-    }
-}
+pub type ND30_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND31` reader - New Data 31"]
-pub struct ND31_R(crate::FieldReader<bool, bool>);
-impl ND31_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND31_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND31_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND31_R = crate::BitReader;
 #[doc = "Field `ND31` writer - New Data 31"]
-pub struct ND31_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND31_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 31)) | ((value as u32 & 0x01) << 31);
-        self.w
-    }
-}
+pub type ND31_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
     #[doc = "Bit 0 - New Data 0"]
     #[inline(always)]
     pub fn nd0(&self) -> ND0_R {
-        ND0_R::new((self.bits & 0x01) != 0)
+        ND0_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - New Data 1"]
     #[inline(always)]
     pub fn nd1(&self) -> ND1_R {
-        ND1_R::new(((self.bits >> 1) & 0x01) != 0)
+        ND1_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - New Data 2"]
     #[inline(always)]
     pub fn nd2(&self) -> ND2_R {
-        ND2_R::new(((self.bits >> 2) & 0x01) != 0)
+        ND2_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - New Data 3"]
     #[inline(always)]
     pub fn nd3(&self) -> ND3_R {
-        ND3_R::new(((self.bits >> 3) & 0x01) != 0)
+        ND3_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - New Data 4"]
     #[inline(always)]
     pub fn nd4(&self) -> ND4_R {
-        ND4_R::new(((self.bits >> 4) & 0x01) != 0)
+        ND4_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - New Data 5"]
     #[inline(always)]
     pub fn nd5(&self) -> ND5_R {
-        ND5_R::new(((self.bits >> 5) & 0x01) != 0)
+        ND5_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - New Data 6"]
     #[inline(always)]
     pub fn nd6(&self) -> ND6_R {
-        ND6_R::new(((self.bits >> 6) & 0x01) != 0)
+        ND6_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - New Data 7"]
     #[inline(always)]
     pub fn nd7(&self) -> ND7_R {
-        ND7_R::new(((self.bits >> 7) & 0x01) != 0)
+        ND7_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - New Data 8"]
     #[inline(always)]
     pub fn nd8(&self) -> ND8_R {
-        ND8_R::new(((self.bits >> 8) & 0x01) != 0)
+        ND8_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - New Data 9"]
     #[inline(always)]
     pub fn nd9(&self) -> ND9_R {
-        ND9_R::new(((self.bits >> 9) & 0x01) != 0)
+        ND9_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - New Data 10"]
     #[inline(always)]
     pub fn nd10(&self) -> ND10_R {
-        ND10_R::new(((self.bits >> 10) & 0x01) != 0)
+        ND10_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - New Data 11"]
     #[inline(always)]
     pub fn nd11(&self) -> ND11_R {
-        ND11_R::new(((self.bits >> 11) & 0x01) != 0)
+        ND11_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - New Data 12"]
     #[inline(always)]
     pub fn nd12(&self) -> ND12_R {
-        ND12_R::new(((self.bits >> 12) & 0x01) != 0)
+        ND12_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - New Data 13"]
     #[inline(always)]
     pub fn nd13(&self) -> ND13_R {
-        ND13_R::new(((self.bits >> 13) & 0x01) != 0)
+        ND13_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - New Data 14"]
     #[inline(always)]
     pub fn nd14(&self) -> ND14_R {
-        ND14_R::new(((self.bits >> 14) & 0x01) != 0)
+        ND14_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - New Data 15"]
     #[inline(always)]
     pub fn nd15(&self) -> ND15_R {
-        ND15_R::new(((self.bits >> 15) & 0x01) != 0)
+        ND15_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - New Data 16"]
     #[inline(always)]
     pub fn nd16(&self) -> ND16_R {
-        ND16_R::new(((self.bits >> 16) & 0x01) != 0)
+        ND16_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - New Data 17"]
     #[inline(always)]
     pub fn nd17(&self) -> ND17_R {
-        ND17_R::new(((self.bits >> 17) & 0x01) != 0)
+        ND17_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - New Data 18"]
     #[inline(always)]
     pub fn nd18(&self) -> ND18_R {
-        ND18_R::new(((self.bits >> 18) & 0x01) != 0)
+        ND18_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - New Data 19"]
     #[inline(always)]
     pub fn nd19(&self) -> ND19_R {
-        ND19_R::new(((self.bits >> 19) & 0x01) != 0)
+        ND19_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - New Data 20"]
     #[inline(always)]
     pub fn nd20(&self) -> ND20_R {
-        ND20_R::new(((self.bits >> 20) & 0x01) != 0)
+        ND20_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - New Data 21"]
     #[inline(always)]
     pub fn nd21(&self) -> ND21_R {
-        ND21_R::new(((self.bits >> 21) & 0x01) != 0)
+        ND21_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - New Data 22"]
     #[inline(always)]
     pub fn nd22(&self) -> ND22_R {
-        ND22_R::new(((self.bits >> 22) & 0x01) != 0)
+        ND22_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - New Data 23"]
     #[inline(always)]
     pub fn nd23(&self) -> ND23_R {
-        ND23_R::new(((self.bits >> 23) & 0x01) != 0)
+        ND23_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - New Data 24"]
     #[inline(always)]
     pub fn nd24(&self) -> ND24_R {
-        ND24_R::new(((self.bits >> 24) & 0x01) != 0)
+        ND24_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - New Data 25"]
     #[inline(always)]
     pub fn nd25(&self) -> ND25_R {
-        ND25_R::new(((self.bits >> 25) & 0x01) != 0)
+        ND25_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - New Data 26"]
     #[inline(always)]
     pub fn nd26(&self) -> ND26_R {
-        ND26_R::new(((self.bits >> 26) & 0x01) != 0)
+        ND26_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - New Data 27"]
     #[inline(always)]
     pub fn nd27(&self) -> ND27_R {
-        ND27_R::new(((self.bits >> 27) & 0x01) != 0)
+        ND27_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - New Data 28"]
     #[inline(always)]
     pub fn nd28(&self) -> ND28_R {
-        ND28_R::new(((self.bits >> 28) & 0x01) != 0)
+        ND28_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - New Data 29"]
     #[inline(always)]
     pub fn nd29(&self) -> ND29_R {
-        ND29_R::new(((self.bits >> 29) & 0x01) != 0)
+        ND29_R::new(((self.bits >> 29) & 1) != 0)
     }
     #[doc = "Bit 30 - New Data 30"]
     #[inline(always)]
     pub fn nd30(&self) -> ND30_R {
-        ND30_R::new(((self.bits >> 30) & 0x01) != 0)
+        ND30_R::new(((self.bits >> 30) & 1) != 0)
     }
     #[doc = "Bit 31 - New Data 31"]
     #[inline(always)]
     pub fn nd31(&self) -> ND31_R {
-        ND31_R::new(((self.bits >> 31) & 0x01) != 0)
+        ND31_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - New Data 0"]
     #[inline(always)]
-    pub fn nd0(&mut self) -> ND0_W {
-        ND0_W { w: self }
+    #[must_use]
+    pub fn nd0(&mut self) -> ND0_W<NDAT1_SPEC, 0> {
+        ND0_W::new(self)
     }
     #[doc = "Bit 1 - New Data 1"]
     #[inline(always)]
-    pub fn nd1(&mut self) -> ND1_W {
-        ND1_W { w: self }
+    #[must_use]
+    pub fn nd1(&mut self) -> ND1_W<NDAT1_SPEC, 1> {
+        ND1_W::new(self)
     }
     #[doc = "Bit 2 - New Data 2"]
     #[inline(always)]
-    pub fn nd2(&mut self) -> ND2_W {
-        ND2_W { w: self }
+    #[must_use]
+    pub fn nd2(&mut self) -> ND2_W<NDAT1_SPEC, 2> {
+        ND2_W::new(self)
     }
     #[doc = "Bit 3 - New Data 3"]
     #[inline(always)]
-    pub fn nd3(&mut self) -> ND3_W {
-        ND3_W { w: self }
+    #[must_use]
+    pub fn nd3(&mut self) -> ND3_W<NDAT1_SPEC, 3> {
+        ND3_W::new(self)
     }
     #[doc = "Bit 4 - New Data 4"]
     #[inline(always)]
-    pub fn nd4(&mut self) -> ND4_W {
-        ND4_W { w: self }
+    #[must_use]
+    pub fn nd4(&mut self) -> ND4_W<NDAT1_SPEC, 4> {
+        ND4_W::new(self)
     }
     #[doc = "Bit 5 - New Data 5"]
     #[inline(always)]
-    pub fn nd5(&mut self) -> ND5_W {
-        ND5_W { w: self }
+    #[must_use]
+    pub fn nd5(&mut self) -> ND5_W<NDAT1_SPEC, 5> {
+        ND5_W::new(self)
     }
     #[doc = "Bit 6 - New Data 6"]
     #[inline(always)]
-    pub fn nd6(&mut self) -> ND6_W {
-        ND6_W { w: self }
+    #[must_use]
+    pub fn nd6(&mut self) -> ND6_W<NDAT1_SPEC, 6> {
+        ND6_W::new(self)
     }
     #[doc = "Bit 7 - New Data 7"]
     #[inline(always)]
-    pub fn nd7(&mut self) -> ND7_W {
-        ND7_W { w: self }
+    #[must_use]
+    pub fn nd7(&mut self) -> ND7_W<NDAT1_SPEC, 7> {
+        ND7_W::new(self)
     }
     #[doc = "Bit 8 - New Data 8"]
     #[inline(always)]
-    pub fn nd8(&mut self) -> ND8_W {
-        ND8_W { w: self }
+    #[must_use]
+    pub fn nd8(&mut self) -> ND8_W<NDAT1_SPEC, 8> {
+        ND8_W::new(self)
     }
     #[doc = "Bit 9 - New Data 9"]
     #[inline(always)]
-    pub fn nd9(&mut self) -> ND9_W {
-        ND9_W { w: self }
+    #[must_use]
+    pub fn nd9(&mut self) -> ND9_W<NDAT1_SPEC, 9> {
+        ND9_W::new(self)
     }
     #[doc = "Bit 10 - New Data 10"]
     #[inline(always)]
-    pub fn nd10(&mut self) -> ND10_W {
-        ND10_W { w: self }
+    #[must_use]
+    pub fn nd10(&mut self) -> ND10_W<NDAT1_SPEC, 10> {
+        ND10_W::new(self)
     }
     #[doc = "Bit 11 - New Data 11"]
     #[inline(always)]
-    pub fn nd11(&mut self) -> ND11_W {
-        ND11_W { w: self }
+    #[must_use]
+    pub fn nd11(&mut self) -> ND11_W<NDAT1_SPEC, 11> {
+        ND11_W::new(self)
     }
     #[doc = "Bit 12 - New Data 12"]
     #[inline(always)]
-    pub fn nd12(&mut self) -> ND12_W {
-        ND12_W { w: self }
+    #[must_use]
+    pub fn nd12(&mut self) -> ND12_W<NDAT1_SPEC, 12> {
+        ND12_W::new(self)
     }
     #[doc = "Bit 13 - New Data 13"]
     #[inline(always)]
-    pub fn nd13(&mut self) -> ND13_W {
-        ND13_W { w: self }
+    #[must_use]
+    pub fn nd13(&mut self) -> ND13_W<NDAT1_SPEC, 13> {
+        ND13_W::new(self)
     }
     #[doc = "Bit 14 - New Data 14"]
     #[inline(always)]
-    pub fn nd14(&mut self) -> ND14_W {
-        ND14_W { w: self }
+    #[must_use]
+    pub fn nd14(&mut self) -> ND14_W<NDAT1_SPEC, 14> {
+        ND14_W::new(self)
     }
     #[doc = "Bit 15 - New Data 15"]
     #[inline(always)]
-    pub fn nd15(&mut self) -> ND15_W {
-        ND15_W { w: self }
+    #[must_use]
+    pub fn nd15(&mut self) -> ND15_W<NDAT1_SPEC, 15> {
+        ND15_W::new(self)
     }
     #[doc = "Bit 16 - New Data 16"]
     #[inline(always)]
-    pub fn nd16(&mut self) -> ND16_W {
-        ND16_W { w: self }
+    #[must_use]
+    pub fn nd16(&mut self) -> ND16_W<NDAT1_SPEC, 16> {
+        ND16_W::new(self)
     }
     #[doc = "Bit 17 - New Data 17"]
     #[inline(always)]
-    pub fn nd17(&mut self) -> ND17_W {
-        ND17_W { w: self }
+    #[must_use]
+    pub fn nd17(&mut self) -> ND17_W<NDAT1_SPEC, 17> {
+        ND17_W::new(self)
     }
     #[doc = "Bit 18 - New Data 18"]
     #[inline(always)]
-    pub fn nd18(&mut self) -> ND18_W {
-        ND18_W { w: self }
+    #[must_use]
+    pub fn nd18(&mut self) -> ND18_W<NDAT1_SPEC, 18> {
+        ND18_W::new(self)
     }
     #[doc = "Bit 19 - New Data 19"]
     #[inline(always)]
-    pub fn nd19(&mut self) -> ND19_W {
-        ND19_W { w: self }
+    #[must_use]
+    pub fn nd19(&mut self) -> ND19_W<NDAT1_SPEC, 19> {
+        ND19_W::new(self)
     }
     #[doc = "Bit 20 - New Data 20"]
     #[inline(always)]
-    pub fn nd20(&mut self) -> ND20_W {
-        ND20_W { w: self }
+    #[must_use]
+    pub fn nd20(&mut self) -> ND20_W<NDAT1_SPEC, 20> {
+        ND20_W::new(self)
     }
     #[doc = "Bit 21 - New Data 21"]
     #[inline(always)]
-    pub fn nd21(&mut self) -> ND21_W {
-        ND21_W { w: self }
+    #[must_use]
+    pub fn nd21(&mut self) -> ND21_W<NDAT1_SPEC, 21> {
+        ND21_W::new(self)
     }
     #[doc = "Bit 22 - New Data 22"]
     #[inline(always)]
-    pub fn nd22(&mut self) -> ND22_W {
-        ND22_W { w: self }
+    #[must_use]
+    pub fn nd22(&mut self) -> ND22_W<NDAT1_SPEC, 22> {
+        ND22_W::new(self)
     }
     #[doc = "Bit 23 - New Data 23"]
     #[inline(always)]
-    pub fn nd23(&mut self) -> ND23_W {
-        ND23_W { w: self }
+    #[must_use]
+    pub fn nd23(&mut self) -> ND23_W<NDAT1_SPEC, 23> {
+        ND23_W::new(self)
     }
     #[doc = "Bit 24 - New Data 24"]
     #[inline(always)]
-    pub fn nd24(&mut self) -> ND24_W {
-        ND24_W { w: self }
+    #[must_use]
+    pub fn nd24(&mut self) -> ND24_W<NDAT1_SPEC, 24> {
+        ND24_W::new(self)
     }
     #[doc = "Bit 25 - New Data 25"]
     #[inline(always)]
-    pub fn nd25(&mut self) -> ND25_W {
-        ND25_W { w: self }
+    #[must_use]
+    pub fn nd25(&mut self) -> ND25_W<NDAT1_SPEC, 25> {
+        ND25_W::new(self)
     }
     #[doc = "Bit 26 - New Data 26"]
     #[inline(always)]
-    pub fn nd26(&mut self) -> ND26_W {
-        ND26_W { w: self }
+    #[must_use]
+    pub fn nd26(&mut self) -> ND26_W<NDAT1_SPEC, 26> {
+        ND26_W::new(self)
     }
     #[doc = "Bit 27 - New Data 27"]
     #[inline(always)]
-    pub fn nd27(&mut self) -> ND27_W {
-        ND27_W { w: self }
+    #[must_use]
+    pub fn nd27(&mut self) -> ND27_W<NDAT1_SPEC, 27> {
+        ND27_W::new(self)
     }
     #[doc = "Bit 28 - New Data 28"]
     #[inline(always)]
-    pub fn nd28(&mut self) -> ND28_W {
-        ND28_W { w: self }
+    #[must_use]
+    pub fn nd28(&mut self) -> ND28_W<NDAT1_SPEC, 28> {
+        ND28_W::new(self)
     }
     #[doc = "Bit 29 - New Data 29"]
     #[inline(always)]
-    pub fn nd29(&mut self) -> ND29_W {
-        ND29_W { w: self }
+    #[must_use]
+    pub fn nd29(&mut self) -> ND29_W<NDAT1_SPEC, 29> {
+        ND29_W::new(self)
     }
     #[doc = "Bit 30 - New Data 30"]
     #[inline(always)]
-    pub fn nd30(&mut self) -> ND30_W {
-        ND30_W { w: self }
+    #[must_use]
+    pub fn nd30(&mut self) -> ND30_W<NDAT1_SPEC, 30> {
+        ND30_W::new(self)
     }
     #[doc = "Bit 31 - New Data 31"]
     #[inline(always)]
-    pub fn nd31(&mut self) -> ND31_W {
-        ND31_W { w: self }
+    #[must_use]
+    pub fn nd31(&mut self) -> ND31_W<NDAT1_SPEC, 31> {
+        ND31_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "New Data 1\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ndat1](index.html) module"]
+#[doc = "New Data 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ndat1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ndat1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct NDAT1_SPEC;
 impl crate::RegisterSpec for NDAT1_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [ndat1::R](R) reader structure"]
-impl crate::Readable for NDAT1_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [ndat1::W](W) writer structure"]
+#[doc = "`read()` method returns [`ndat1::R`](R) reader structure"]
+impl crate::Readable for NDAT1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ndat1::W`](W) writer structure"]
 impl crate::Writable for NDAT1_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets NDAT1 to value 0"]
 impl crate::Resettable for NDAT1_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/ndat2.rs
+++ b/mcan/src/reg/ndat2.rs
@@ -1,1570 +1,514 @@
 #[doc = "Register `NDAT2` reader"]
-pub struct R(crate::R<NDAT2_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<NDAT2_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<NDAT2_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<NDAT2_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<NDAT2_SPEC>;
 #[doc = "Register `NDAT2` writer"]
-pub struct W(crate::W<NDAT2_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<NDAT2_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<NDAT2_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<NDAT2_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<NDAT2_SPEC>;
 #[doc = "Field `ND32` reader - New Data 32"]
-pub struct ND32_R(crate::FieldReader<bool, bool>);
-impl ND32_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND32_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND32_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND32_R = crate::BitReader;
 #[doc = "Field `ND32` writer - New Data 32"]
-pub struct ND32_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND32_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x01) | (value as u32 & 0x01);
-        self.w
-    }
-}
+pub type ND32_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND33` reader - New Data 33"]
-pub struct ND33_R(crate::FieldReader<bool, bool>);
-impl ND33_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND33_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND33_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND33_R = crate::BitReader;
 #[doc = "Field `ND33` writer - New Data 33"]
-pub struct ND33_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND33_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 1)) | ((value as u32 & 0x01) << 1);
-        self.w
-    }
-}
+pub type ND33_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND34` reader - New Data 34"]
-pub struct ND34_R(crate::FieldReader<bool, bool>);
-impl ND34_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND34_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND34_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND34_R = crate::BitReader;
 #[doc = "Field `ND34` writer - New Data 34"]
-pub struct ND34_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND34_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 2)) | ((value as u32 & 0x01) << 2);
-        self.w
-    }
-}
+pub type ND34_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND35` reader - New Data 35"]
-pub struct ND35_R(crate::FieldReader<bool, bool>);
-impl ND35_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND35_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND35_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND35_R = crate::BitReader;
 #[doc = "Field `ND35` writer - New Data 35"]
-pub struct ND35_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND35_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 3)) | ((value as u32 & 0x01) << 3);
-        self.w
-    }
-}
+pub type ND35_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND36` reader - New Data 36"]
-pub struct ND36_R(crate::FieldReader<bool, bool>);
-impl ND36_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND36_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND36_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND36_R = crate::BitReader;
 #[doc = "Field `ND36` writer - New Data 36"]
-pub struct ND36_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND36_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 4)) | ((value as u32 & 0x01) << 4);
-        self.w
-    }
-}
+pub type ND36_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND37` reader - New Data 37"]
-pub struct ND37_R(crate::FieldReader<bool, bool>);
-impl ND37_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND37_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND37_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND37_R = crate::BitReader;
 #[doc = "Field `ND37` writer - New Data 37"]
-pub struct ND37_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND37_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 5)) | ((value as u32 & 0x01) << 5);
-        self.w
-    }
-}
+pub type ND37_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND38` reader - New Data 38"]
-pub struct ND38_R(crate::FieldReader<bool, bool>);
-impl ND38_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND38_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND38_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND38_R = crate::BitReader;
 #[doc = "Field `ND38` writer - New Data 38"]
-pub struct ND38_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND38_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 6)) | ((value as u32 & 0x01) << 6);
-        self.w
-    }
-}
+pub type ND38_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND39` reader - New Data 39"]
-pub struct ND39_R(crate::FieldReader<bool, bool>);
-impl ND39_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND39_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND39_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND39_R = crate::BitReader;
 #[doc = "Field `ND39` writer - New Data 39"]
-pub struct ND39_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND39_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 7)) | ((value as u32 & 0x01) << 7);
-        self.w
-    }
-}
+pub type ND39_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND40` reader - New Data 40"]
-pub struct ND40_R(crate::FieldReader<bool, bool>);
-impl ND40_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND40_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND40_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND40_R = crate::BitReader;
 #[doc = "Field `ND40` writer - New Data 40"]
-pub struct ND40_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND40_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 8)) | ((value as u32 & 0x01) << 8);
-        self.w
-    }
-}
+pub type ND40_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND41` reader - New Data 41"]
-pub struct ND41_R(crate::FieldReader<bool, bool>);
-impl ND41_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND41_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND41_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND41_R = crate::BitReader;
 #[doc = "Field `ND41` writer - New Data 41"]
-pub struct ND41_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND41_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 9)) | ((value as u32 & 0x01) << 9);
-        self.w
-    }
-}
+pub type ND41_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND42` reader - New Data 42"]
-pub struct ND42_R(crate::FieldReader<bool, bool>);
-impl ND42_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND42_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND42_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND42_R = crate::BitReader;
 #[doc = "Field `ND42` writer - New Data 42"]
-pub struct ND42_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND42_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 10)) | ((value as u32 & 0x01) << 10);
-        self.w
-    }
-}
+pub type ND42_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND43` reader - New Data 43"]
-pub struct ND43_R(crate::FieldReader<bool, bool>);
-impl ND43_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND43_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND43_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND43_R = crate::BitReader;
 #[doc = "Field `ND43` writer - New Data 43"]
-pub struct ND43_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND43_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 11)) | ((value as u32 & 0x01) << 11);
-        self.w
-    }
-}
+pub type ND43_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND44` reader - New Data 44"]
-pub struct ND44_R(crate::FieldReader<bool, bool>);
-impl ND44_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND44_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND44_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND44_R = crate::BitReader;
 #[doc = "Field `ND44` writer - New Data 44"]
-pub struct ND44_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND44_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 12)) | ((value as u32 & 0x01) << 12);
-        self.w
-    }
-}
+pub type ND44_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND45` reader - New Data 45"]
-pub struct ND45_R(crate::FieldReader<bool, bool>);
-impl ND45_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND45_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND45_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND45_R = crate::BitReader;
 #[doc = "Field `ND45` writer - New Data 45"]
-pub struct ND45_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND45_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 13)) | ((value as u32 & 0x01) << 13);
-        self.w
-    }
-}
+pub type ND45_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND46` reader - New Data 46"]
-pub struct ND46_R(crate::FieldReader<bool, bool>);
-impl ND46_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND46_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND46_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND46_R = crate::BitReader;
 #[doc = "Field `ND46` writer - New Data 46"]
-pub struct ND46_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND46_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 14)) | ((value as u32 & 0x01) << 14);
-        self.w
-    }
-}
+pub type ND46_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND47` reader - New Data 47"]
-pub struct ND47_R(crate::FieldReader<bool, bool>);
-impl ND47_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND47_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND47_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND47_R = crate::BitReader;
 #[doc = "Field `ND47` writer - New Data 47"]
-pub struct ND47_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND47_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 15)) | ((value as u32 & 0x01) << 15);
-        self.w
-    }
-}
+pub type ND47_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND48` reader - New Data 48"]
-pub struct ND48_R(crate::FieldReader<bool, bool>);
-impl ND48_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND48_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND48_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND48_R = crate::BitReader;
 #[doc = "Field `ND48` writer - New Data 48"]
-pub struct ND48_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND48_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 16)) | ((value as u32 & 0x01) << 16);
-        self.w
-    }
-}
+pub type ND48_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND49` reader - New Data 49"]
-pub struct ND49_R(crate::FieldReader<bool, bool>);
-impl ND49_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND49_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND49_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND49_R = crate::BitReader;
 #[doc = "Field `ND49` writer - New Data 49"]
-pub struct ND49_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND49_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 17)) | ((value as u32 & 0x01) << 17);
-        self.w
-    }
-}
+pub type ND49_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND50` reader - New Data 50"]
-pub struct ND50_R(crate::FieldReader<bool, bool>);
-impl ND50_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND50_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND50_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND50_R = crate::BitReader;
 #[doc = "Field `ND50` writer - New Data 50"]
-pub struct ND50_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND50_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 18)) | ((value as u32 & 0x01) << 18);
-        self.w
-    }
-}
+pub type ND50_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND51` reader - New Data 51"]
-pub struct ND51_R(crate::FieldReader<bool, bool>);
-impl ND51_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND51_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND51_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND51_R = crate::BitReader;
 #[doc = "Field `ND51` writer - New Data 51"]
-pub struct ND51_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND51_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 19)) | ((value as u32 & 0x01) << 19);
-        self.w
-    }
-}
+pub type ND51_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND52` reader - New Data 52"]
-pub struct ND52_R(crate::FieldReader<bool, bool>);
-impl ND52_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND52_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND52_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND52_R = crate::BitReader;
 #[doc = "Field `ND52` writer - New Data 52"]
-pub struct ND52_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND52_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 20)) | ((value as u32 & 0x01) << 20);
-        self.w
-    }
-}
+pub type ND52_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND53` reader - New Data 53"]
-pub struct ND53_R(crate::FieldReader<bool, bool>);
-impl ND53_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND53_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND53_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND53_R = crate::BitReader;
 #[doc = "Field `ND53` writer - New Data 53"]
-pub struct ND53_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND53_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 21)) | ((value as u32 & 0x01) << 21);
-        self.w
-    }
-}
+pub type ND53_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND54` reader - New Data 54"]
-pub struct ND54_R(crate::FieldReader<bool, bool>);
-impl ND54_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND54_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND54_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND54_R = crate::BitReader;
 #[doc = "Field `ND54` writer - New Data 54"]
-pub struct ND54_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND54_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 22)) | ((value as u32 & 0x01) << 22);
-        self.w
-    }
-}
+pub type ND54_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND55` reader - New Data 55"]
-pub struct ND55_R(crate::FieldReader<bool, bool>);
-impl ND55_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND55_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND55_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND55_R = crate::BitReader;
 #[doc = "Field `ND55` writer - New Data 55"]
-pub struct ND55_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND55_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 23)) | ((value as u32 & 0x01) << 23);
-        self.w
-    }
-}
+pub type ND55_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND56` reader - New Data 56"]
-pub struct ND56_R(crate::FieldReader<bool, bool>);
-impl ND56_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND56_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND56_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND56_R = crate::BitReader;
 #[doc = "Field `ND56` writer - New Data 56"]
-pub struct ND56_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND56_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 24)) | ((value as u32 & 0x01) << 24);
-        self.w
-    }
-}
+pub type ND56_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND57` reader - New Data 57"]
-pub struct ND57_R(crate::FieldReader<bool, bool>);
-impl ND57_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND57_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND57_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND57_R = crate::BitReader;
 #[doc = "Field `ND57` writer - New Data 57"]
-pub struct ND57_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND57_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 25)) | ((value as u32 & 0x01) << 25);
-        self.w
-    }
-}
+pub type ND57_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND58` reader - New Data 58"]
-pub struct ND58_R(crate::FieldReader<bool, bool>);
-impl ND58_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND58_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND58_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND58_R = crate::BitReader;
 #[doc = "Field `ND58` writer - New Data 58"]
-pub struct ND58_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND58_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 26)) | ((value as u32 & 0x01) << 26);
-        self.w
-    }
-}
+pub type ND58_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND59` reader - New Data 59"]
-pub struct ND59_R(crate::FieldReader<bool, bool>);
-impl ND59_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND59_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND59_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND59_R = crate::BitReader;
 #[doc = "Field `ND59` writer - New Data 59"]
-pub struct ND59_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND59_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 27)) | ((value as u32 & 0x01) << 27);
-        self.w
-    }
-}
+pub type ND59_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND60` reader - New Data 60"]
-pub struct ND60_R(crate::FieldReader<bool, bool>);
-impl ND60_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND60_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND60_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND60_R = crate::BitReader;
 #[doc = "Field `ND60` writer - New Data 60"]
-pub struct ND60_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND60_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 28)) | ((value as u32 & 0x01) << 28);
-        self.w
-    }
-}
+pub type ND60_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND61` reader - New Data 61"]
-pub struct ND61_R(crate::FieldReader<bool, bool>);
-impl ND61_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND61_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND61_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND61_R = crate::BitReader;
 #[doc = "Field `ND61` writer - New Data 61"]
-pub struct ND61_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND61_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 29)) | ((value as u32 & 0x01) << 29);
-        self.w
-    }
-}
+pub type ND61_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND62` reader - New Data 62"]
-pub struct ND62_R(crate::FieldReader<bool, bool>);
-impl ND62_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND62_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND62_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND62_R = crate::BitReader;
 #[doc = "Field `ND62` writer - New Data 62"]
-pub struct ND62_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND62_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 30)) | ((value as u32 & 0x01) << 30);
-        self.w
-    }
-}
+pub type ND62_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `ND63` reader - New Data 63"]
-pub struct ND63_R(crate::FieldReader<bool, bool>);
-impl ND63_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ND63_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ND63_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ND63_R = crate::BitReader;
 #[doc = "Field `ND63` writer - New Data 63"]
-pub struct ND63_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ND63_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 31)) | ((value as u32 & 0x01) << 31);
-        self.w
-    }
-}
+pub type ND63_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
     #[doc = "Bit 0 - New Data 32"]
     #[inline(always)]
     pub fn nd32(&self) -> ND32_R {
-        ND32_R::new((self.bits & 0x01) != 0)
+        ND32_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - New Data 33"]
     #[inline(always)]
     pub fn nd33(&self) -> ND33_R {
-        ND33_R::new(((self.bits >> 1) & 0x01) != 0)
+        ND33_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - New Data 34"]
     #[inline(always)]
     pub fn nd34(&self) -> ND34_R {
-        ND34_R::new(((self.bits >> 2) & 0x01) != 0)
+        ND34_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - New Data 35"]
     #[inline(always)]
     pub fn nd35(&self) -> ND35_R {
-        ND35_R::new(((self.bits >> 3) & 0x01) != 0)
+        ND35_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - New Data 36"]
     #[inline(always)]
     pub fn nd36(&self) -> ND36_R {
-        ND36_R::new(((self.bits >> 4) & 0x01) != 0)
+        ND36_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - New Data 37"]
     #[inline(always)]
     pub fn nd37(&self) -> ND37_R {
-        ND37_R::new(((self.bits >> 5) & 0x01) != 0)
+        ND37_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - New Data 38"]
     #[inline(always)]
     pub fn nd38(&self) -> ND38_R {
-        ND38_R::new(((self.bits >> 6) & 0x01) != 0)
+        ND38_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - New Data 39"]
     #[inline(always)]
     pub fn nd39(&self) -> ND39_R {
-        ND39_R::new(((self.bits >> 7) & 0x01) != 0)
+        ND39_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - New Data 40"]
     #[inline(always)]
     pub fn nd40(&self) -> ND40_R {
-        ND40_R::new(((self.bits >> 8) & 0x01) != 0)
+        ND40_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - New Data 41"]
     #[inline(always)]
     pub fn nd41(&self) -> ND41_R {
-        ND41_R::new(((self.bits >> 9) & 0x01) != 0)
+        ND41_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - New Data 42"]
     #[inline(always)]
     pub fn nd42(&self) -> ND42_R {
-        ND42_R::new(((self.bits >> 10) & 0x01) != 0)
+        ND42_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - New Data 43"]
     #[inline(always)]
     pub fn nd43(&self) -> ND43_R {
-        ND43_R::new(((self.bits >> 11) & 0x01) != 0)
+        ND43_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - New Data 44"]
     #[inline(always)]
     pub fn nd44(&self) -> ND44_R {
-        ND44_R::new(((self.bits >> 12) & 0x01) != 0)
+        ND44_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - New Data 45"]
     #[inline(always)]
     pub fn nd45(&self) -> ND45_R {
-        ND45_R::new(((self.bits >> 13) & 0x01) != 0)
+        ND45_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - New Data 46"]
     #[inline(always)]
     pub fn nd46(&self) -> ND46_R {
-        ND46_R::new(((self.bits >> 14) & 0x01) != 0)
+        ND46_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - New Data 47"]
     #[inline(always)]
     pub fn nd47(&self) -> ND47_R {
-        ND47_R::new(((self.bits >> 15) & 0x01) != 0)
+        ND47_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - New Data 48"]
     #[inline(always)]
     pub fn nd48(&self) -> ND48_R {
-        ND48_R::new(((self.bits >> 16) & 0x01) != 0)
+        ND48_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - New Data 49"]
     #[inline(always)]
     pub fn nd49(&self) -> ND49_R {
-        ND49_R::new(((self.bits >> 17) & 0x01) != 0)
+        ND49_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - New Data 50"]
     #[inline(always)]
     pub fn nd50(&self) -> ND50_R {
-        ND50_R::new(((self.bits >> 18) & 0x01) != 0)
+        ND50_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - New Data 51"]
     #[inline(always)]
     pub fn nd51(&self) -> ND51_R {
-        ND51_R::new(((self.bits >> 19) & 0x01) != 0)
+        ND51_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - New Data 52"]
     #[inline(always)]
     pub fn nd52(&self) -> ND52_R {
-        ND52_R::new(((self.bits >> 20) & 0x01) != 0)
+        ND52_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - New Data 53"]
     #[inline(always)]
     pub fn nd53(&self) -> ND53_R {
-        ND53_R::new(((self.bits >> 21) & 0x01) != 0)
+        ND53_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - New Data 54"]
     #[inline(always)]
     pub fn nd54(&self) -> ND54_R {
-        ND54_R::new(((self.bits >> 22) & 0x01) != 0)
+        ND54_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - New Data 55"]
     #[inline(always)]
     pub fn nd55(&self) -> ND55_R {
-        ND55_R::new(((self.bits >> 23) & 0x01) != 0)
+        ND55_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - New Data 56"]
     #[inline(always)]
     pub fn nd56(&self) -> ND56_R {
-        ND56_R::new(((self.bits >> 24) & 0x01) != 0)
+        ND56_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - New Data 57"]
     #[inline(always)]
     pub fn nd57(&self) -> ND57_R {
-        ND57_R::new(((self.bits >> 25) & 0x01) != 0)
+        ND57_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - New Data 58"]
     #[inline(always)]
     pub fn nd58(&self) -> ND58_R {
-        ND58_R::new(((self.bits >> 26) & 0x01) != 0)
+        ND58_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - New Data 59"]
     #[inline(always)]
     pub fn nd59(&self) -> ND59_R {
-        ND59_R::new(((self.bits >> 27) & 0x01) != 0)
+        ND59_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - New Data 60"]
     #[inline(always)]
     pub fn nd60(&self) -> ND60_R {
-        ND60_R::new(((self.bits >> 28) & 0x01) != 0)
+        ND60_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - New Data 61"]
     #[inline(always)]
     pub fn nd61(&self) -> ND61_R {
-        ND61_R::new(((self.bits >> 29) & 0x01) != 0)
+        ND61_R::new(((self.bits >> 29) & 1) != 0)
     }
     #[doc = "Bit 30 - New Data 62"]
     #[inline(always)]
     pub fn nd62(&self) -> ND62_R {
-        ND62_R::new(((self.bits >> 30) & 0x01) != 0)
+        ND62_R::new(((self.bits >> 30) & 1) != 0)
     }
     #[doc = "Bit 31 - New Data 63"]
     #[inline(always)]
     pub fn nd63(&self) -> ND63_R {
-        ND63_R::new(((self.bits >> 31) & 0x01) != 0)
+        ND63_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - New Data 32"]
     #[inline(always)]
-    pub fn nd32(&mut self) -> ND32_W {
-        ND32_W { w: self }
+    #[must_use]
+    pub fn nd32(&mut self) -> ND32_W<NDAT2_SPEC, 0> {
+        ND32_W::new(self)
     }
     #[doc = "Bit 1 - New Data 33"]
     #[inline(always)]
-    pub fn nd33(&mut self) -> ND33_W {
-        ND33_W { w: self }
+    #[must_use]
+    pub fn nd33(&mut self) -> ND33_W<NDAT2_SPEC, 1> {
+        ND33_W::new(self)
     }
     #[doc = "Bit 2 - New Data 34"]
     #[inline(always)]
-    pub fn nd34(&mut self) -> ND34_W {
-        ND34_W { w: self }
+    #[must_use]
+    pub fn nd34(&mut self) -> ND34_W<NDAT2_SPEC, 2> {
+        ND34_W::new(self)
     }
     #[doc = "Bit 3 - New Data 35"]
     #[inline(always)]
-    pub fn nd35(&mut self) -> ND35_W {
-        ND35_W { w: self }
+    #[must_use]
+    pub fn nd35(&mut self) -> ND35_W<NDAT2_SPEC, 3> {
+        ND35_W::new(self)
     }
     #[doc = "Bit 4 - New Data 36"]
     #[inline(always)]
-    pub fn nd36(&mut self) -> ND36_W {
-        ND36_W { w: self }
+    #[must_use]
+    pub fn nd36(&mut self) -> ND36_W<NDAT2_SPEC, 4> {
+        ND36_W::new(self)
     }
     #[doc = "Bit 5 - New Data 37"]
     #[inline(always)]
-    pub fn nd37(&mut self) -> ND37_W {
-        ND37_W { w: self }
+    #[must_use]
+    pub fn nd37(&mut self) -> ND37_W<NDAT2_SPEC, 5> {
+        ND37_W::new(self)
     }
     #[doc = "Bit 6 - New Data 38"]
     #[inline(always)]
-    pub fn nd38(&mut self) -> ND38_W {
-        ND38_W { w: self }
+    #[must_use]
+    pub fn nd38(&mut self) -> ND38_W<NDAT2_SPEC, 6> {
+        ND38_W::new(self)
     }
     #[doc = "Bit 7 - New Data 39"]
     #[inline(always)]
-    pub fn nd39(&mut self) -> ND39_W {
-        ND39_W { w: self }
+    #[must_use]
+    pub fn nd39(&mut self) -> ND39_W<NDAT2_SPEC, 7> {
+        ND39_W::new(self)
     }
     #[doc = "Bit 8 - New Data 40"]
     #[inline(always)]
-    pub fn nd40(&mut self) -> ND40_W {
-        ND40_W { w: self }
+    #[must_use]
+    pub fn nd40(&mut self) -> ND40_W<NDAT2_SPEC, 8> {
+        ND40_W::new(self)
     }
     #[doc = "Bit 9 - New Data 41"]
     #[inline(always)]
-    pub fn nd41(&mut self) -> ND41_W {
-        ND41_W { w: self }
+    #[must_use]
+    pub fn nd41(&mut self) -> ND41_W<NDAT2_SPEC, 9> {
+        ND41_W::new(self)
     }
     #[doc = "Bit 10 - New Data 42"]
     #[inline(always)]
-    pub fn nd42(&mut self) -> ND42_W {
-        ND42_W { w: self }
+    #[must_use]
+    pub fn nd42(&mut self) -> ND42_W<NDAT2_SPEC, 10> {
+        ND42_W::new(self)
     }
     #[doc = "Bit 11 - New Data 43"]
     #[inline(always)]
-    pub fn nd43(&mut self) -> ND43_W {
-        ND43_W { w: self }
+    #[must_use]
+    pub fn nd43(&mut self) -> ND43_W<NDAT2_SPEC, 11> {
+        ND43_W::new(self)
     }
     #[doc = "Bit 12 - New Data 44"]
     #[inline(always)]
-    pub fn nd44(&mut self) -> ND44_W {
-        ND44_W { w: self }
+    #[must_use]
+    pub fn nd44(&mut self) -> ND44_W<NDAT2_SPEC, 12> {
+        ND44_W::new(self)
     }
     #[doc = "Bit 13 - New Data 45"]
     #[inline(always)]
-    pub fn nd45(&mut self) -> ND45_W {
-        ND45_W { w: self }
+    #[must_use]
+    pub fn nd45(&mut self) -> ND45_W<NDAT2_SPEC, 13> {
+        ND45_W::new(self)
     }
     #[doc = "Bit 14 - New Data 46"]
     #[inline(always)]
-    pub fn nd46(&mut self) -> ND46_W {
-        ND46_W { w: self }
+    #[must_use]
+    pub fn nd46(&mut self) -> ND46_W<NDAT2_SPEC, 14> {
+        ND46_W::new(self)
     }
     #[doc = "Bit 15 - New Data 47"]
     #[inline(always)]
-    pub fn nd47(&mut self) -> ND47_W {
-        ND47_W { w: self }
+    #[must_use]
+    pub fn nd47(&mut self) -> ND47_W<NDAT2_SPEC, 15> {
+        ND47_W::new(self)
     }
     #[doc = "Bit 16 - New Data 48"]
     #[inline(always)]
-    pub fn nd48(&mut self) -> ND48_W {
-        ND48_W { w: self }
+    #[must_use]
+    pub fn nd48(&mut self) -> ND48_W<NDAT2_SPEC, 16> {
+        ND48_W::new(self)
     }
     #[doc = "Bit 17 - New Data 49"]
     #[inline(always)]
-    pub fn nd49(&mut self) -> ND49_W {
-        ND49_W { w: self }
+    #[must_use]
+    pub fn nd49(&mut self) -> ND49_W<NDAT2_SPEC, 17> {
+        ND49_W::new(self)
     }
     #[doc = "Bit 18 - New Data 50"]
     #[inline(always)]
-    pub fn nd50(&mut self) -> ND50_W {
-        ND50_W { w: self }
+    #[must_use]
+    pub fn nd50(&mut self) -> ND50_W<NDAT2_SPEC, 18> {
+        ND50_W::new(self)
     }
     #[doc = "Bit 19 - New Data 51"]
     #[inline(always)]
-    pub fn nd51(&mut self) -> ND51_W {
-        ND51_W { w: self }
+    #[must_use]
+    pub fn nd51(&mut self) -> ND51_W<NDAT2_SPEC, 19> {
+        ND51_W::new(self)
     }
     #[doc = "Bit 20 - New Data 52"]
     #[inline(always)]
-    pub fn nd52(&mut self) -> ND52_W {
-        ND52_W { w: self }
+    #[must_use]
+    pub fn nd52(&mut self) -> ND52_W<NDAT2_SPEC, 20> {
+        ND52_W::new(self)
     }
     #[doc = "Bit 21 - New Data 53"]
     #[inline(always)]
-    pub fn nd53(&mut self) -> ND53_W {
-        ND53_W { w: self }
+    #[must_use]
+    pub fn nd53(&mut self) -> ND53_W<NDAT2_SPEC, 21> {
+        ND53_W::new(self)
     }
     #[doc = "Bit 22 - New Data 54"]
     #[inline(always)]
-    pub fn nd54(&mut self) -> ND54_W {
-        ND54_W { w: self }
+    #[must_use]
+    pub fn nd54(&mut self) -> ND54_W<NDAT2_SPEC, 22> {
+        ND54_W::new(self)
     }
     #[doc = "Bit 23 - New Data 55"]
     #[inline(always)]
-    pub fn nd55(&mut self) -> ND55_W {
-        ND55_W { w: self }
+    #[must_use]
+    pub fn nd55(&mut self) -> ND55_W<NDAT2_SPEC, 23> {
+        ND55_W::new(self)
     }
     #[doc = "Bit 24 - New Data 56"]
     #[inline(always)]
-    pub fn nd56(&mut self) -> ND56_W {
-        ND56_W { w: self }
+    #[must_use]
+    pub fn nd56(&mut self) -> ND56_W<NDAT2_SPEC, 24> {
+        ND56_W::new(self)
     }
     #[doc = "Bit 25 - New Data 57"]
     #[inline(always)]
-    pub fn nd57(&mut self) -> ND57_W {
-        ND57_W { w: self }
+    #[must_use]
+    pub fn nd57(&mut self) -> ND57_W<NDAT2_SPEC, 25> {
+        ND57_W::new(self)
     }
     #[doc = "Bit 26 - New Data 58"]
     #[inline(always)]
-    pub fn nd58(&mut self) -> ND58_W {
-        ND58_W { w: self }
+    #[must_use]
+    pub fn nd58(&mut self) -> ND58_W<NDAT2_SPEC, 26> {
+        ND58_W::new(self)
     }
     #[doc = "Bit 27 - New Data 59"]
     #[inline(always)]
-    pub fn nd59(&mut self) -> ND59_W {
-        ND59_W { w: self }
+    #[must_use]
+    pub fn nd59(&mut self) -> ND59_W<NDAT2_SPEC, 27> {
+        ND59_W::new(self)
     }
     #[doc = "Bit 28 - New Data 60"]
     #[inline(always)]
-    pub fn nd60(&mut self) -> ND60_W {
-        ND60_W { w: self }
+    #[must_use]
+    pub fn nd60(&mut self) -> ND60_W<NDAT2_SPEC, 28> {
+        ND60_W::new(self)
     }
     #[doc = "Bit 29 - New Data 61"]
     #[inline(always)]
-    pub fn nd61(&mut self) -> ND61_W {
-        ND61_W { w: self }
+    #[must_use]
+    pub fn nd61(&mut self) -> ND61_W<NDAT2_SPEC, 29> {
+        ND61_W::new(self)
     }
     #[doc = "Bit 30 - New Data 62"]
     #[inline(always)]
-    pub fn nd62(&mut self) -> ND62_W {
-        ND62_W { w: self }
+    #[must_use]
+    pub fn nd62(&mut self) -> ND62_W<NDAT2_SPEC, 30> {
+        ND62_W::new(self)
     }
     #[doc = "Bit 31 - New Data 63"]
     #[inline(always)]
-    pub fn nd63(&mut self) -> ND63_W {
-        ND63_W { w: self }
+    #[must_use]
+    pub fn nd63(&mut self) -> ND63_W<NDAT2_SPEC, 31> {
+        ND63_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "New Data 2\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ndat2](index.html) module"]
+#[doc = "New Data 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ndat2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ndat2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct NDAT2_SPEC;
 impl crate::RegisterSpec for NDAT2_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [ndat2::R](R) reader structure"]
-impl crate::Readable for NDAT2_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [ndat2::W](W) writer structure"]
+#[doc = "`read()` method returns [`ndat2::R`](R) reader structure"]
+impl crate::Readable for NDAT2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ndat2::W`](W) writer structure"]
 impl crate::Writable for NDAT2_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets NDAT2 to value 0"]
 impl crate::Resettable for NDAT2_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/ndat2.rs
+++ b/mcan/src/reg/ndat2.rs
@@ -496,7 +496,7 @@ impl W {
         self
     }
 }
-#[doc = "New Data 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ndat2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ndat2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "New Data 2\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`ndat2::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`ndat2::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct NDAT2_SPEC;
 impl crate::RegisterSpec for NDAT2_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/psr.rs
+++ b/mcan/src/reg/psr.rs
@@ -1,22 +1,11 @@
 #[doc = "Register `PSR` reader"]
-pub struct R(crate::R<PSR_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<PSR_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<PSR_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<PSR_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<PSR_SPEC>;
+#[doc = "Field `LEC` reader - Last Error Code"]
+pub type LEC_R = crate::FieldReader<LECSELECT_A>;
 #[doc = "Last Error Code\n\nValue on reset: 7"]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
-pub enum LEC_A {
+pub enum LECSELECT_A {
     #[doc = "0: No Error"]
     NONE = 0,
     #[doc = "1: Stuff Error"]
@@ -34,86 +23,78 @@ pub enum LEC_A {
     #[doc = "7: No Change"]
     NC = 7,
 }
-impl From<LEC_A> for u8 {
+impl From<LECSELECT_A> for u8 {
     #[inline(always)]
-    fn from(variant: LEC_A) -> Self {
+    fn from(variant: LECSELECT_A) -> Self {
         variant as _
     }
 }
-#[doc = "Field `LEC` reader - Last Error Code"]
-pub struct LEC_R(crate::FieldReader<u8, LEC_A>);
+impl crate::FieldSpec for LECSELECT_A {
+    type Ux = u8;
+}
 impl LEC_R {
+    #[doc = "Get enumerated values variant"]
     #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        LEC_R(crate::FieldReader::new(bits))
-    }
-    #[doc = r"Get enumerated values variant"]
-    #[inline(always)]
-    pub fn variant(&self) -> LEC_A {
+    pub const fn variant(&self) -> LECSELECT_A {
         match self.bits {
-            0 => LEC_A::NONE,
-            1 => LEC_A::STUFF,
-            2 => LEC_A::FORM,
-            3 => LEC_A::ACK,
-            4 => LEC_A::BIT1,
-            5 => LEC_A::BIT0,
-            6 => LEC_A::CRC,
-            7 => LEC_A::NC,
+            0 => LECSELECT_A::NONE,
+            1 => LECSELECT_A::STUFF,
+            2 => LECSELECT_A::FORM,
+            3 => LECSELECT_A::ACK,
+            4 => LECSELECT_A::BIT1,
+            5 => LECSELECT_A::BIT0,
+            6 => LECSELECT_A::CRC,
+            7 => LECSELECT_A::NC,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `NONE`"]
+    #[doc = "No Error"]
     #[inline(always)]
     pub fn is_none(&self) -> bool {
-        **self == LEC_A::NONE
+        *self == LECSELECT_A::NONE
     }
-    #[doc = "Checks if the value of the field is `STUFF`"]
+    #[doc = "Stuff Error"]
     #[inline(always)]
     pub fn is_stuff(&self) -> bool {
-        **self == LEC_A::STUFF
+        *self == LECSELECT_A::STUFF
     }
-    #[doc = "Checks if the value of the field is `FORM`"]
+    #[doc = "Form Error"]
     #[inline(always)]
     pub fn is_form(&self) -> bool {
-        **self == LEC_A::FORM
+        *self == LECSELECT_A::FORM
     }
-    #[doc = "Checks if the value of the field is `ACK`"]
+    #[doc = "Ack Error"]
     #[inline(always)]
     pub fn is_ack(&self) -> bool {
-        **self == LEC_A::ACK
+        *self == LECSELECT_A::ACK
     }
-    #[doc = "Checks if the value of the field is `BIT1`"]
+    #[doc = "Bit1 Error"]
     #[inline(always)]
     pub fn is_bit1(&self) -> bool {
-        **self == LEC_A::BIT1
+        *self == LECSELECT_A::BIT1
     }
-    #[doc = "Checks if the value of the field is `BIT0`"]
+    #[doc = "Bit0 Error"]
     #[inline(always)]
     pub fn is_bit0(&self) -> bool {
-        **self == LEC_A::BIT0
+        *self == LECSELECT_A::BIT0
     }
-    #[doc = "Checks if the value of the field is `CRC`"]
+    #[doc = "CRC Error"]
     #[inline(always)]
     pub fn is_crc(&self) -> bool {
-        **self == LEC_A::CRC
+        *self == LECSELECT_A::CRC
     }
-    #[doc = "Checks if the value of the field is `NC`"]
+    #[doc = "No Change"]
     #[inline(always)]
     pub fn is_nc(&self) -> bool {
-        **self == LEC_A::NC
+        *self == LECSELECT_A::NC
     }
 }
-impl core::ops::Deref for LEC_R {
-    type Target = crate::FieldReader<u8, LEC_A>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+#[doc = "Field `ACT` reader - Activity"]
+pub type ACT_R = crate::FieldReader<ACTSELECT_A>;
 #[doc = "Activity\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
-pub enum ACT_A {
+pub enum ACTSELECT_A {
     #[doc = "0: Node is synchronizing on CAN communication"]
     SYNC = 0,
     #[doc = "1: Node is neither receiver nor transmitter"]
@@ -123,107 +104,60 @@ pub enum ACT_A {
     #[doc = "3: Node is operating as transmitter"]
     TX = 3,
 }
-impl From<ACT_A> for u8 {
+impl From<ACTSELECT_A> for u8 {
     #[inline(always)]
-    fn from(variant: ACT_A) -> Self {
+    fn from(variant: ACTSELECT_A) -> Self {
         variant as _
     }
 }
-#[doc = "Field `ACT` reader - Activity"]
-pub struct ACT_R(crate::FieldReader<u8, ACT_A>);
+impl crate::FieldSpec for ACTSELECT_A {
+    type Ux = u8;
+}
 impl ACT_R {
+    #[doc = "Get enumerated values variant"]
     #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        ACT_R(crate::FieldReader::new(bits))
-    }
-    #[doc = r"Get enumerated values variant"]
-    #[inline(always)]
-    pub fn variant(&self) -> ACT_A {
+    pub const fn variant(&self) -> ACTSELECT_A {
         match self.bits {
-            0 => ACT_A::SYNC,
-            1 => ACT_A::IDLE,
-            2 => ACT_A::RX,
-            3 => ACT_A::TX,
+            0 => ACTSELECT_A::SYNC,
+            1 => ACTSELECT_A::IDLE,
+            2 => ACTSELECT_A::RX,
+            3 => ACTSELECT_A::TX,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `SYNC`"]
+    #[doc = "Node is synchronizing on CAN communication"]
     #[inline(always)]
     pub fn is_sync(&self) -> bool {
-        **self == ACT_A::SYNC
+        *self == ACTSELECT_A::SYNC
     }
-    #[doc = "Checks if the value of the field is `IDLE`"]
+    #[doc = "Node is neither receiver nor transmitter"]
     #[inline(always)]
     pub fn is_idle(&self) -> bool {
-        **self == ACT_A::IDLE
+        *self == ACTSELECT_A::IDLE
     }
-    #[doc = "Checks if the value of the field is `RX`"]
+    #[doc = "Node is operating as receiver"]
     #[inline(always)]
     pub fn is_rx(&self) -> bool {
-        **self == ACT_A::RX
+        *self == ACTSELECT_A::RX
     }
-    #[doc = "Checks if the value of the field is `TX`"]
+    #[doc = "Node is operating as transmitter"]
     #[inline(always)]
     pub fn is_tx(&self) -> bool {
-        **self == ACT_A::TX
-    }
-}
-impl core::ops::Deref for ACT_R {
-    type Target = crate::FieldReader<u8, ACT_A>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
+        *self == ACTSELECT_A::TX
     }
 }
 #[doc = "Field `EP` reader - Error Passive"]
-pub struct EP_R(crate::FieldReader<bool, bool>);
-impl EP_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        EP_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for EP_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type EP_R = crate::BitReader;
 #[doc = "Field `EW` reader - Warning Status"]
-pub struct EW_R(crate::FieldReader<bool, bool>);
-impl EW_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        EW_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for EW_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type EW_R = crate::BitReader;
 #[doc = "Field `BO` reader - Bus_Off Status"]
-pub struct BO_R(crate::FieldReader<bool, bool>);
-impl BO_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        BO_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for BO_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type BO_R = crate::BitReader;
+#[doc = "Field `DLEC` reader - Data Phase Last Error Code"]
+pub type DLEC_R = crate::FieldReader<DLECSELECT_A>;
 #[doc = "Data Phase Last Error Code\n\nValue on reset: 7"]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
-pub enum DLEC_A {
+pub enum DLECSELECT_A {
     #[doc = "0: No Error"]
     NONE = 0,
     #[doc = "1: Stuff Error"]
@@ -241,207 +175,132 @@ pub enum DLEC_A {
     #[doc = "7: No Change"]
     NC = 7,
 }
-impl From<DLEC_A> for u8 {
+impl From<DLECSELECT_A> for u8 {
     #[inline(always)]
-    fn from(variant: DLEC_A) -> Self {
+    fn from(variant: DLECSELECT_A) -> Self {
         variant as _
     }
 }
-#[doc = "Field `DLEC` reader - Data Phase Last Error Code"]
-pub struct DLEC_R(crate::FieldReader<u8, DLEC_A>);
+impl crate::FieldSpec for DLECSELECT_A {
+    type Ux = u8;
+}
 impl DLEC_R {
+    #[doc = "Get enumerated values variant"]
     #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        DLEC_R(crate::FieldReader::new(bits))
-    }
-    #[doc = r"Get enumerated values variant"]
-    #[inline(always)]
-    pub fn variant(&self) -> DLEC_A {
+    pub const fn variant(&self) -> DLECSELECT_A {
         match self.bits {
-            0 => DLEC_A::NONE,
-            1 => DLEC_A::STUFF,
-            2 => DLEC_A::FORM,
-            3 => DLEC_A::ACK,
-            4 => DLEC_A::BIT1,
-            5 => DLEC_A::BIT0,
-            6 => DLEC_A::CRC,
-            7 => DLEC_A::NC,
+            0 => DLECSELECT_A::NONE,
+            1 => DLECSELECT_A::STUFF,
+            2 => DLECSELECT_A::FORM,
+            3 => DLECSELECT_A::ACK,
+            4 => DLECSELECT_A::BIT1,
+            5 => DLECSELECT_A::BIT0,
+            6 => DLECSELECT_A::CRC,
+            7 => DLECSELECT_A::NC,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `NONE`"]
+    #[doc = "No Error"]
     #[inline(always)]
     pub fn is_none(&self) -> bool {
-        **self == DLEC_A::NONE
+        *self == DLECSELECT_A::NONE
     }
-    #[doc = "Checks if the value of the field is `STUFF`"]
+    #[doc = "Stuff Error"]
     #[inline(always)]
     pub fn is_stuff(&self) -> bool {
-        **self == DLEC_A::STUFF
+        *self == DLECSELECT_A::STUFF
     }
-    #[doc = "Checks if the value of the field is `FORM`"]
+    #[doc = "Form Error"]
     #[inline(always)]
     pub fn is_form(&self) -> bool {
-        **self == DLEC_A::FORM
+        *self == DLECSELECT_A::FORM
     }
-    #[doc = "Checks if the value of the field is `ACK`"]
+    #[doc = "Ack Error"]
     #[inline(always)]
     pub fn is_ack(&self) -> bool {
-        **self == DLEC_A::ACK
+        *self == DLECSELECT_A::ACK
     }
-    #[doc = "Checks if the value of the field is `BIT1`"]
+    #[doc = "Bit1 Error"]
     #[inline(always)]
     pub fn is_bit1(&self) -> bool {
-        **self == DLEC_A::BIT1
+        *self == DLECSELECT_A::BIT1
     }
-    #[doc = "Checks if the value of the field is `BIT0`"]
+    #[doc = "Bit0 Error"]
     #[inline(always)]
     pub fn is_bit0(&self) -> bool {
-        **self == DLEC_A::BIT0
+        *self == DLECSELECT_A::BIT0
     }
-    #[doc = "Checks if the value of the field is `CRC`"]
+    #[doc = "CRC Error"]
     #[inline(always)]
     pub fn is_crc(&self) -> bool {
-        **self == DLEC_A::CRC
+        *self == DLECSELECT_A::CRC
     }
-    #[doc = "Checks if the value of the field is `NC`"]
+    #[doc = "No Change"]
     #[inline(always)]
     pub fn is_nc(&self) -> bool {
-        **self == DLEC_A::NC
-    }
-}
-impl core::ops::Deref for DLEC_R {
-    type Target = crate::FieldReader<u8, DLEC_A>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
+        *self == DLECSELECT_A::NC
     }
 }
 #[doc = "Field `RESI` reader - ESI flag of last received CAN FD Message"]
-pub struct RESI_R(crate::FieldReader<bool, bool>);
-impl RESI_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RESI_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RESI_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RESI_R = crate::BitReader;
 #[doc = "Field `RBRS` reader - BRS flag of last received CAN FD Message"]
-pub struct RBRS_R(crate::FieldReader<bool, bool>);
-impl RBRS_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RBRS_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RBRS_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RBRS_R = crate::BitReader;
 #[doc = "Field `RFDF` reader - Received a CAN FD Message"]
-pub struct RFDF_R(crate::FieldReader<bool, bool>);
-impl RFDF_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RFDF_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RFDF_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RFDF_R = crate::BitReader;
 #[doc = "Field `PXE` reader - Protocol Exception Event"]
-pub struct PXE_R(crate::FieldReader<bool, bool>);
-impl PXE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        PXE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for PXE_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type PXE_R = crate::BitReader;
 #[doc = "Field `TDCV` reader - Transmitter Delay Compensation Value"]
-pub struct TDCV_R(crate::FieldReader<u8, u8>);
-impl TDCV_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        TDCV_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TDCV_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TDCV_R = crate::FieldReader;
 impl R {
     #[doc = "Bits 0:2 - Last Error Code"]
     #[inline(always)]
     pub fn lec(&self) -> LEC_R {
-        LEC_R::new((self.bits & 0x07) as u8)
+        LEC_R::new((self.bits & 7) as u8)
     }
     #[doc = "Bits 3:4 - Activity"]
     #[inline(always)]
     pub fn act(&self) -> ACT_R {
-        ACT_R::new(((self.bits >> 3) & 0x03) as u8)
+        ACT_R::new(((self.bits >> 3) & 3) as u8)
     }
     #[doc = "Bit 5 - Error Passive"]
     #[inline(always)]
     pub fn ep(&self) -> EP_R {
-        EP_R::new(((self.bits >> 5) & 0x01) != 0)
+        EP_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - Warning Status"]
     #[inline(always)]
     pub fn ew(&self) -> EW_R {
-        EW_R::new(((self.bits >> 6) & 0x01) != 0)
+        EW_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - Bus_Off Status"]
     #[inline(always)]
     pub fn bo(&self) -> BO_R {
-        BO_R::new(((self.bits >> 7) & 0x01) != 0)
+        BO_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bits 8:10 - Data Phase Last Error Code"]
     #[inline(always)]
     pub fn dlec(&self) -> DLEC_R {
-        DLEC_R::new(((self.bits >> 8) & 0x07) as u8)
+        DLEC_R::new(((self.bits >> 8) & 7) as u8)
     }
     #[doc = "Bit 11 - ESI flag of last received CAN FD Message"]
     #[inline(always)]
     pub fn resi(&self) -> RESI_R {
-        RESI_R::new(((self.bits >> 11) & 0x01) != 0)
+        RESI_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - BRS flag of last received CAN FD Message"]
     #[inline(always)]
     pub fn rbrs(&self) -> RBRS_R {
-        RBRS_R::new(((self.bits >> 12) & 0x01) != 0)
+        RBRS_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - Received a CAN FD Message"]
     #[inline(always)]
     pub fn rfdf(&self) -> RFDF_R {
-        RFDF_R::new(((self.bits >> 13) & 0x01) != 0)
+        RFDF_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - Protocol Exception Event"]
     #[inline(always)]
     pub fn pxe(&self) -> PXE_R {
-        PXE_R::new(((self.bits >> 14) & 0x01) != 0)
+        PXE_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bits 16:22 - Transmitter Delay Compensation Value"]
     #[inline(always)]
@@ -449,19 +308,14 @@ impl R {
         TDCV_R::new(((self.bits >> 16) & 0x7f) as u8)
     }
 }
-#[doc = "Protocol Status\n\nThis register you can [`read`](crate::reg::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [psr](index.html) module"]
+#[doc = "Protocol Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`psr::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PSR_SPEC;
 impl crate::RegisterSpec for PSR_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [psr::R](R) reader structure"]
-impl crate::Readable for PSR_SPEC {
-    type Reader = R;
-}
+#[doc = "`read()` method returns [`psr::R`](R) reader structure"]
+impl crate::Readable for PSR_SPEC {}
 #[doc = "`reset()` method sets PSR to value 0x0707"]
 impl crate::Resettable for PSR_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0x0707
-    }
+    const RESET_VALUE: Self::Ux = 0x0707;
 }

--- a/mcan/src/reg/psr.rs
+++ b/mcan/src/reg/psr.rs
@@ -308,7 +308,7 @@ impl R {
         TDCV_R::new(((self.bits >> 16) & 0x7f) as u8)
     }
 }
-#[doc = "Protocol Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`psr::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Protocol Status\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`psr::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PSR_SPEC;
 impl crate::RegisterSpec for PSR_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/rwd.rs
+++ b/mcan/src/reg/rwd.rs
@@ -1,93 +1,15 @@
 #[doc = "Register `RWD` reader"]
-pub struct R(crate::R<RWD_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<RWD_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<RWD_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<RWD_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<RWD_SPEC>;
 #[doc = "Register `RWD` writer"]
-pub struct W(crate::W<RWD_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<RWD_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<RWD_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<RWD_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<RWD_SPEC>;
 #[doc = "Field `WDC` reader - Watchdog Configuration"]
-pub struct WDC_R(crate::FieldReader<u8, u8>);
-impl WDC_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        WDC_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for WDC_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type WDC_R = crate::FieldReader;
 #[doc = "Field `WDC` writer - Watchdog Configuration"]
-pub struct WDC_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> WDC_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0xff) | (value as u32 & 0xff);
-        self.w
-    }
-}
+pub type WDC_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
 #[doc = "Field `WDV` reader - Watchdog Value"]
-pub struct WDV_R(crate::FieldReader<u8, u8>);
-impl WDV_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        WDV_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for WDV_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type WDV_R = crate::FieldReader;
 #[doc = "Field `WDV` writer - Watchdog Value"]
-pub struct WDV_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> WDV_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0xff << 8)) | ((value as u32 & 0xff) << 8);
-        self.w
-    }
-}
+pub type WDV_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
 impl R {
     #[doc = "Bits 0:7 - Watchdog Configuration"]
     #[inline(always)]
@@ -103,38 +25,40 @@ impl R {
 impl W {
     #[doc = "Bits 0:7 - Watchdog Configuration"]
     #[inline(always)]
-    pub fn wdc(&mut self) -> WDC_W {
-        WDC_W { w: self }
+    #[must_use]
+    pub fn wdc(&mut self) -> WDC_W<RWD_SPEC, 0> {
+        WDC_W::new(self)
     }
     #[doc = "Bits 8:15 - Watchdog Value"]
     #[inline(always)]
-    pub fn wdv(&mut self) -> WDV_W {
-        WDV_W { w: self }
+    #[must_use]
+    pub fn wdv(&mut self) -> WDV_W<RWD_SPEC, 8> {
+        WDV_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "RAM Watchdog\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rwd](index.html) module"]
+#[doc = "RAM Watchdog\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rwd::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rwd::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct RWD_SPEC;
 impl crate::RegisterSpec for RWD_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [rwd::R](R) reader structure"]
-impl crate::Readable for RWD_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [rwd::W](W) writer structure"]
+#[doc = "`read()` method returns [`rwd::R`](R) reader structure"]
+impl crate::Readable for RWD_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rwd::W`](W) writer structure"]
 impl crate::Writable for RWD_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets RWD to value 0"]
 impl crate::Resettable for RWD_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/rwd.rs
+++ b/mcan/src/reg/rwd.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "RAM Watchdog\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rwd::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rwd::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "RAM Watchdog\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`rwd::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`rwd::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct RWD_SPEC;
 impl crate::RegisterSpec for RWD_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/rxbc.rs
+++ b/mcan/src/reg/rxbc.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Rx Buffer Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rxbc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rxbc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Rx Buffer Configuration\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`rxbc::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`rxbc::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct RXBC_SPEC;
 impl crate::RegisterSpec for RXBC_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/rxbc.rs
+++ b/mcan/src/reg/rxbc.rs
@@ -1,66 +1,11 @@
 #[doc = "Register `RXBC` reader"]
-pub struct R(crate::R<RXBC_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<RXBC_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<RXBC_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<RXBC_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<RXBC_SPEC>;
 #[doc = "Register `RXBC` writer"]
-pub struct W(crate::W<RXBC_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<RXBC_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<RXBC_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<RXBC_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<RXBC_SPEC>;
 #[doc = "Field `RBSA` reader - Rx Buffer Start Address"]
-pub struct RBSA_R(crate::FieldReader<u16, u16>);
-impl RBSA_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u16) -> Self {
-        RBSA_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RBSA_R {
-    type Target = crate::FieldReader<u16, u16>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RBSA_R = crate::FieldReader<u16>;
 #[doc = "Field `RBSA` writer - Rx Buffer Start Address"]
-pub struct RBSA_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RBSA_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u16) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0xffff) | (value as u32 & 0xffff);
-        self.w
-    }
-}
+pub type RBSA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
 impl R {
     #[doc = "Bits 0:15 - Rx Buffer Start Address"]
     #[inline(always)]
@@ -71,33 +16,34 @@ impl R {
 impl W {
     #[doc = "Bits 0:15 - Rx Buffer Start Address"]
     #[inline(always)]
-    pub fn rbsa(&mut self) -> RBSA_W {
-        RBSA_W { w: self }
+    #[must_use]
+    pub fn rbsa(&mut self) -> RBSA_W<RXBC_SPEC, 0> {
+        RBSA_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Rx Buffer Configuration\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxbc](index.html) module"]
+#[doc = "Rx Buffer Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rxbc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rxbc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct RXBC_SPEC;
 impl crate::RegisterSpec for RXBC_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [rxbc::R](R) reader structure"]
-impl crate::Readable for RXBC_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [rxbc::W](W) writer structure"]
+#[doc = "`read()` method returns [`rxbc::R`](R) reader structure"]
+impl crate::Readable for RXBC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rxbc::W`](W) writer structure"]
 impl crate::Writable for RXBC_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets RXBC to value 0"]
 impl crate::Resettable for RXBC_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/rxesc.rs
+++ b/mcan/src/reg/rxesc.rs
@@ -1,43 +1,13 @@
 #[doc = "Register `RXESC` reader"]
-pub struct R(crate::R<RXESC_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<RXESC_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<RXESC_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<RXESC_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<RXESC_SPEC>;
 #[doc = "Register `RXESC` writer"]
-pub struct W(crate::W<RXESC_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<RXESC_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<RXESC_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<RXESC_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<RXESC_SPEC>;
+#[doc = "Field `F0DS` reader - Rx FIFO 0 Data Field Size"]
+pub type F0DS_R = crate::FieldReader<F0DSSELECT_A>;
 #[doc = "Rx FIFO 0 Data Field Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
-pub enum F0DS_A {
+pub enum F0DSSELECT_A {
     #[doc = "0: 8 byte data field"]
     DATA8 = 0,
     #[doc = "1: 12 byte data field"]
@@ -55,297 +25,126 @@ pub enum F0DS_A {
     #[doc = "7: 64 byte data field"]
     DATA64 = 7,
 }
-impl From<F0DS_A> for u8 {
+impl From<F0DSSELECT_A> for u8 {
     #[inline(always)]
-    fn from(variant: F0DS_A) -> Self {
+    fn from(variant: F0DSSELECT_A) -> Self {
         variant as _
     }
 }
-#[doc = "Field `F0DS` reader - Rx FIFO 0 Data Field Size"]
-pub struct F0DS_R(crate::FieldReader<u8, F0DS_A>);
+impl crate::FieldSpec for F0DSSELECT_A {
+    type Ux = u8;
+}
 impl F0DS_R {
+    #[doc = "Get enumerated values variant"]
     #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        F0DS_R(crate::FieldReader::new(bits))
-    }
-    #[doc = r"Get enumerated values variant"]
-    #[inline(always)]
-    pub fn variant(&self) -> F0DS_A {
+    pub const fn variant(&self) -> F0DSSELECT_A {
         match self.bits {
-            0 => F0DS_A::DATA8,
-            1 => F0DS_A::DATA12,
-            2 => F0DS_A::DATA16,
-            3 => F0DS_A::DATA20,
-            4 => F0DS_A::DATA24,
-            5 => F0DS_A::DATA32,
-            6 => F0DS_A::DATA48,
-            7 => F0DS_A::DATA64,
+            0 => F0DSSELECT_A::DATA8,
+            1 => F0DSSELECT_A::DATA12,
+            2 => F0DSSELECT_A::DATA16,
+            3 => F0DSSELECT_A::DATA20,
+            4 => F0DSSELECT_A::DATA24,
+            5 => F0DSSELECT_A::DATA32,
+            6 => F0DSSELECT_A::DATA48,
+            7 => F0DSSELECT_A::DATA64,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `DATA8`"]
+    #[doc = "8 byte data field"]
     #[inline(always)]
     pub fn is_data8(&self) -> bool {
-        **self == F0DS_A::DATA8
+        *self == F0DSSELECT_A::DATA8
     }
-    #[doc = "Checks if the value of the field is `DATA12`"]
+    #[doc = "12 byte data field"]
     #[inline(always)]
     pub fn is_data12(&self) -> bool {
-        **self == F0DS_A::DATA12
+        *self == F0DSSELECT_A::DATA12
     }
-    #[doc = "Checks if the value of the field is `DATA16`"]
+    #[doc = "16 byte data field"]
     #[inline(always)]
     pub fn is_data16(&self) -> bool {
-        **self == F0DS_A::DATA16
+        *self == F0DSSELECT_A::DATA16
     }
-    #[doc = "Checks if the value of the field is `DATA20`"]
+    #[doc = "20 byte data field"]
     #[inline(always)]
     pub fn is_data20(&self) -> bool {
-        **self == F0DS_A::DATA20
+        *self == F0DSSELECT_A::DATA20
     }
-    #[doc = "Checks if the value of the field is `DATA24`"]
+    #[doc = "24 byte data field"]
     #[inline(always)]
     pub fn is_data24(&self) -> bool {
-        **self == F0DS_A::DATA24
+        *self == F0DSSELECT_A::DATA24
     }
-    #[doc = "Checks if the value of the field is `DATA32`"]
+    #[doc = "32 byte data field"]
     #[inline(always)]
     pub fn is_data32(&self) -> bool {
-        **self == F0DS_A::DATA32
+        *self == F0DSSELECT_A::DATA32
     }
-    #[doc = "Checks if the value of the field is `DATA48`"]
+    #[doc = "48 byte data field"]
     #[inline(always)]
     pub fn is_data48(&self) -> bool {
-        **self == F0DS_A::DATA48
+        *self == F0DSSELECT_A::DATA48
     }
-    #[doc = "Checks if the value of the field is `DATA64`"]
+    #[doc = "64 byte data field"]
     #[inline(always)]
     pub fn is_data64(&self) -> bool {
-        **self == F0DS_A::DATA64
-    }
-}
-impl core::ops::Deref for F0DS_R {
-    type Target = crate::FieldReader<u8, F0DS_A>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
+        *self == F0DSSELECT_A::DATA64
     }
 }
 #[doc = "Field `F0DS` writer - Rx FIFO 0 Data Field Size"]
-pub struct F0DS_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> F0DS_W<'a> {
-    #[doc = r"Writes `variant` to the field"]
-    #[inline(always)]
-    pub fn variant(self, variant: F0DS_A) -> &'a mut W {
-        self.bits(variant.into())
-    }
+pub type F0DS_W<'a, REG, const O: u8> = crate::FieldWriterSafe<'a, REG, 3, O, F0DSSELECT_A>;
+impl<'a, REG, const O: u8> F0DS_W<'a, REG, O>
+where
+    REG: crate::Writable + crate::RegisterSpec,
+    REG::Ux: From<u8>,
+{
     #[doc = "8 byte data field"]
     #[inline(always)]
-    pub fn data8(self) -> &'a mut W {
-        self.variant(F0DS_A::DATA8)
+    pub fn data8(self) -> &'a mut crate::W<REG> {
+        self.variant(F0DSSELECT_A::DATA8)
     }
     #[doc = "12 byte data field"]
     #[inline(always)]
-    pub fn data12(self) -> &'a mut W {
-        self.variant(F0DS_A::DATA12)
+    pub fn data12(self) -> &'a mut crate::W<REG> {
+        self.variant(F0DSSELECT_A::DATA12)
     }
     #[doc = "16 byte data field"]
     #[inline(always)]
-    pub fn data16(self) -> &'a mut W {
-        self.variant(F0DS_A::DATA16)
+    pub fn data16(self) -> &'a mut crate::W<REG> {
+        self.variant(F0DSSELECT_A::DATA16)
     }
     #[doc = "20 byte data field"]
     #[inline(always)]
-    pub fn data20(self) -> &'a mut W {
-        self.variant(F0DS_A::DATA20)
+    pub fn data20(self) -> &'a mut crate::W<REG> {
+        self.variant(F0DSSELECT_A::DATA20)
     }
     #[doc = "24 byte data field"]
     #[inline(always)]
-    pub fn data24(self) -> &'a mut W {
-        self.variant(F0DS_A::DATA24)
+    pub fn data24(self) -> &'a mut crate::W<REG> {
+        self.variant(F0DSSELECT_A::DATA24)
     }
     #[doc = "32 byte data field"]
     #[inline(always)]
-    pub fn data32(self) -> &'a mut W {
-        self.variant(F0DS_A::DATA32)
+    pub fn data32(self) -> &'a mut crate::W<REG> {
+        self.variant(F0DSSELECT_A::DATA32)
     }
     #[doc = "48 byte data field"]
     #[inline(always)]
-    pub fn data48(self) -> &'a mut W {
-        self.variant(F0DS_A::DATA48)
+    pub fn data48(self) -> &'a mut crate::W<REG> {
+        self.variant(F0DSSELECT_A::DATA48)
     }
     #[doc = "64 byte data field"]
     #[inline(always)]
-    pub fn data64(self) -> &'a mut W {
-        self.variant(F0DS_A::DATA64)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x07) | (value as u32 & 0x07);
-        self.w
-    }
-}
-#[doc = "Rx FIFO 1 Data Field Size\n\nValue on reset: 0"]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(u8)]
-pub enum F1DS_A {
-    #[doc = "0: 8 byte data field"]
-    DATA8 = 0,
-    #[doc = "1: 12 byte data field"]
-    DATA12 = 1,
-    #[doc = "2: 16 byte data field"]
-    DATA16 = 2,
-    #[doc = "3: 20 byte data field"]
-    DATA20 = 3,
-    #[doc = "4: 24 byte data field"]
-    DATA24 = 4,
-    #[doc = "5: 32 byte data field"]
-    DATA32 = 5,
-    #[doc = "6: 48 byte data field"]
-    DATA48 = 6,
-    #[doc = "7: 64 byte data field"]
-    DATA64 = 7,
-}
-impl From<F1DS_A> for u8 {
-    #[inline(always)]
-    fn from(variant: F1DS_A) -> Self {
-        variant as _
+    pub fn data64(self) -> &'a mut crate::W<REG> {
+        self.variant(F0DSSELECT_A::DATA64)
     }
 }
 #[doc = "Field `F1DS` reader - Rx FIFO 1 Data Field Size"]
-pub struct F1DS_R(crate::FieldReader<u8, F1DS_A>);
-impl F1DS_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        F1DS_R(crate::FieldReader::new(bits))
-    }
-    #[doc = r"Get enumerated values variant"]
-    #[inline(always)]
-    pub fn variant(&self) -> F1DS_A {
-        match self.bits {
-            0 => F1DS_A::DATA8,
-            1 => F1DS_A::DATA12,
-            2 => F1DS_A::DATA16,
-            3 => F1DS_A::DATA20,
-            4 => F1DS_A::DATA24,
-            5 => F1DS_A::DATA32,
-            6 => F1DS_A::DATA48,
-            7 => F1DS_A::DATA64,
-            _ => unreachable!(),
-        }
-    }
-    #[doc = "Checks if the value of the field is `DATA8`"]
-    #[inline(always)]
-    pub fn is_data8(&self) -> bool {
-        **self == F1DS_A::DATA8
-    }
-    #[doc = "Checks if the value of the field is `DATA12`"]
-    #[inline(always)]
-    pub fn is_data12(&self) -> bool {
-        **self == F1DS_A::DATA12
-    }
-    #[doc = "Checks if the value of the field is `DATA16`"]
-    #[inline(always)]
-    pub fn is_data16(&self) -> bool {
-        **self == F1DS_A::DATA16
-    }
-    #[doc = "Checks if the value of the field is `DATA20`"]
-    #[inline(always)]
-    pub fn is_data20(&self) -> bool {
-        **self == F1DS_A::DATA20
-    }
-    #[doc = "Checks if the value of the field is `DATA24`"]
-    #[inline(always)]
-    pub fn is_data24(&self) -> bool {
-        **self == F1DS_A::DATA24
-    }
-    #[doc = "Checks if the value of the field is `DATA32`"]
-    #[inline(always)]
-    pub fn is_data32(&self) -> bool {
-        **self == F1DS_A::DATA32
-    }
-    #[doc = "Checks if the value of the field is `DATA48`"]
-    #[inline(always)]
-    pub fn is_data48(&self) -> bool {
-        **self == F1DS_A::DATA48
-    }
-    #[doc = "Checks if the value of the field is `DATA64`"]
-    #[inline(always)]
-    pub fn is_data64(&self) -> bool {
-        **self == F1DS_A::DATA64
-    }
-}
-impl core::ops::Deref for F1DS_R {
-    type Target = crate::FieldReader<u8, F1DS_A>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[doc = "Field `F1DS` writer - Rx FIFO 1 Data Field Size"]
-pub struct F1DS_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> F1DS_W<'a> {
-    #[doc = r"Writes `variant` to the field"]
-    #[inline(always)]
-    pub fn variant(self, variant: F1DS_A) -> &'a mut W {
-        self.bits(variant.into())
-    }
-    #[doc = "8 byte data field"]
-    #[inline(always)]
-    pub fn data8(self) -> &'a mut W {
-        self.variant(F1DS_A::DATA8)
-    }
-    #[doc = "12 byte data field"]
-    #[inline(always)]
-    pub fn data12(self) -> &'a mut W {
-        self.variant(F1DS_A::DATA12)
-    }
-    #[doc = "16 byte data field"]
-    #[inline(always)]
-    pub fn data16(self) -> &'a mut W {
-        self.variant(F1DS_A::DATA16)
-    }
-    #[doc = "20 byte data field"]
-    #[inline(always)]
-    pub fn data20(self) -> &'a mut W {
-        self.variant(F1DS_A::DATA20)
-    }
-    #[doc = "24 byte data field"]
-    #[inline(always)]
-    pub fn data24(self) -> &'a mut W {
-        self.variant(F1DS_A::DATA24)
-    }
-    #[doc = "32 byte data field"]
-    #[inline(always)]
-    pub fn data32(self) -> &'a mut W {
-        self.variant(F1DS_A::DATA32)
-    }
-    #[doc = "48 byte data field"]
-    #[inline(always)]
-    pub fn data48(self) -> &'a mut W {
-        self.variant(F1DS_A::DATA48)
-    }
-    #[doc = "64 byte data field"]
-    #[inline(always)]
-    pub fn data64(self) -> &'a mut W {
-        self.variant(F1DS_A::DATA64)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x07 << 4)) | ((value as u32 & 0x07) << 4);
-        self.w
-    }
-}
-#[doc = "Rx Buffer Data Field Size\n\nValue on reset: 0"]
+pub type F1DS_R = crate::FieldReader<F1DSSELECT_A>;
+#[doc = "Rx FIFO 1 Data Field Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
-pub enum RBDS_A {
+pub enum F1DSSELECT_A {
     #[doc = "0: 8 byte data field"]
     DATA8 = 0,
     #[doc = "1: 12 byte data field"]
@@ -363,196 +162,317 @@ pub enum RBDS_A {
     #[doc = "7: 64 byte data field"]
     DATA64 = 7,
 }
-impl From<RBDS_A> for u8 {
+impl From<F1DSSELECT_A> for u8 {
     #[inline(always)]
-    fn from(variant: RBDS_A) -> Self {
+    fn from(variant: F1DSSELECT_A) -> Self {
         variant as _
     }
 }
-#[doc = "Field `RBDS` reader - Rx Buffer Data Field Size"]
-pub struct RBDS_R(crate::FieldReader<u8, RBDS_A>);
-impl RBDS_R {
+impl crate::FieldSpec for F1DSSELECT_A {
+    type Ux = u8;
+}
+impl F1DS_R {
+    #[doc = "Get enumerated values variant"]
     #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        RBDS_R(crate::FieldReader::new(bits))
-    }
-    #[doc = r"Get enumerated values variant"]
-    #[inline(always)]
-    pub fn variant(&self) -> RBDS_A {
+    pub const fn variant(&self) -> F1DSSELECT_A {
         match self.bits {
-            0 => RBDS_A::DATA8,
-            1 => RBDS_A::DATA12,
-            2 => RBDS_A::DATA16,
-            3 => RBDS_A::DATA20,
-            4 => RBDS_A::DATA24,
-            5 => RBDS_A::DATA32,
-            6 => RBDS_A::DATA48,
-            7 => RBDS_A::DATA64,
+            0 => F1DSSELECT_A::DATA8,
+            1 => F1DSSELECT_A::DATA12,
+            2 => F1DSSELECT_A::DATA16,
+            3 => F1DSSELECT_A::DATA20,
+            4 => F1DSSELECT_A::DATA24,
+            5 => F1DSSELECT_A::DATA32,
+            6 => F1DSSELECT_A::DATA48,
+            7 => F1DSSELECT_A::DATA64,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `DATA8`"]
-    #[inline(always)]
-    pub fn is_data8(&self) -> bool {
-        **self == RBDS_A::DATA8
-    }
-    #[doc = "Checks if the value of the field is `DATA12`"]
-    #[inline(always)]
-    pub fn is_data12(&self) -> bool {
-        **self == RBDS_A::DATA12
-    }
-    #[doc = "Checks if the value of the field is `DATA16`"]
-    #[inline(always)]
-    pub fn is_data16(&self) -> bool {
-        **self == RBDS_A::DATA16
-    }
-    #[doc = "Checks if the value of the field is `DATA20`"]
-    #[inline(always)]
-    pub fn is_data20(&self) -> bool {
-        **self == RBDS_A::DATA20
-    }
-    #[doc = "Checks if the value of the field is `DATA24`"]
-    #[inline(always)]
-    pub fn is_data24(&self) -> bool {
-        **self == RBDS_A::DATA24
-    }
-    #[doc = "Checks if the value of the field is `DATA32`"]
-    #[inline(always)]
-    pub fn is_data32(&self) -> bool {
-        **self == RBDS_A::DATA32
-    }
-    #[doc = "Checks if the value of the field is `DATA48`"]
-    #[inline(always)]
-    pub fn is_data48(&self) -> bool {
-        **self == RBDS_A::DATA48
-    }
-    #[doc = "Checks if the value of the field is `DATA64`"]
-    #[inline(always)]
-    pub fn is_data64(&self) -> bool {
-        **self == RBDS_A::DATA64
-    }
-}
-impl core::ops::Deref for RBDS_R {
-    type Target = crate::FieldReader<u8, RBDS_A>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[doc = "Field `RBDS` writer - Rx Buffer Data Field Size"]
-pub struct RBDS_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RBDS_W<'a> {
-    #[doc = r"Writes `variant` to the field"]
-    #[inline(always)]
-    pub fn variant(self, variant: RBDS_A) -> &'a mut W {
-        self.bits(variant.into())
-    }
     #[doc = "8 byte data field"]
     #[inline(always)]
-    pub fn data8(self) -> &'a mut W {
-        self.variant(RBDS_A::DATA8)
+    pub fn is_data8(&self) -> bool {
+        *self == F1DSSELECT_A::DATA8
     }
     #[doc = "12 byte data field"]
     #[inline(always)]
-    pub fn data12(self) -> &'a mut W {
-        self.variant(RBDS_A::DATA12)
+    pub fn is_data12(&self) -> bool {
+        *self == F1DSSELECT_A::DATA12
     }
     #[doc = "16 byte data field"]
     #[inline(always)]
-    pub fn data16(self) -> &'a mut W {
-        self.variant(RBDS_A::DATA16)
+    pub fn is_data16(&self) -> bool {
+        *self == F1DSSELECT_A::DATA16
     }
     #[doc = "20 byte data field"]
     #[inline(always)]
-    pub fn data20(self) -> &'a mut W {
-        self.variant(RBDS_A::DATA20)
+    pub fn is_data20(&self) -> bool {
+        *self == F1DSSELECT_A::DATA20
     }
     #[doc = "24 byte data field"]
     #[inline(always)]
-    pub fn data24(self) -> &'a mut W {
-        self.variant(RBDS_A::DATA24)
+    pub fn is_data24(&self) -> bool {
+        *self == F1DSSELECT_A::DATA24
     }
     #[doc = "32 byte data field"]
     #[inline(always)]
-    pub fn data32(self) -> &'a mut W {
-        self.variant(RBDS_A::DATA32)
+    pub fn is_data32(&self) -> bool {
+        *self == F1DSSELECT_A::DATA32
     }
     #[doc = "48 byte data field"]
     #[inline(always)]
-    pub fn data48(self) -> &'a mut W {
-        self.variant(RBDS_A::DATA48)
+    pub fn is_data48(&self) -> bool {
+        *self == F1DSSELECT_A::DATA48
     }
     #[doc = "64 byte data field"]
     #[inline(always)]
-    pub fn data64(self) -> &'a mut W {
-        self.variant(RBDS_A::DATA64)
+    pub fn is_data64(&self) -> bool {
+        *self == F1DSSELECT_A::DATA64
     }
-    #[doc = r"Writes raw bits to the field"]
+}
+#[doc = "Field `F1DS` writer - Rx FIFO 1 Data Field Size"]
+pub type F1DS_W<'a, REG, const O: u8> = crate::FieldWriterSafe<'a, REG, 3, O, F1DSSELECT_A>;
+impl<'a, REG, const O: u8> F1DS_W<'a, REG, O>
+where
+    REG: crate::Writable + crate::RegisterSpec,
+    REG::Ux: From<u8>,
+{
+    #[doc = "8 byte data field"]
     #[inline(always)]
-    pub fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x07 << 8)) | ((value as u32 & 0x07) << 8);
-        self.w
+    pub fn data8(self) -> &'a mut crate::W<REG> {
+        self.variant(F1DSSELECT_A::DATA8)
+    }
+    #[doc = "12 byte data field"]
+    #[inline(always)]
+    pub fn data12(self) -> &'a mut crate::W<REG> {
+        self.variant(F1DSSELECT_A::DATA12)
+    }
+    #[doc = "16 byte data field"]
+    #[inline(always)]
+    pub fn data16(self) -> &'a mut crate::W<REG> {
+        self.variant(F1DSSELECT_A::DATA16)
+    }
+    #[doc = "20 byte data field"]
+    #[inline(always)]
+    pub fn data20(self) -> &'a mut crate::W<REG> {
+        self.variant(F1DSSELECT_A::DATA20)
+    }
+    #[doc = "24 byte data field"]
+    #[inline(always)]
+    pub fn data24(self) -> &'a mut crate::W<REG> {
+        self.variant(F1DSSELECT_A::DATA24)
+    }
+    #[doc = "32 byte data field"]
+    #[inline(always)]
+    pub fn data32(self) -> &'a mut crate::W<REG> {
+        self.variant(F1DSSELECT_A::DATA32)
+    }
+    #[doc = "48 byte data field"]
+    #[inline(always)]
+    pub fn data48(self) -> &'a mut crate::W<REG> {
+        self.variant(F1DSSELECT_A::DATA48)
+    }
+    #[doc = "64 byte data field"]
+    #[inline(always)]
+    pub fn data64(self) -> &'a mut crate::W<REG> {
+        self.variant(F1DSSELECT_A::DATA64)
+    }
+}
+#[doc = "Field `RBDS` reader - Rx Buffer Data Field Size"]
+pub type RBDS_R = crate::FieldReader<RBDSSELECT_A>;
+#[doc = "Rx Buffer Data Field Size\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum RBDSSELECT_A {
+    #[doc = "0: 8 byte data field"]
+    DATA8 = 0,
+    #[doc = "1: 12 byte data field"]
+    DATA12 = 1,
+    #[doc = "2: 16 byte data field"]
+    DATA16 = 2,
+    #[doc = "3: 20 byte data field"]
+    DATA20 = 3,
+    #[doc = "4: 24 byte data field"]
+    DATA24 = 4,
+    #[doc = "5: 32 byte data field"]
+    DATA32 = 5,
+    #[doc = "6: 48 byte data field"]
+    DATA48 = 6,
+    #[doc = "7: 64 byte data field"]
+    DATA64 = 7,
+}
+impl From<RBDSSELECT_A> for u8 {
+    #[inline(always)]
+    fn from(variant: RBDSSELECT_A) -> Self {
+        variant as _
+    }
+}
+impl crate::FieldSpec for RBDSSELECT_A {
+    type Ux = u8;
+}
+impl RBDS_R {
+    #[doc = "Get enumerated values variant"]
+    #[inline(always)]
+    pub const fn variant(&self) -> RBDSSELECT_A {
+        match self.bits {
+            0 => RBDSSELECT_A::DATA8,
+            1 => RBDSSELECT_A::DATA12,
+            2 => RBDSSELECT_A::DATA16,
+            3 => RBDSSELECT_A::DATA20,
+            4 => RBDSSELECT_A::DATA24,
+            5 => RBDSSELECT_A::DATA32,
+            6 => RBDSSELECT_A::DATA48,
+            7 => RBDSSELECT_A::DATA64,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "8 byte data field"]
+    #[inline(always)]
+    pub fn is_data8(&self) -> bool {
+        *self == RBDSSELECT_A::DATA8
+    }
+    #[doc = "12 byte data field"]
+    #[inline(always)]
+    pub fn is_data12(&self) -> bool {
+        *self == RBDSSELECT_A::DATA12
+    }
+    #[doc = "16 byte data field"]
+    #[inline(always)]
+    pub fn is_data16(&self) -> bool {
+        *self == RBDSSELECT_A::DATA16
+    }
+    #[doc = "20 byte data field"]
+    #[inline(always)]
+    pub fn is_data20(&self) -> bool {
+        *self == RBDSSELECT_A::DATA20
+    }
+    #[doc = "24 byte data field"]
+    #[inline(always)]
+    pub fn is_data24(&self) -> bool {
+        *self == RBDSSELECT_A::DATA24
+    }
+    #[doc = "32 byte data field"]
+    #[inline(always)]
+    pub fn is_data32(&self) -> bool {
+        *self == RBDSSELECT_A::DATA32
+    }
+    #[doc = "48 byte data field"]
+    #[inline(always)]
+    pub fn is_data48(&self) -> bool {
+        *self == RBDSSELECT_A::DATA48
+    }
+    #[doc = "64 byte data field"]
+    #[inline(always)]
+    pub fn is_data64(&self) -> bool {
+        *self == RBDSSELECT_A::DATA64
+    }
+}
+#[doc = "Field `RBDS` writer - Rx Buffer Data Field Size"]
+pub type RBDS_W<'a, REG, const O: u8> = crate::FieldWriterSafe<'a, REG, 3, O, RBDSSELECT_A>;
+impl<'a, REG, const O: u8> RBDS_W<'a, REG, O>
+where
+    REG: crate::Writable + crate::RegisterSpec,
+    REG::Ux: From<u8>,
+{
+    #[doc = "8 byte data field"]
+    #[inline(always)]
+    pub fn data8(self) -> &'a mut crate::W<REG> {
+        self.variant(RBDSSELECT_A::DATA8)
+    }
+    #[doc = "12 byte data field"]
+    #[inline(always)]
+    pub fn data12(self) -> &'a mut crate::W<REG> {
+        self.variant(RBDSSELECT_A::DATA12)
+    }
+    #[doc = "16 byte data field"]
+    #[inline(always)]
+    pub fn data16(self) -> &'a mut crate::W<REG> {
+        self.variant(RBDSSELECT_A::DATA16)
+    }
+    #[doc = "20 byte data field"]
+    #[inline(always)]
+    pub fn data20(self) -> &'a mut crate::W<REG> {
+        self.variant(RBDSSELECT_A::DATA20)
+    }
+    #[doc = "24 byte data field"]
+    #[inline(always)]
+    pub fn data24(self) -> &'a mut crate::W<REG> {
+        self.variant(RBDSSELECT_A::DATA24)
+    }
+    #[doc = "32 byte data field"]
+    #[inline(always)]
+    pub fn data32(self) -> &'a mut crate::W<REG> {
+        self.variant(RBDSSELECT_A::DATA32)
+    }
+    #[doc = "48 byte data field"]
+    #[inline(always)]
+    pub fn data48(self) -> &'a mut crate::W<REG> {
+        self.variant(RBDSSELECT_A::DATA48)
+    }
+    #[doc = "64 byte data field"]
+    #[inline(always)]
+    pub fn data64(self) -> &'a mut crate::W<REG> {
+        self.variant(RBDSSELECT_A::DATA64)
     }
 }
 impl R {
     #[doc = "Bits 0:2 - Rx FIFO 0 Data Field Size"]
     #[inline(always)]
     pub fn f0ds(&self) -> F0DS_R {
-        F0DS_R::new((self.bits & 0x07) as u8)
+        F0DS_R::new((self.bits & 7) as u8)
     }
     #[doc = "Bits 4:6 - Rx FIFO 1 Data Field Size"]
     #[inline(always)]
     pub fn f1ds(&self) -> F1DS_R {
-        F1DS_R::new(((self.bits >> 4) & 0x07) as u8)
+        F1DS_R::new(((self.bits >> 4) & 7) as u8)
     }
     #[doc = "Bits 8:10 - Rx Buffer Data Field Size"]
     #[inline(always)]
     pub fn rbds(&self) -> RBDS_R {
-        RBDS_R::new(((self.bits >> 8) & 0x07) as u8)
+        RBDS_R::new(((self.bits >> 8) & 7) as u8)
     }
 }
 impl W {
     #[doc = "Bits 0:2 - Rx FIFO 0 Data Field Size"]
     #[inline(always)]
-    pub fn f0ds(&mut self) -> F0DS_W {
-        F0DS_W { w: self }
+    #[must_use]
+    pub fn f0ds(&mut self) -> F0DS_W<RXESC_SPEC, 0> {
+        F0DS_W::new(self)
     }
     #[doc = "Bits 4:6 - Rx FIFO 1 Data Field Size"]
     #[inline(always)]
-    pub fn f1ds(&mut self) -> F1DS_W {
-        F1DS_W { w: self }
+    #[must_use]
+    pub fn f1ds(&mut self) -> F1DS_W<RXESC_SPEC, 4> {
+        F1DS_W::new(self)
     }
     #[doc = "Bits 8:10 - Rx Buffer Data Field Size"]
     #[inline(always)]
-    pub fn rbds(&mut self) -> RBDS_W {
-        RBDS_W { w: self }
+    #[must_use]
+    pub fn rbds(&mut self) -> RBDS_W<RXESC_SPEC, 8> {
+        RBDS_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Rx Buffer / FIFO Element Size Configuration\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxesc](index.html) module"]
+#[doc = "Rx Buffer / FIFO Element Size Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rxesc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rxesc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct RXESC_SPEC;
 impl crate::RegisterSpec for RXESC_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [rxesc::R](R) reader structure"]
-impl crate::Readable for RXESC_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [rxesc::W](W) writer structure"]
+#[doc = "`read()` method returns [`rxesc::R`](R) reader structure"]
+impl crate::Readable for RXESC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rxesc::W`](W) writer structure"]
 impl crate::Writable for RXESC_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets RXESC to value 0"]
 impl crate::Resettable for RXESC_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/rxesc.rs
+++ b/mcan/src/reg/rxesc.rs
@@ -460,7 +460,7 @@ impl W {
         self
     }
 }
-#[doc = "Rx Buffer / FIFO Element Size Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rxesc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rxesc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Rx Buffer / FIFO Element Size Configuration\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`rxesc::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`rxesc::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct RXESC_SPEC;
 impl crate::RegisterSpec for RXESC_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/rxf0a.rs
+++ b/mcan/src/reg/rxf0a.rs
@@ -1,66 +1,11 @@
 #[doc = "Register `RXF0A` reader"]
-pub struct R(crate::R<RXF0A_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<RXF0A_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<RXF0A_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<RXF0A_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<RXF0A_SPEC>;
 #[doc = "Register `RXF0A` writer"]
-pub struct W(crate::W<RXF0A_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<RXF0A_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<RXF0A_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<RXF0A_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<RXF0A_SPEC>;
 #[doc = "Field `F0AI` reader - Rx FIFO 0 Acknowledge Index"]
-pub struct F0AI_R(crate::FieldReader<u8, u8>);
-impl F0AI_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        F0AI_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for F0AI_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type F0AI_R = crate::FieldReader;
 #[doc = "Field `F0AI` writer - Rx FIFO 0 Acknowledge Index"]
-pub struct F0AI_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> F0AI_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x3f) | (value as u32 & 0x3f);
-        self.w
-    }
-}
+pub type F0AI_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 6, O>;
 impl R {
     #[doc = "Bits 0:5 - Rx FIFO 0 Acknowledge Index"]
     #[inline(always)]
@@ -71,33 +16,34 @@ impl R {
 impl W {
     #[doc = "Bits 0:5 - Rx FIFO 0 Acknowledge Index"]
     #[inline(always)]
-    pub fn f0ai(&mut self) -> F0AI_W {
-        F0AI_W { w: self }
+    #[must_use]
+    pub fn f0ai(&mut self) -> F0AI_W<RXF0A_SPEC, 0> {
+        F0AI_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Rx FIFO 0 Acknowledge\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxf0a](index.html) module"]
+#[doc = "Rx FIFO 0 Acknowledge\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rxf0a::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rxf0a::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct RXF0A_SPEC;
 impl crate::RegisterSpec for RXF0A_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [rxf0a::R](R) reader structure"]
-impl crate::Readable for RXF0A_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [rxf0a::W](W) writer structure"]
+#[doc = "`read()` method returns [`rxf0a::R`](R) reader structure"]
+impl crate::Readable for RXF0A_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rxf0a::W`](W) writer structure"]
 impl crate::Writable for RXF0A_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets RXF0A to value 0"]
 impl crate::Resettable for RXF0A_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/rxf0a.rs
+++ b/mcan/src/reg/rxf0a.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Rx FIFO 0 Acknowledge\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rxf0a::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rxf0a::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Rx FIFO 0 Acknowledge\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`rxf0a::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`rxf0a::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct RXF0A_SPEC;
 impl crate::RegisterSpec for RXF0A_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/rxf0c.rs
+++ b/mcan/src/reg/rxf0c.rs
@@ -76,7 +76,7 @@ impl W {
         self
     }
 }
-#[doc = "Rx FIFO 0 Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rxf0c::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rxf0c::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Rx FIFO 0 Configuration\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`rxf0c::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`rxf0c::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct RXF0C_SPEC;
 impl crate::RegisterSpec for RXF0C_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/rxf0c.rs
+++ b/mcan/src/reg/rxf0c.rs
@@ -1,157 +1,23 @@
 #[doc = "Register `RXF0C` reader"]
-pub struct R(crate::R<RXF0C_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<RXF0C_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<RXF0C_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<RXF0C_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<RXF0C_SPEC>;
 #[doc = "Register `RXF0C` writer"]
-pub struct W(crate::W<RXF0C_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<RXF0C_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<RXF0C_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<RXF0C_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<RXF0C_SPEC>;
 #[doc = "Field `F0SA` reader - Rx FIFO 0 Start Address"]
-pub struct F0SA_R(crate::FieldReader<u16, u16>);
-impl F0SA_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u16) -> Self {
-        F0SA_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for F0SA_R {
-    type Target = crate::FieldReader<u16, u16>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type F0SA_R = crate::FieldReader<u16>;
 #[doc = "Field `F0SA` writer - Rx FIFO 0 Start Address"]
-pub struct F0SA_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> F0SA_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u16) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0xffff) | (value as u32 & 0xffff);
-        self.w
-    }
-}
+pub type F0SA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
 #[doc = "Field `F0S` reader - Rx FIFO 0 Size"]
-pub struct F0S_R(crate::FieldReader<u8, u8>);
-impl F0S_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        F0S_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for F0S_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type F0S_R = crate::FieldReader;
 #[doc = "Field `F0S` writer - Rx FIFO 0 Size"]
-pub struct F0S_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> F0S_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x7f << 16)) | ((value as u32 & 0x7f) << 16);
-        self.w
-    }
-}
+pub type F0S_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
 #[doc = "Field `F0WM` reader - Rx FIFO 0 Watermark"]
-pub struct F0WM_R(crate::FieldReader<u8, u8>);
-impl F0WM_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        F0WM_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for F0WM_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type F0WM_R = crate::FieldReader;
 #[doc = "Field `F0WM` writer - Rx FIFO 0 Watermark"]
-pub struct F0WM_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> F0WM_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x7f << 24)) | ((value as u32 & 0x7f) << 24);
-        self.w
-    }
-}
+pub type F0WM_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
 #[doc = "Field `F0OM` reader - FIFO 0 Operation Mode"]
-pub struct F0OM_R(crate::FieldReader<bool, bool>);
-impl F0OM_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        F0OM_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for F0OM_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type F0OM_R = crate::BitReader;
 #[doc = "Field `F0OM` writer - FIFO 0 Operation Mode"]
-pub struct F0OM_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> F0OM_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 31)) | ((value as u32 & 0x01) << 31);
-        self.w
-    }
-}
+pub type F0OM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
     #[doc = "Bits 0:15 - Rx FIFO 0 Start Address"]
     #[inline(always)]
@@ -171,54 +37,58 @@ impl R {
     #[doc = "Bit 31 - FIFO 0 Operation Mode"]
     #[inline(always)]
     pub fn f0om(&self) -> F0OM_R {
-        F0OM_R::new(((self.bits >> 31) & 0x01) != 0)
+        F0OM_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bits 0:15 - Rx FIFO 0 Start Address"]
     #[inline(always)]
-    pub fn f0sa(&mut self) -> F0SA_W {
-        F0SA_W { w: self }
+    #[must_use]
+    pub fn f0sa(&mut self) -> F0SA_W<RXF0C_SPEC, 0> {
+        F0SA_W::new(self)
     }
     #[doc = "Bits 16:22 - Rx FIFO 0 Size"]
     #[inline(always)]
-    pub fn f0s(&mut self) -> F0S_W {
-        F0S_W { w: self }
+    #[must_use]
+    pub fn f0s(&mut self) -> F0S_W<RXF0C_SPEC, 16> {
+        F0S_W::new(self)
     }
     #[doc = "Bits 24:30 - Rx FIFO 0 Watermark"]
     #[inline(always)]
-    pub fn f0wm(&mut self) -> F0WM_W {
-        F0WM_W { w: self }
+    #[must_use]
+    pub fn f0wm(&mut self) -> F0WM_W<RXF0C_SPEC, 24> {
+        F0WM_W::new(self)
     }
     #[doc = "Bit 31 - FIFO 0 Operation Mode"]
     #[inline(always)]
-    pub fn f0om(&mut self) -> F0OM_W {
-        F0OM_W { w: self }
+    #[must_use]
+    pub fn f0om(&mut self) -> F0OM_W<RXF0C_SPEC, 31> {
+        F0OM_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Rx FIFO 0 Configuration\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxf0c](index.html) module"]
+#[doc = "Rx FIFO 0 Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rxf0c::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rxf0c::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct RXF0C_SPEC;
 impl crate::RegisterSpec for RXF0C_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [rxf0c::R](R) reader structure"]
-impl crate::Readable for RXF0C_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [rxf0c::W](W) writer structure"]
+#[doc = "`read()` method returns [`rxf0c::R`](R) reader structure"]
+impl crate::Readable for RXF0C_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rxf0c::W`](W) writer structure"]
 impl crate::Writable for RXF0C_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets RXF0C to value 0"]
 impl crate::Resettable for RXF0C_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/rxf0s.rs
+++ b/mcan/src/reg/rxf0s.rs
@@ -37,7 +37,7 @@ impl R {
         RF0L_R::new(((self.bits >> 25) & 1) != 0)
     }
 }
-#[doc = "Rx FIFO 0 Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rxf0s::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Rx FIFO 0 Status\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`rxf0s::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct RXF0S_SPEC;
 impl crate::RegisterSpec for RXF0S_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/rxf0s.rs
+++ b/mcan/src/reg/rxf0s.rs
@@ -1,93 +1,15 @@
 #[doc = "Register `RXF0S` reader"]
-pub struct R(crate::R<RXF0S_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<RXF0S_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<RXF0S_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<RXF0S_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<RXF0S_SPEC>;
 #[doc = "Field `F0FL` reader - Rx FIFO 0 Fill Level"]
-pub struct F0FL_R(crate::FieldReader<u8, u8>);
-impl F0FL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        F0FL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for F0FL_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type F0FL_R = crate::FieldReader;
 #[doc = "Field `F0GI` reader - Rx FIFO 0 Get Index"]
-pub struct F0GI_R(crate::FieldReader<u8, u8>);
-impl F0GI_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        F0GI_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for F0GI_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type F0GI_R = crate::FieldReader;
 #[doc = "Field `F0PI` reader - Rx FIFO 0 Put Index"]
-pub struct F0PI_R(crate::FieldReader<u8, u8>);
-impl F0PI_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        F0PI_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for F0PI_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type F0PI_R = crate::FieldReader;
 #[doc = "Field `F0F` reader - Rx FIFO 0 Full"]
-pub struct F0F_R(crate::FieldReader<bool, bool>);
-impl F0F_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        F0F_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for F0F_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type F0F_R = crate::BitReader;
 #[doc = "Field `RF0L` reader - Rx FIFO 0 Message Lost"]
-pub struct RF0L_R(crate::FieldReader<bool, bool>);
-impl RF0L_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF0L_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF0L_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF0L_R = crate::BitReader;
 impl R {
     #[doc = "Bits 0:6 - Rx FIFO 0 Fill Level"]
     #[inline(always)]
@@ -107,27 +29,22 @@ impl R {
     #[doc = "Bit 24 - Rx FIFO 0 Full"]
     #[inline(always)]
     pub fn f0f(&self) -> F0F_R {
-        F0F_R::new(((self.bits >> 24) & 0x01) != 0)
+        F0F_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - Rx FIFO 0 Message Lost"]
     #[inline(always)]
     pub fn rf0l(&self) -> RF0L_R {
-        RF0L_R::new(((self.bits >> 25) & 0x01) != 0)
+        RF0L_R::new(((self.bits >> 25) & 1) != 0)
     }
 }
-#[doc = "Rx FIFO 0 Status\n\nThis register you can [`read`](crate::reg::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxf0s](index.html) module"]
+#[doc = "Rx FIFO 0 Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rxf0s::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct RXF0S_SPEC;
 impl crate::RegisterSpec for RXF0S_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [rxf0s::R](R) reader structure"]
-impl crate::Readable for RXF0S_SPEC {
-    type Reader = R;
-}
+#[doc = "`read()` method returns [`rxf0s::R`](R) reader structure"]
+impl crate::Readable for RXF0S_SPEC {}
 #[doc = "`reset()` method sets RXF0S to value 0"]
 impl crate::Resettable for RXF0S_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/rxf1a.rs
+++ b/mcan/src/reg/rxf1a.rs
@@ -1,66 +1,11 @@
 #[doc = "Register `RXF1A` reader"]
-pub struct R(crate::R<RXF1A_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<RXF1A_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<RXF1A_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<RXF1A_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<RXF1A_SPEC>;
 #[doc = "Register `RXF1A` writer"]
-pub struct W(crate::W<RXF1A_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<RXF1A_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<RXF1A_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<RXF1A_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<RXF1A_SPEC>;
 #[doc = "Field `F1AI` reader - Rx FIFO 1 Acknowledge Index"]
-pub struct F1AI_R(crate::FieldReader<u8, u8>);
-impl F1AI_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        F1AI_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for F1AI_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type F1AI_R = crate::FieldReader;
 #[doc = "Field `F1AI` writer - Rx FIFO 1 Acknowledge Index"]
-pub struct F1AI_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> F1AI_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x3f) | (value as u32 & 0x3f);
-        self.w
-    }
-}
+pub type F1AI_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 6, O>;
 impl R {
     #[doc = "Bits 0:5 - Rx FIFO 1 Acknowledge Index"]
     #[inline(always)]
@@ -71,33 +16,34 @@ impl R {
 impl W {
     #[doc = "Bits 0:5 - Rx FIFO 1 Acknowledge Index"]
     #[inline(always)]
-    pub fn f1ai(&mut self) -> F1AI_W {
-        F1AI_W { w: self }
+    #[must_use]
+    pub fn f1ai(&mut self) -> F1AI_W<RXF1A_SPEC, 0> {
+        F1AI_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Rx FIFO 1 Acknowledge\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxf1a](index.html) module"]
+#[doc = "Rx FIFO 1 Acknowledge\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rxf1a::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rxf1a::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct RXF1A_SPEC;
 impl crate::RegisterSpec for RXF1A_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [rxf1a::R](R) reader structure"]
-impl crate::Readable for RXF1A_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [rxf1a::W](W) writer structure"]
+#[doc = "`read()` method returns [`rxf1a::R`](R) reader structure"]
+impl crate::Readable for RXF1A_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rxf1a::W`](W) writer structure"]
 impl crate::Writable for RXF1A_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets RXF1A to value 0"]
 impl crate::Resettable for RXF1A_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/rxf1a.rs
+++ b/mcan/src/reg/rxf1a.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Rx FIFO 1 Acknowledge\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rxf1a::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rxf1a::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Rx FIFO 1 Acknowledge\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`rxf1a::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`rxf1a::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct RXF1A_SPEC;
 impl crate::RegisterSpec for RXF1A_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/rxf1c.rs
+++ b/mcan/src/reg/rxf1c.rs
@@ -76,7 +76,7 @@ impl W {
         self
     }
 }
-#[doc = "Rx FIFO 1 Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rxf1c::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rxf1c::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Rx FIFO 1 Configuration\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`rxf1c::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`rxf1c::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct RXF1C_SPEC;
 impl crate::RegisterSpec for RXF1C_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/rxf1c.rs
+++ b/mcan/src/reg/rxf1c.rs
@@ -1,157 +1,23 @@
 #[doc = "Register `RXF1C` reader"]
-pub struct R(crate::R<RXF1C_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<RXF1C_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<RXF1C_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<RXF1C_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<RXF1C_SPEC>;
 #[doc = "Register `RXF1C` writer"]
-pub struct W(crate::W<RXF1C_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<RXF1C_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<RXF1C_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<RXF1C_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<RXF1C_SPEC>;
 #[doc = "Field `F1SA` reader - Rx FIFO 1 Start Address"]
-pub struct F1SA_R(crate::FieldReader<u16, u16>);
-impl F1SA_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u16) -> Self {
-        F1SA_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for F1SA_R {
-    type Target = crate::FieldReader<u16, u16>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type F1SA_R = crate::FieldReader<u16>;
 #[doc = "Field `F1SA` writer - Rx FIFO 1 Start Address"]
-pub struct F1SA_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> F1SA_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u16) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0xffff) | (value as u32 & 0xffff);
-        self.w
-    }
-}
+pub type F1SA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
 #[doc = "Field `F1S` reader - Rx FIFO 1 Size"]
-pub struct F1S_R(crate::FieldReader<u8, u8>);
-impl F1S_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        F1S_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for F1S_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type F1S_R = crate::FieldReader;
 #[doc = "Field `F1S` writer - Rx FIFO 1 Size"]
-pub struct F1S_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> F1S_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x7f << 16)) | ((value as u32 & 0x7f) << 16);
-        self.w
-    }
-}
+pub type F1S_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
 #[doc = "Field `F1WM` reader - Rx FIFO 1 Watermark"]
-pub struct F1WM_R(crate::FieldReader<u8, u8>);
-impl F1WM_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        F1WM_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for F1WM_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type F1WM_R = crate::FieldReader;
 #[doc = "Field `F1WM` writer - Rx FIFO 1 Watermark"]
-pub struct F1WM_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> F1WM_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x7f << 24)) | ((value as u32 & 0x7f) << 24);
-        self.w
-    }
-}
+pub type F1WM_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
 #[doc = "Field `F1OM` reader - FIFO 1 Operation Mode"]
-pub struct F1OM_R(crate::FieldReader<bool, bool>);
-impl F1OM_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        F1OM_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for F1OM_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type F1OM_R = crate::BitReader;
 #[doc = "Field `F1OM` writer - FIFO 1 Operation Mode"]
-pub struct F1OM_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> F1OM_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 31)) | ((value as u32 & 0x01) << 31);
-        self.w
-    }
-}
+pub type F1OM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
     #[doc = "Bits 0:15 - Rx FIFO 1 Start Address"]
     #[inline(always)]
@@ -171,54 +37,58 @@ impl R {
     #[doc = "Bit 31 - FIFO 1 Operation Mode"]
     #[inline(always)]
     pub fn f1om(&self) -> F1OM_R {
-        F1OM_R::new(((self.bits >> 31) & 0x01) != 0)
+        F1OM_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bits 0:15 - Rx FIFO 1 Start Address"]
     #[inline(always)]
-    pub fn f1sa(&mut self) -> F1SA_W {
-        F1SA_W { w: self }
+    #[must_use]
+    pub fn f1sa(&mut self) -> F1SA_W<RXF1C_SPEC, 0> {
+        F1SA_W::new(self)
     }
     #[doc = "Bits 16:22 - Rx FIFO 1 Size"]
     #[inline(always)]
-    pub fn f1s(&mut self) -> F1S_W {
-        F1S_W { w: self }
+    #[must_use]
+    pub fn f1s(&mut self) -> F1S_W<RXF1C_SPEC, 16> {
+        F1S_W::new(self)
     }
     #[doc = "Bits 24:30 - Rx FIFO 1 Watermark"]
     #[inline(always)]
-    pub fn f1wm(&mut self) -> F1WM_W {
-        F1WM_W { w: self }
+    #[must_use]
+    pub fn f1wm(&mut self) -> F1WM_W<RXF1C_SPEC, 24> {
+        F1WM_W::new(self)
     }
     #[doc = "Bit 31 - FIFO 1 Operation Mode"]
     #[inline(always)]
-    pub fn f1om(&mut self) -> F1OM_W {
-        F1OM_W { w: self }
+    #[must_use]
+    pub fn f1om(&mut self) -> F1OM_W<RXF1C_SPEC, 31> {
+        F1OM_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Rx FIFO 1 Configuration\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxf1c](index.html) module"]
+#[doc = "Rx FIFO 1 Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rxf1c::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rxf1c::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct RXF1C_SPEC;
 impl crate::RegisterSpec for RXF1C_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [rxf1c::R](R) reader structure"]
-impl crate::Readable for RXF1C_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [rxf1c::W](W) writer structure"]
+#[doc = "`read()` method returns [`rxf1c::R`](R) reader structure"]
+impl crate::Readable for RXF1C_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rxf1c::W`](W) writer structure"]
 impl crate::Writable for RXF1C_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets RXF1C to value 0"]
 impl crate::Resettable for RXF1C_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/rxf1s.rs
+++ b/mcan/src/reg/rxf1s.rs
@@ -99,7 +99,7 @@ impl R {
         DMS_R::new(((self.bits >> 30) & 3) as u8)
     }
 }
-#[doc = "Rx FIFO 1 Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rxf1s::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Rx FIFO 1 Status\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`rxf1s::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct RXF1S_SPEC;
 impl crate::RegisterSpec for RXF1S_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/rxf1s.rs
+++ b/mcan/src/reg/rxf1s.rs
@@ -1,97 +1,21 @@
 #[doc = "Register `RXF1S` reader"]
-pub struct R(crate::R<RXF1S_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<RXF1S_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<RXF1S_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<RXF1S_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<RXF1S_SPEC>;
 #[doc = "Field `F1FL` reader - Rx FIFO 1 Fill Level"]
-pub struct F1FL_R(crate::FieldReader<u8, u8>);
-impl F1FL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        F1FL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for F1FL_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type F1FL_R = crate::FieldReader;
 #[doc = "Field `F1GI` reader - Rx FIFO 1 Get Index"]
-pub struct F1GI_R(crate::FieldReader<u8, u8>);
-impl F1GI_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        F1GI_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for F1GI_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type F1GI_R = crate::FieldReader;
 #[doc = "Field `F1PI` reader - Rx FIFO 1 Put Index"]
-pub struct F1PI_R(crate::FieldReader<u8, u8>);
-impl F1PI_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        F1PI_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for F1PI_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type F1PI_R = crate::FieldReader;
 #[doc = "Field `F1F` reader - Rx FIFO 1 Full"]
-pub struct F1F_R(crate::FieldReader<bool, bool>);
-impl F1F_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        F1F_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for F1F_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type F1F_R = crate::BitReader;
 #[doc = "Field `RF1L` reader - Rx FIFO 1 Message Lost"]
-pub struct RF1L_R(crate::FieldReader<bool, bool>);
-impl RF1L_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RF1L_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RF1L_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RF1L_R = crate::BitReader;
+#[doc = "Field `DMS` reader - Debug Message Status"]
+pub type DMS_R = crate::FieldReader<DMSSELECT_A>;
 #[doc = "Debug Message Status\n\nValue on reset: 0"]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
-pub enum DMS_A {
+pub enum DMSSELECT_A {
     #[doc = "0: Idle state"]
     IDLE = 0,
     #[doc = "1: Debug message A received"]
@@ -101,56 +25,46 @@ pub enum DMS_A {
     #[doc = "3: Debug message A/B/C received, DMA request set"]
     DBGC = 3,
 }
-impl From<DMS_A> for u8 {
+impl From<DMSSELECT_A> for u8 {
     #[inline(always)]
-    fn from(variant: DMS_A) -> Self {
+    fn from(variant: DMSSELECT_A) -> Self {
         variant as _
     }
 }
-#[doc = "Field `DMS` reader - Debug Message Status"]
-pub struct DMS_R(crate::FieldReader<u8, DMS_A>);
+impl crate::FieldSpec for DMSSELECT_A {
+    type Ux = u8;
+}
 impl DMS_R {
+    #[doc = "Get enumerated values variant"]
     #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        DMS_R(crate::FieldReader::new(bits))
-    }
-    #[doc = r"Get enumerated values variant"]
-    #[inline(always)]
-    pub fn variant(&self) -> DMS_A {
+    pub const fn variant(&self) -> DMSSELECT_A {
         match self.bits {
-            0 => DMS_A::IDLE,
-            1 => DMS_A::DBGA,
-            2 => DMS_A::DBGB,
-            3 => DMS_A::DBGC,
+            0 => DMSSELECT_A::IDLE,
+            1 => DMSSELECT_A::DBGA,
+            2 => DMSSELECT_A::DBGB,
+            3 => DMSSELECT_A::DBGC,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `IDLE`"]
+    #[doc = "Idle state"]
     #[inline(always)]
     pub fn is_idle(&self) -> bool {
-        **self == DMS_A::IDLE
+        *self == DMSSELECT_A::IDLE
     }
-    #[doc = "Checks if the value of the field is `DBGA`"]
+    #[doc = "Debug message A received"]
     #[inline(always)]
     pub fn is_dbga(&self) -> bool {
-        **self == DMS_A::DBGA
+        *self == DMSSELECT_A::DBGA
     }
-    #[doc = "Checks if the value of the field is `DBGB`"]
+    #[doc = "Debug message A/B received"]
     #[inline(always)]
     pub fn is_dbgb(&self) -> bool {
-        **self == DMS_A::DBGB
+        *self == DMSSELECT_A::DBGB
     }
-    #[doc = "Checks if the value of the field is `DBGC`"]
+    #[doc = "Debug message A/B/C received, DMA request set"]
     #[inline(always)]
     pub fn is_dbgc(&self) -> bool {
-        **self == DMS_A::DBGC
-    }
-}
-impl core::ops::Deref for DMS_R {
-    type Target = crate::FieldReader<u8, DMS_A>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
+        *self == DMSSELECT_A::DBGC
     }
 }
 impl R {
@@ -172,32 +86,27 @@ impl R {
     #[doc = "Bit 24 - Rx FIFO 1 Full"]
     #[inline(always)]
     pub fn f1f(&self) -> F1F_R {
-        F1F_R::new(((self.bits >> 24) & 0x01) != 0)
+        F1F_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - Rx FIFO 1 Message Lost"]
     #[inline(always)]
     pub fn rf1l(&self) -> RF1L_R {
-        RF1L_R::new(((self.bits >> 25) & 0x01) != 0)
+        RF1L_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bits 30:31 - Debug Message Status"]
     #[inline(always)]
     pub fn dms(&self) -> DMS_R {
-        DMS_R::new(((self.bits >> 30) & 0x03) as u8)
+        DMS_R::new(((self.bits >> 30) & 3) as u8)
     }
 }
-#[doc = "Rx FIFO 1 Status\n\nThis register you can [`read`](crate::reg::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxf1s](index.html) module"]
+#[doc = "Rx FIFO 1 Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rxf1s::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct RXF1S_SPEC;
 impl crate::RegisterSpec for RXF1S_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [rxf1s::R](R) reader structure"]
-impl crate::Readable for RXF1S_SPEC {
-    type Reader = R;
-}
+#[doc = "`read()` method returns [`rxf1s::R`](R) reader structure"]
+impl crate::Readable for RXF1S_SPEC {}
 #[doc = "`reset()` method sets RXF1S to value 0"]
 impl crate::Resettable for RXF1S_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/rxfa.rs
+++ b/mcan/src/reg/rxfa.rs
@@ -1,24 +1,24 @@
-#[doc = "Register `RXF0A` reader"]
-pub type R = crate::R<RXF0A_SPEC>;
-#[doc = "Register `RXF0A` writer"]
-pub type W = crate::W<RXF0A_SPEC>;
-#[doc = "Field `F0AI` reader - Rx FIFO 0 Acknowledge Index"]
-pub type F0AI_R = crate::FieldReader;
-#[doc = "Field `F0AI` writer - Rx FIFO 0 Acknowledge Index"]
-pub type F0AI_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 6, O>;
+#[doc = "Register `RXFA` reader"]
+pub type R = crate::R<RXFA_SPEC>;
+#[doc = "Register `RXFA` writer"]
+pub type W = crate::W<RXFA_SPEC>;
+#[doc = "Field `FAI` reader - Rx FIFO Acknowledge Index"]
+pub type FAI_R = crate::FieldReader;
+#[doc = "Field `FAI` writer - Rx FIFO Acknowledge Index"]
+pub type FAI_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 6, O>;
 impl R {
-    #[doc = "Bits 0:5 - Rx FIFO 0 Acknowledge Index"]
+    #[doc = "Bits 0:5 - Rx FIFO Acknowledge Index"]
     #[inline(always)]
-    pub fn f0ai(&self) -> F0AI_R {
-        F0AI_R::new((self.bits & 0x3f) as u8)
+    pub fn fai(&self) -> FAI_R {
+        FAI_R::new((self.bits & 0x3f) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:5 - Rx FIFO 0 Acknowledge Index"]
+    #[doc = "Bits 0:5 - Rx FIFO Acknowledge Index"]
     #[inline(always)]
     #[must_use]
-    pub fn f0ai(&mut self) -> F0AI_W<RXF0A_SPEC, 0> {
-        F0AI_W::new(self)
+    pub fn fai(&mut self) -> FAI_W<RXFA_SPEC, 0> {
+        FAI_W::new(self)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
@@ -31,19 +31,19 @@ impl W {
         self
     }
 }
-#[doc = "Rx FIFO 0 Acknowledge\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rxf0a::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rxf0a::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct RXF0A_SPEC;
-impl crate::RegisterSpec for RXF0A_SPEC {
+#[doc = "Rx FIFO Acknowledge\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`rxfa::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`rxfa::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct RXFA_SPEC;
+impl crate::RegisterSpec for RXFA_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`rxf0a::R`](R) reader structure"]
-impl crate::Readable for RXF0A_SPEC {}
-#[doc = "`write(|w| ..)` method takes [`rxf0a::W`](W) writer structure"]
-impl crate::Writable for RXF0A_SPEC {
+#[doc = "`read()` method returns [`rxfa::R`](R) reader structure"]
+impl crate::Readable for RXFA_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rxfa::W`](W) writer structure"]
+impl crate::Writable for RXFA_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
-#[doc = "`reset()` method sets RXF0A to value 0"]
-impl crate::Resettable for RXF0A_SPEC {
+#[doc = "`reset()` method sets RXFA to value 0"]
+impl crate::Resettable for RXFA_SPEC {
     const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/rxfa.rs
+++ b/mcan/src/reg/rxfa.rs
@@ -1,103 +1,49 @@
-#[doc = "Register `RXFA` reader"]
-pub struct R(crate::R<RXFA_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<RXFA_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<RXFA_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<RXFA_SPEC>) -> Self {
-        R(reader)
-    }
-}
-#[doc = "Register `RXFA` writer"]
-pub struct W(crate::W<RXFA_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<RXFA_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<RXFA_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<RXFA_SPEC>) -> Self {
-        W(writer)
-    }
-}
-#[doc = "Field `FAI` reader - Rx FIFO Acknowledge Index"]
-pub struct FAI_R(crate::FieldReader<u8, u8>);
-impl FAI_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        FAI_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for FAI_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[doc = "Field `FAI` writer - Rx FIFO Acknowledge Index"]
-pub struct FAI_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> FAI_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x3f) | (value as u32 & 0x3f);
-        self.w
-    }
-}
+#[doc = "Register `RXF0A` reader"]
+pub type R = crate::R<RXF0A_SPEC>;
+#[doc = "Register `RXF0A` writer"]
+pub type W = crate::W<RXF0A_SPEC>;
+#[doc = "Field `F0AI` reader - Rx FIFO 0 Acknowledge Index"]
+pub type F0AI_R = crate::FieldReader;
+#[doc = "Field `F0AI` writer - Rx FIFO 0 Acknowledge Index"]
+pub type F0AI_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 6, O>;
 impl R {
-    #[doc = "Bits 0:5 - Rx FIFO Acknowledge Index"]
+    #[doc = "Bits 0:5 - Rx FIFO 0 Acknowledge Index"]
     #[inline(always)]
-    pub fn fai(&self) -> FAI_R {
-        FAI_R::new((self.bits & 0x3f) as u8)
+    pub fn f0ai(&self) -> F0AI_R {
+        F0AI_R::new((self.bits & 0x3f) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:5 - Rx FIFO Acknowledge Index"]
+    #[doc = "Bits 0:5 - Rx FIFO 0 Acknowledge Index"]
     #[inline(always)]
-    pub fn fai(&mut self) -> FAI_W {
-        FAI_W { w: self }
+    #[must_use]
+    pub fn f0ai(&mut self) -> F0AI_W<RXF0A_SPEC, 0> {
+        F0AI_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Rx FIFO Acknowledge\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxfa](index.html) module"]
-pub struct RXFA_SPEC;
-impl crate::RegisterSpec for RXFA_SPEC {
+#[doc = "Rx FIFO 0 Acknowledge\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rxf0a::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rxf0a::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct RXF0A_SPEC;
+impl crate::RegisterSpec for RXF0A_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [rxfa::R](R) reader structure"]
-impl crate::Readable for RXFA_SPEC {
-    type Reader = R;
+#[doc = "`read()` method returns [`rxf0a::R`](R) reader structure"]
+impl crate::Readable for RXF0A_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rxf0a::W`](W) writer structure"]
+impl crate::Writable for RXF0A_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
-#[doc = "`write(|w| ..)` method takes [rxfa::W](W) writer structure"]
-impl crate::Writable for RXFA_SPEC {
-    type Writer = W;
-}
-#[doc = "`reset()` method sets RXFA to value 0"]
-impl crate::Resettable for RXFA_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+#[doc = "`reset()` method sets RXF0A to value 0"]
+impl crate::Resettable for RXF0A_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/rxfc.rs
+++ b/mcan/src/reg/rxfc.rs
@@ -1,69 +1,69 @@
-#[doc = "Register `RXF0C` reader"]
-pub type R = crate::R<RXF0C_SPEC>;
-#[doc = "Register `RXF0C` writer"]
-pub type W = crate::W<RXF0C_SPEC>;
-#[doc = "Field `F0SA` reader - Rx FIFO 0 Start Address"]
-pub type F0SA_R = crate::FieldReader<u16>;
-#[doc = "Field `F0SA` writer - Rx FIFO 0 Start Address"]
-pub type F0SA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
-#[doc = "Field `F0S` reader - Rx FIFO 0 Size"]
-pub type F0S_R = crate::FieldReader;
-#[doc = "Field `F0S` writer - Rx FIFO 0 Size"]
-pub type F0S_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
-#[doc = "Field `F0WM` reader - Rx FIFO 0 Watermark"]
-pub type F0WM_R = crate::FieldReader;
-#[doc = "Field `F0WM` writer - Rx FIFO 0 Watermark"]
-pub type F0WM_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
-#[doc = "Field `F0OM` reader - FIFO 0 Operation Mode"]
-pub type F0OM_R = crate::BitReader;
-#[doc = "Field `F0OM` writer - FIFO 0 Operation Mode"]
-pub type F0OM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Register `RXFC` reader"]
+pub type R = crate::R<RXFC_SPEC>;
+#[doc = "Register `RXFC` writer"]
+pub type W = crate::W<RXFC_SPEC>;
+#[doc = "Field `FSA` reader - Rx FIFO Start Address"]
+pub type FSA_R = crate::FieldReader<u16>;
+#[doc = "Field `FSA` writer - Rx FIFO Start Address"]
+pub type FSA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
+#[doc = "Field `FS` reader - Rx FIFO Size"]
+pub type FS_R = crate::FieldReader;
+#[doc = "Field `FS` writer - Rx FIFO Size"]
+pub type FS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `FWM` reader - Rx FIFO Watermark"]
+pub type FWM_R = crate::FieldReader;
+#[doc = "Field `FWM` writer - Rx FIFO Watermark"]
+pub type FWM_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `FOM` reader - FIFO Operation Mode"]
+pub type FOM_R = crate::BitReader;
+#[doc = "Field `FOM` writer - FIFO Operation Mode"]
+pub type FOM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
-    #[doc = "Bits 0:15 - Rx FIFO 0 Start Address"]
+    #[doc = "Bits 0:15 - Rx FIFO Start Address"]
     #[inline(always)]
-    pub fn f0sa(&self) -> F0SA_R {
-        F0SA_R::new((self.bits & 0xffff) as u16)
+    pub fn fsa(&self) -> FSA_R {
+        FSA_R::new((self.bits & 0xffff) as u16)
     }
-    #[doc = "Bits 16:22 - Rx FIFO 0 Size"]
+    #[doc = "Bits 16:22 - Rx FIFO Size"]
     #[inline(always)]
-    pub fn f0s(&self) -> F0S_R {
-        F0S_R::new(((self.bits >> 16) & 0x7f) as u8)
+    pub fn fs(&self) -> FS_R {
+        FS_R::new(((self.bits >> 16) & 0x7f) as u8)
     }
-    #[doc = "Bits 24:30 - Rx FIFO 0 Watermark"]
+    #[doc = "Bits 24:30 - Rx FIFO Watermark"]
     #[inline(always)]
-    pub fn f0wm(&self) -> F0WM_R {
-        F0WM_R::new(((self.bits >> 24) & 0x7f) as u8)
+    pub fn fwm(&self) -> FWM_R {
+        FWM_R::new(((self.bits >> 24) & 0x7f) as u8)
     }
-    #[doc = "Bit 31 - FIFO 0 Operation Mode"]
+    #[doc = "Bit 31 - FIFO Operation Mode"]
     #[inline(always)]
-    pub fn f0om(&self) -> F0OM_R {
-        F0OM_R::new(((self.bits >> 31) & 1) != 0)
+    pub fn fom(&self) -> FOM_R {
+        FOM_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bits 0:15 - Rx FIFO 0 Start Address"]
+    #[doc = "Bits 0:15 - Rx FIFO Start Address"]
     #[inline(always)]
     #[must_use]
-    pub fn f0sa(&mut self) -> F0SA_W<RXF0C_SPEC, 0> {
-        F0SA_W::new(self)
+    pub fn fsa(&mut self) -> FSA_W<RXFC_SPEC, 0> {
+        FSA_W::new(self)
     }
-    #[doc = "Bits 16:22 - Rx FIFO 0 Size"]
+    #[doc = "Bits 16:22 - Rx FIFO Size"]
     #[inline(always)]
     #[must_use]
-    pub fn f0s(&mut self) -> F0S_W<RXF0C_SPEC, 16> {
-        F0S_W::new(self)
+    pub fn fs(&mut self) -> FS_W<RXFC_SPEC, 16> {
+        FS_W::new(self)
     }
-    #[doc = "Bits 24:30 - Rx FIFO 0 Watermark"]
+    #[doc = "Bits 24:30 - Rx FIFO Watermark"]
     #[inline(always)]
     #[must_use]
-    pub fn f0wm(&mut self) -> F0WM_W<RXF0C_SPEC, 24> {
-        F0WM_W::new(self)
+    pub fn fwm(&mut self) -> FWM_W<RXFC_SPEC, 24> {
+        FWM_W::new(self)
     }
-    #[doc = "Bit 31 - FIFO 0 Operation Mode"]
+    #[doc = "Bit 31 - FIFO Operation Mode"]
     #[inline(always)]
     #[must_use]
-    pub fn f0om(&mut self) -> F0OM_W<RXF0C_SPEC, 31> {
-        F0OM_W::new(self)
+    pub fn fom(&mut self) -> FOM_W<RXFC_SPEC, 31> {
+        FOM_W::new(self)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
@@ -76,19 +76,19 @@ impl W {
         self
     }
 }
-#[doc = "Rx FIFO 0 Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rxf0c::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rxf0c::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct RXF0C_SPEC;
-impl crate::RegisterSpec for RXF0C_SPEC {
+#[doc = "Rx FIFO Configuration\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`rxfc::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`rxfc::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct RXFC_SPEC;
+impl crate::RegisterSpec for RXFC_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`rxf0c::R`](R) reader structure"]
-impl crate::Readable for RXF0C_SPEC {}
-#[doc = "`write(|w| ..)` method takes [`rxf0c::W`](W) writer structure"]
-impl crate::Writable for RXF0C_SPEC {
+#[doc = "`read()` method returns [`rxfc::R`](R) reader structure"]
+impl crate::Readable for RXFC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rxfc::W`](W) writer structure"]
+impl crate::Writable for RXFC_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
-#[doc = "`reset()` method sets RXF0C to value 0"]
-impl crate::Resettable for RXF0C_SPEC {
+#[doc = "`reset()` method sets RXFC to value 0"]
+impl crate::Resettable for RXFC_SPEC {
     const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/rxfc.rs
+++ b/mcan/src/reg/rxfc.rs
@@ -1,224 +1,94 @@
-#[doc = "Register `RXFC` reader"]
-pub struct R(crate::R<RXFC_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<RXFC_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<RXFC_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<RXFC_SPEC>) -> Self {
-        R(reader)
-    }
-}
-#[doc = "Register `RXFC` writer"]
-pub struct W(crate::W<RXFC_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<RXFC_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<RXFC_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<RXFC_SPEC>) -> Self {
-        W(writer)
-    }
-}
-#[doc = "Field `FSA` reader - Rx FIFO Start Address"]
-pub struct FSA_R(crate::FieldReader<u16, u16>);
-impl FSA_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u16) -> Self {
-        FSA_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for FSA_R {
-    type Target = crate::FieldReader<u16, u16>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[doc = "Field `FSA` writer - Rx FIFO Start Address"]
-pub struct FSA_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> FSA_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u16) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0xffff) | (value as u32 & 0xffff);
-        self.w
-    }
-}
-#[doc = "Field `FS` reader - Rx FIFO Size"]
-pub struct FS_R(crate::FieldReader<u8, u8>);
-impl FS_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        FS_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for FS_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[doc = "Field `FS` writer - Rx FIFO Size"]
-pub struct FS_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> FS_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x7f << 16)) | ((value as u32 & 0x7f) << 16);
-        self.w
-    }
-}
-#[doc = "Field `FWM` reader - Rx FIFO Watermark"]
-pub struct FWM_R(crate::FieldReader<u8, u8>);
-impl FWM_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        FWM_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for FWM_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[doc = "Field `FWM` writer - Rx FIFO Watermark"]
-pub struct FWM_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> FWM_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x7f << 24)) | ((value as u32 & 0x7f) << 24);
-        self.w
-    }
-}
-#[doc = "Field `FOM` reader - FIFO Operation Mode"]
-pub struct FOM_R(crate::FieldReader<bool, bool>);
-impl FOM_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        FOM_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for FOM_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[doc = "Field `FOM` writer - FIFO Operation Mode"]
-pub struct FOM_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> FOM_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 31)) | ((value as u32 & 0x01) << 31);
-        self.w
-    }
-}
+#[doc = "Register `RXF0C` reader"]
+pub type R = crate::R<RXF0C_SPEC>;
+#[doc = "Register `RXF0C` writer"]
+pub type W = crate::W<RXF0C_SPEC>;
+#[doc = "Field `F0SA` reader - Rx FIFO 0 Start Address"]
+pub type F0SA_R = crate::FieldReader<u16>;
+#[doc = "Field `F0SA` writer - Rx FIFO 0 Start Address"]
+pub type F0SA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
+#[doc = "Field `F0S` reader - Rx FIFO 0 Size"]
+pub type F0S_R = crate::FieldReader;
+#[doc = "Field `F0S` writer - Rx FIFO 0 Size"]
+pub type F0S_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `F0WM` reader - Rx FIFO 0 Watermark"]
+pub type F0WM_R = crate::FieldReader;
+#[doc = "Field `F0WM` writer - Rx FIFO 0 Watermark"]
+pub type F0WM_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `F0OM` reader - FIFO 0 Operation Mode"]
+pub type F0OM_R = crate::BitReader;
+#[doc = "Field `F0OM` writer - FIFO 0 Operation Mode"]
+pub type F0OM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
-    #[doc = "Bits 0:15 - Rx FIFO Start Address"]
+    #[doc = "Bits 0:15 - Rx FIFO 0 Start Address"]
     #[inline(always)]
-    pub fn fsa(&self) -> FSA_R {
-        FSA_R::new((self.bits & 0xffff) as u16)
+    pub fn f0sa(&self) -> F0SA_R {
+        F0SA_R::new((self.bits & 0xffff) as u16)
     }
-    #[doc = "Bits 16:22 - Rx FIFO Size"]
+    #[doc = "Bits 16:22 - Rx FIFO 0 Size"]
     #[inline(always)]
-    pub fn fs(&self) -> FS_R {
-        FS_R::new(((self.bits >> 16) & 0x7f) as u8)
+    pub fn f0s(&self) -> F0S_R {
+        F0S_R::new(((self.bits >> 16) & 0x7f) as u8)
     }
-    #[doc = "Bits 24:30 - Rx FIFO Watermark"]
+    #[doc = "Bits 24:30 - Rx FIFO 0 Watermark"]
     #[inline(always)]
-    pub fn fwm(&self) -> FWM_R {
-        FWM_R::new(((self.bits >> 24) & 0x7f) as u8)
+    pub fn f0wm(&self) -> F0WM_R {
+        F0WM_R::new(((self.bits >> 24) & 0x7f) as u8)
     }
-    #[doc = "Bit 31 - FIFO Operation Mode"]
+    #[doc = "Bit 31 - FIFO 0 Operation Mode"]
     #[inline(always)]
-    pub fn fom(&self) -> FOM_R {
-        FOM_R::new(((self.bits >> 31) & 0x01) != 0)
+    pub fn f0om(&self) -> F0OM_R {
+        F0OM_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bits 0:15 - Rx FIFO Start Address"]
+    #[doc = "Bits 0:15 - Rx FIFO 0 Start Address"]
     #[inline(always)]
-    pub fn fsa(&mut self) -> FSA_W {
-        FSA_W { w: self }
+    #[must_use]
+    pub fn f0sa(&mut self) -> F0SA_W<RXF0C_SPEC, 0> {
+        F0SA_W::new(self)
     }
-    #[doc = "Bits 16:22 - Rx FIFO Size"]
+    #[doc = "Bits 16:22 - Rx FIFO 0 Size"]
     #[inline(always)]
-    pub fn fs(&mut self) -> FS_W {
-        FS_W { w: self }
+    #[must_use]
+    pub fn f0s(&mut self) -> F0S_W<RXF0C_SPEC, 16> {
+        F0S_W::new(self)
     }
-    #[doc = "Bits 24:30 - Rx FIFO Watermark"]
+    #[doc = "Bits 24:30 - Rx FIFO 0 Watermark"]
     #[inline(always)]
-    pub fn fwm(&mut self) -> FWM_W {
-        FWM_W { w: self }
+    #[must_use]
+    pub fn f0wm(&mut self) -> F0WM_W<RXF0C_SPEC, 24> {
+        F0WM_W::new(self)
     }
-    #[doc = "Bit 31 - FIFO Operation Mode"]
+    #[doc = "Bit 31 - FIFO 0 Operation Mode"]
     #[inline(always)]
-    pub fn fom(&mut self) -> FOM_W {
-        FOM_W { w: self }
+    #[must_use]
+    pub fn f0om(&mut self) -> F0OM_W<RXF0C_SPEC, 31> {
+        F0OM_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Rx FIFO Configuration\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxfc](index.html) module"]
-pub struct RXFC_SPEC;
-impl crate::RegisterSpec for RXFC_SPEC {
+#[doc = "Rx FIFO 0 Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rxf0c::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rxf0c::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct RXF0C_SPEC;
+impl crate::RegisterSpec for RXF0C_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [rxfc::R](R) reader structure"]
-impl crate::Readable for RXFC_SPEC {
-    type Reader = R;
+#[doc = "`read()` method returns [`rxf0c::R`](R) reader structure"]
+impl crate::Readable for RXF0C_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rxf0c::W`](W) writer structure"]
+impl crate::Writable for RXF0C_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
-#[doc = "`write(|w| ..)` method takes [rxfc::W](W) writer structure"]
-impl crate::Writable for RXFC_SPEC {
-    type Writer = W;
-}
-#[doc = "`reset()` method sets RXFC to value 0"]
-impl crate::Resettable for RXFC_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+#[doc = "`reset()` method sets RXF0C to value 0"]
+impl crate::Resettable for RXF0C_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/rxfs.rs
+++ b/mcan/src/reg/rxfs.rs
@@ -1,50 +1,50 @@
-#[doc = "Register `RXF0S` reader"]
-pub type R = crate::R<RXF0S_SPEC>;
-#[doc = "Field `F0FL` reader - Rx FIFO 0 Fill Level"]
-pub type F0FL_R = crate::FieldReader;
-#[doc = "Field `F0GI` reader - Rx FIFO 0 Get Index"]
-pub type F0GI_R = crate::FieldReader;
-#[doc = "Field `F0PI` reader - Rx FIFO 0 Put Index"]
-pub type F0PI_R = crate::FieldReader;
-#[doc = "Field `F0F` reader - Rx FIFO 0 Full"]
-pub type F0F_R = crate::BitReader;
-#[doc = "Field `RF0L` reader - Rx FIFO 0 Message Lost"]
-pub type RF0L_R = crate::BitReader;
+#[doc = "Register `RXFS` reader"]
+pub type R = crate::R<RXFS_SPEC>;
+#[doc = "Field `FFL` reader - Rx FIFO Fill Level"]
+pub type FFL_R = crate::FieldReader;
+#[doc = "Field `FGI` reader - Rx FIFO Get Index"]
+pub type FGI_R = crate::FieldReader;
+#[doc = "Field `FPI` reader - Rx FIFO Put Index"]
+pub type FPI_R = crate::FieldReader;
+#[doc = "Field `FF` reader - Rx FIFO Full"]
+pub type FF_R = crate::BitReader;
+#[doc = "Field `RFL` reader - Rx FIFO Message Lost"]
+pub type RFL_R = crate::BitReader;
 impl R {
-    #[doc = "Bits 0:6 - Rx FIFO 0 Fill Level"]
+    #[doc = "Bits 0:6 - Rx FIFO Fill Level"]
     #[inline(always)]
-    pub fn f0fl(&self) -> F0FL_R {
-        F0FL_R::new((self.bits & 0x7f) as u8)
+    pub fn ffl(&self) -> FFL_R {
+        FFL_R::new((self.bits & 0x7f) as u8)
     }
-    #[doc = "Bits 8:13 - Rx FIFO 0 Get Index"]
+    #[doc = "Bits 8:13 - Rx FIFO Get Index"]
     #[inline(always)]
-    pub fn f0gi(&self) -> F0GI_R {
-        F0GI_R::new(((self.bits >> 8) & 0x3f) as u8)
+    pub fn fgi(&self) -> FGI_R {
+        FGI_R::new(((self.bits >> 8) & 0x3f) as u8)
     }
-    #[doc = "Bits 16:21 - Rx FIFO 0 Put Index"]
+    #[doc = "Bits 16:21 - Rx FIFO Put Index"]
     #[inline(always)]
-    pub fn f0pi(&self) -> F0PI_R {
-        F0PI_R::new(((self.bits >> 16) & 0x3f) as u8)
+    pub fn fpi(&self) -> FPI_R {
+        FPI_R::new(((self.bits >> 16) & 0x3f) as u8)
     }
-    #[doc = "Bit 24 - Rx FIFO 0 Full"]
+    #[doc = "Bit 24 - Rx FIFO Full"]
     #[inline(always)]
-    pub fn f0f(&self) -> F0F_R {
-        F0F_R::new(((self.bits >> 24) & 1) != 0)
+    pub fn ff(&self) -> FF_R {
+        FF_R::new(((self.bits >> 24) & 1) != 0)
     }
-    #[doc = "Bit 25 - Rx FIFO 0 Message Lost"]
+    #[doc = "Bit 25 - Rx FIFO Message Lost"]
     #[inline(always)]
-    pub fn rf0l(&self) -> RF0L_R {
-        RF0L_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn rfl(&self) -> RFL_R {
+        RFL_R::new(((self.bits >> 25) & 1) != 0)
     }
 }
-#[doc = "Rx FIFO 0 Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rxf0s::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct RXF0S_SPEC;
-impl crate::RegisterSpec for RXF0S_SPEC {
+#[doc = "Rx FIFO Status\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`rxfs::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct RXFS_SPEC;
+impl crate::RegisterSpec for RXFS_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`rxf0s::R`](R) reader structure"]
-impl crate::Readable for RXF0S_SPEC {}
-#[doc = "`reset()` method sets RXF0S to value 0"]
-impl crate::Resettable for RXF0S_SPEC {
+#[doc = "`read()` method returns [`rxfs::R`](R) reader structure"]
+impl crate::Readable for RXFS_SPEC {}
+#[doc = "`reset()` method sets RXFS to value 0"]
+impl crate::Resettable for RXFS_SPEC {
     const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/rxfs.rs
+++ b/mcan/src/reg/rxfs.rs
@@ -1,133 +1,50 @@
-#[doc = "Register `RXFS` reader"]
-pub struct R(crate::R<RXFS_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<RXFS_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<RXFS_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<RXFS_SPEC>) -> Self {
-        R(reader)
-    }
-}
-#[doc = "Field `FFL` reader - Rx FIFO Fill Level"]
-pub struct FFL_R(crate::FieldReader<u8, u8>);
-impl FFL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        FFL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for FFL_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[doc = "Field `FGI` reader - Rx FIFO Get Index"]
-pub struct FGI_R(crate::FieldReader<u8, u8>);
-impl FGI_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        FGI_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for FGI_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[doc = "Field `FPI` reader - Rx FIFO Put Index"]
-pub struct FPI_R(crate::FieldReader<u8, u8>);
-impl FPI_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        FPI_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for FPI_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[doc = "Field `FF` reader - Rx FIFO Full"]
-pub struct FF_R(crate::FieldReader<bool, bool>);
-impl FF_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        FF_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for FF_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[doc = "Field `RFL` reader - Rx FIFO Message Lost"]
-pub struct RFL_R(crate::FieldReader<bool, bool>);
-impl RFL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RFL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RFL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+#[doc = "Register `RXF0S` reader"]
+pub type R = crate::R<RXF0S_SPEC>;
+#[doc = "Field `F0FL` reader - Rx FIFO 0 Fill Level"]
+pub type F0FL_R = crate::FieldReader;
+#[doc = "Field `F0GI` reader - Rx FIFO 0 Get Index"]
+pub type F0GI_R = crate::FieldReader;
+#[doc = "Field `F0PI` reader - Rx FIFO 0 Put Index"]
+pub type F0PI_R = crate::FieldReader;
+#[doc = "Field `F0F` reader - Rx FIFO 0 Full"]
+pub type F0F_R = crate::BitReader;
+#[doc = "Field `RF0L` reader - Rx FIFO 0 Message Lost"]
+pub type RF0L_R = crate::BitReader;
 impl R {
-    #[doc = "Bits 0:6 - Rx FIFO Fill Level"]
+    #[doc = "Bits 0:6 - Rx FIFO 0 Fill Level"]
     #[inline(always)]
-    pub fn ffl(&self) -> FFL_R {
-        FFL_R::new((self.bits & 0x7f) as u8)
+    pub fn f0fl(&self) -> F0FL_R {
+        F0FL_R::new((self.bits & 0x7f) as u8)
     }
-    #[doc = "Bits 8:13 - Rx FIFO Get Index"]
+    #[doc = "Bits 8:13 - Rx FIFO 0 Get Index"]
     #[inline(always)]
-    pub fn fgi(&self) -> FGI_R {
-        FGI_R::new(((self.bits >> 8) & 0x3f) as u8)
+    pub fn f0gi(&self) -> F0GI_R {
+        F0GI_R::new(((self.bits >> 8) & 0x3f) as u8)
     }
-    #[doc = "Bits 16:21 - Rx FIFO Put Index"]
+    #[doc = "Bits 16:21 - Rx FIFO 0 Put Index"]
     #[inline(always)]
-    pub fn fpi(&self) -> FPI_R {
-        FPI_R::new(((self.bits >> 16) & 0x3f) as u8)
+    pub fn f0pi(&self) -> F0PI_R {
+        F0PI_R::new(((self.bits >> 16) & 0x3f) as u8)
     }
-    #[doc = "Bit 24 - Rx FIFO Full"]
+    #[doc = "Bit 24 - Rx FIFO 0 Full"]
     #[inline(always)]
-    pub fn ff(&self) -> FF_R {
-        FF_R::new(((self.bits >> 24) & 0x01) != 0)
+    pub fn f0f(&self) -> F0F_R {
+        F0F_R::new(((self.bits >> 24) & 1) != 0)
     }
-    #[doc = "Bit 25 - Rx FIFO Message Lost"]
+    #[doc = "Bit 25 - Rx FIFO 0 Message Lost"]
     #[inline(always)]
-    pub fn rfl(&self) -> RFL_R {
-        RFL_R::new(((self.bits >> 25) & 0x01) != 0)
+    pub fn rf0l(&self) -> RF0L_R {
+        RF0L_R::new(((self.bits >> 25) & 1) != 0)
     }
 }
-#[doc = "Rx FIFO Status\n\nThis register you can [`read`](crate::reg::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxfs](index.html) module"]
-pub struct RXFS_SPEC;
-impl crate::RegisterSpec for RXFS_SPEC {
+#[doc = "Rx FIFO 0 Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rxf0s::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct RXF0S_SPEC;
+impl crate::RegisterSpec for RXF0S_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [rxfs::R](R) reader structure"]
-impl crate::Readable for RXFS_SPEC {
-    type Reader = R;
-}
-#[doc = "`reset()` method sets RXFS to value 0"]
-impl crate::Resettable for RXFS_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+#[doc = "`read()` method returns [`rxf0s::R`](R) reader structure"]
+impl crate::Readable for RXF0S_SPEC {}
+#[doc = "`reset()` method sets RXF0S to value 0"]
+impl crate::Resettable for RXF0S_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/sidfc.rs
+++ b/mcan/src/reg/sidfc.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Standard ID Filter Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`sidfc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`sidfc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Standard ID Filter Configuration\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`sidfc::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`sidfc::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct SIDFC_SPEC;
 impl crate::RegisterSpec for SIDFC_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/sidfc.rs
+++ b/mcan/src/reg/sidfc.rs
@@ -1,93 +1,15 @@
 #[doc = "Register `SIDFC` reader"]
-pub struct R(crate::R<SIDFC_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<SIDFC_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<SIDFC_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<SIDFC_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<SIDFC_SPEC>;
 #[doc = "Register `SIDFC` writer"]
-pub struct W(crate::W<SIDFC_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<SIDFC_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<SIDFC_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<SIDFC_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<SIDFC_SPEC>;
 #[doc = "Field `FLSSA` reader - Filter List Standard Start Address"]
-pub struct FLSSA_R(crate::FieldReader<u16, u16>);
-impl FLSSA_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u16) -> Self {
-        FLSSA_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for FLSSA_R {
-    type Target = crate::FieldReader<u16, u16>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type FLSSA_R = crate::FieldReader<u16>;
 #[doc = "Field `FLSSA` writer - Filter List Standard Start Address"]
-pub struct FLSSA_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> FLSSA_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u16) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0xffff) | (value as u32 & 0xffff);
-        self.w
-    }
-}
+pub type FLSSA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
 #[doc = "Field `LSS` reader - List Size Standard"]
-pub struct LSS_R(crate::FieldReader<u8, u8>);
-impl LSS_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        LSS_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for LSS_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type LSS_R = crate::FieldReader;
 #[doc = "Field `LSS` writer - List Size Standard"]
-pub struct LSS_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> LSS_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0xff << 16)) | ((value as u32 & 0xff) << 16);
-        self.w
-    }
-}
+pub type LSS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
 impl R {
     #[doc = "Bits 0:15 - Filter List Standard Start Address"]
     #[inline(always)]
@@ -103,38 +25,40 @@ impl R {
 impl W {
     #[doc = "Bits 0:15 - Filter List Standard Start Address"]
     #[inline(always)]
-    pub fn flssa(&mut self) -> FLSSA_W {
-        FLSSA_W { w: self }
+    #[must_use]
+    pub fn flssa(&mut self) -> FLSSA_W<SIDFC_SPEC, 0> {
+        FLSSA_W::new(self)
     }
     #[doc = "Bits 16:23 - List Size Standard"]
     #[inline(always)]
-    pub fn lss(&mut self) -> LSS_W {
-        LSS_W { w: self }
+    #[must_use]
+    pub fn lss(&mut self) -> LSS_W<SIDFC_SPEC, 16> {
+        LSS_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Standard ID Filter Configuration\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sidfc](index.html) module"]
+#[doc = "Standard ID Filter Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`sidfc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`sidfc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct SIDFC_SPEC;
 impl crate::RegisterSpec for SIDFC_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [sidfc::R](R) reader structure"]
-impl crate::Readable for SIDFC_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [sidfc::W](W) writer structure"]
+#[doc = "`read()` method returns [`sidfc::R`](R) reader structure"]
+impl crate::Readable for SIDFC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`sidfc::W`](W) writer structure"]
 impl crate::Writable for SIDFC_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets SIDFC to value 0"]
 impl crate::Resettable for SIDFC_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/tdcr.rs
+++ b/mcan/src/reg/tdcr.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Extended ID Filter Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`tdcr::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`tdcr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Transmitter Delay Compensation\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`tdcr::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`tdcr::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TDCR_SPEC;
 impl crate::RegisterSpec for TDCR_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/tdcr.rs
+++ b/mcan/src/reg/tdcr.rs
@@ -1,93 +1,15 @@
 #[doc = "Register `TDCR` reader"]
-pub struct R(crate::R<TDCR_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<TDCR_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<TDCR_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<TDCR_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<TDCR_SPEC>;
 #[doc = "Register `TDCR` writer"]
-pub struct W(crate::W<TDCR_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<TDCR_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<TDCR_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<TDCR_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<TDCR_SPEC>;
 #[doc = "Field `TDCF` reader - Transmitter Delay Compensation Filter Length"]
-pub struct TDCF_R(crate::FieldReader<u8, u8>);
-impl TDCF_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        TDCF_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TDCF_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TDCF_R = crate::FieldReader;
 #[doc = "Field `TDCF` writer - Transmitter Delay Compensation Filter Length"]
-pub struct TDCF_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TDCF_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x7f) | (value as u32 & 0x7f);
-        self.w
-    }
-}
+pub type TDCF_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
 #[doc = "Field `TDCO` reader - Transmitter Delay Compensation Offset"]
-pub struct TDCO_R(crate::FieldReader<u8, u8>);
-impl TDCO_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        TDCO_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TDCO_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TDCO_R = crate::FieldReader;
 #[doc = "Field `TDCO` writer - Transmitter Delay Compensation Offset"]
-pub struct TDCO_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TDCO_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x7f << 8)) | ((value as u32 & 0x7f) << 8);
-        self.w
-    }
-}
+pub type TDCO_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
 impl R {
     #[doc = "Bits 0:6 - Transmitter Delay Compensation Filter Length"]
     #[inline(always)]
@@ -103,38 +25,40 @@ impl R {
 impl W {
     #[doc = "Bits 0:6 - Transmitter Delay Compensation Filter Length"]
     #[inline(always)]
-    pub fn tdcf(&mut self) -> TDCF_W {
-        TDCF_W { w: self }
+    #[must_use]
+    pub fn tdcf(&mut self) -> TDCF_W<TDCR_SPEC, 0> {
+        TDCF_W::new(self)
     }
     #[doc = "Bits 8:14 - Transmitter Delay Compensation Offset"]
     #[inline(always)]
-    pub fn tdco(&mut self) -> TDCO_W {
-        TDCO_W { w: self }
+    #[must_use]
+    pub fn tdco(&mut self) -> TDCO_W<TDCR_SPEC, 8> {
+        TDCO_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Transmitter Delay Compensation\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tdcr](index.html) module"]
+#[doc = "Extended ID Filter Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`tdcr::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`tdcr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TDCR_SPEC;
 impl crate::RegisterSpec for TDCR_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [tdcr::R](R) reader structure"]
-impl crate::Readable for TDCR_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [tdcr::W](W) writer structure"]
+#[doc = "`read()` method returns [`tdcr::R`](R) reader structure"]
+impl crate::Readable for TDCR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`tdcr::W`](W) writer structure"]
 impl crate::Writable for TDCR_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets TDCR to value 0"]
 impl crate::Resettable for TDCR_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/test.rs
+++ b/mcan/src/reg/test.rs
@@ -142,7 +142,7 @@ impl W {
         self
     }
 }
-#[doc = "Test\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`test::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`test::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Test\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`test::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`test::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TEST_SPEC;
 impl crate::RegisterSpec for TEST_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/test.rs
+++ b/mcan/src/reg/test.rs
@@ -1,80 +1,17 @@
 #[doc = "Register `TEST` reader"]
-pub struct R(crate::R<TEST_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<TEST_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<TEST_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<TEST_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<TEST_SPEC>;
 #[doc = "Register `TEST` writer"]
-pub struct W(crate::W<TEST_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<TEST_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<TEST_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<TEST_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<TEST_SPEC>;
 #[doc = "Field `LBCK` reader - Loop Back Mode"]
-pub struct LBCK_R(crate::FieldReader<bool, bool>);
-impl LBCK_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        LBCK_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for LBCK_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type LBCK_R = crate::BitReader;
 #[doc = "Field `LBCK` writer - Loop Back Mode"]
-pub struct LBCK_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> LBCK_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 4)) | ((value as u32 & 0x01) << 4);
-        self.w
-    }
-}
+pub type LBCK_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `TX` reader - Control of Transmit Pin"]
+pub type TX_R = crate::FieldReader<TXSELECT_A>;
 #[doc = "Control of Transmit Pin\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
-pub enum TX_A {
+pub enum TXSELECT_A {
     #[doc = "0: TX controlled by CAN core"]
     CORE = 0,
     #[doc = "1: TX monitoring sample point"]
@@ -84,189 +21,140 @@ pub enum TX_A {
     #[doc = "3: Recessive (1) level at pin CAN_TX"]
     RECESSIVE = 3,
 }
-impl From<TX_A> for u8 {
+impl From<TXSELECT_A> for u8 {
     #[inline(always)]
-    fn from(variant: TX_A) -> Self {
+    fn from(variant: TXSELECT_A) -> Self {
         variant as _
     }
 }
-#[doc = "Field `TX` reader - Control of Transmit Pin"]
-pub struct TX_R(crate::FieldReader<u8, TX_A>);
+impl crate::FieldSpec for TXSELECT_A {
+    type Ux = u8;
+}
 impl TX_R {
+    #[doc = "Get enumerated values variant"]
     #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        TX_R(crate::FieldReader::new(bits))
-    }
-    #[doc = r"Get enumerated values variant"]
-    #[inline(always)]
-    pub fn variant(&self) -> TX_A {
+    pub const fn variant(&self) -> TXSELECT_A {
         match self.bits {
-            0 => TX_A::CORE,
-            1 => TX_A::SAMPLE,
-            2 => TX_A::DOMINANT,
-            3 => TX_A::RECESSIVE,
+            0 => TXSELECT_A::CORE,
+            1 => TXSELECT_A::SAMPLE,
+            2 => TXSELECT_A::DOMINANT,
+            3 => TXSELECT_A::RECESSIVE,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `CORE`"]
-    #[inline(always)]
-    pub fn is_core(&self) -> bool {
-        **self == TX_A::CORE
-    }
-    #[doc = "Checks if the value of the field is `SAMPLE`"]
-    #[inline(always)]
-    pub fn is_sample(&self) -> bool {
-        **self == TX_A::SAMPLE
-    }
-    #[doc = "Checks if the value of the field is `DOMINANT`"]
-    #[inline(always)]
-    pub fn is_dominant(&self) -> bool {
-        **self == TX_A::DOMINANT
-    }
-    #[doc = "Checks if the value of the field is `RECESSIVE`"]
-    #[inline(always)]
-    pub fn is_recessive(&self) -> bool {
-        **self == TX_A::RECESSIVE
-    }
-}
-impl core::ops::Deref for TX_R {
-    type Target = crate::FieldReader<u8, TX_A>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[doc = "Field `TX` writer - Control of Transmit Pin"]
-pub struct TX_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TX_W<'a> {
-    #[doc = r"Writes `variant` to the field"]
-    #[inline(always)]
-    pub fn variant(self, variant: TX_A) -> &'a mut W {
-        self.bits(variant.into())
-    }
     #[doc = "TX controlled by CAN core"]
     #[inline(always)]
-    pub fn core(self) -> &'a mut W {
-        self.variant(TX_A::CORE)
+    pub fn is_core(&self) -> bool {
+        *self == TXSELECT_A::CORE
     }
     #[doc = "TX monitoring sample point"]
     #[inline(always)]
-    pub fn sample(self) -> &'a mut W {
-        self.variant(TX_A::SAMPLE)
+    pub fn is_sample(&self) -> bool {
+        *self == TXSELECT_A::SAMPLE
     }
     #[doc = "Dominant (0) level at pin CAN_TX"]
     #[inline(always)]
-    pub fn dominant(self) -> &'a mut W {
-        self.variant(TX_A::DOMINANT)
+    pub fn is_dominant(&self) -> bool {
+        *self == TXSELECT_A::DOMINANT
     }
     #[doc = "Recessive (1) level at pin CAN_TX"]
     #[inline(always)]
-    pub fn recessive(self) -> &'a mut W {
-        self.variant(TX_A::RECESSIVE)
+    pub fn is_recessive(&self) -> bool {
+        *self == TXSELECT_A::RECESSIVE
     }
-    #[doc = r"Writes raw bits to the field"]
+}
+#[doc = "Field `TX` writer - Control of Transmit Pin"]
+pub type TX_W<'a, REG, const O: u8> = crate::FieldWriterSafe<'a, REG, 2, O, TXSELECT_A>;
+impl<'a, REG, const O: u8> TX_W<'a, REG, O>
+where
+    REG: crate::Writable + crate::RegisterSpec,
+    REG::Ux: From<u8>,
+{
+    #[doc = "TX controlled by CAN core"]
     #[inline(always)]
-    pub fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x03 << 5)) | ((value as u32 & 0x03) << 5);
-        self.w
+    pub fn core(self) -> &'a mut crate::W<REG> {
+        self.variant(TXSELECT_A::CORE)
+    }
+    #[doc = "TX monitoring sample point"]
+    #[inline(always)]
+    pub fn sample(self) -> &'a mut crate::W<REG> {
+        self.variant(TXSELECT_A::SAMPLE)
+    }
+    #[doc = "Dominant (0) level at pin CAN_TX"]
+    #[inline(always)]
+    pub fn dominant(self) -> &'a mut crate::W<REG> {
+        self.variant(TXSELECT_A::DOMINANT)
+    }
+    #[doc = "Recessive (1) level at pin CAN_TX"]
+    #[inline(always)]
+    pub fn recessive(self) -> &'a mut crate::W<REG> {
+        self.variant(TXSELECT_A::RECESSIVE)
     }
 }
 #[doc = "Field `RX` reader - Receive Pin"]
-pub struct RX_R(crate::FieldReader<bool, bool>);
-impl RX_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        RX_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for RX_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type RX_R = crate::BitReader;
 #[doc = "Field `RX` writer - Receive Pin"]
-pub struct RX_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> RX_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 7)) | ((value as u32 & 0x01) << 7);
-        self.w
-    }
-}
+pub type RX_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
     #[doc = "Bit 4 - Loop Back Mode"]
     #[inline(always)]
     pub fn lbck(&self) -> LBCK_R {
-        LBCK_R::new(((self.bits >> 4) & 0x01) != 0)
+        LBCK_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bits 5:6 - Control of Transmit Pin"]
     #[inline(always)]
     pub fn tx(&self) -> TX_R {
-        TX_R::new(((self.bits >> 5) & 0x03) as u8)
+        TX_R::new(((self.bits >> 5) & 3) as u8)
     }
     #[doc = "Bit 7 - Receive Pin"]
     #[inline(always)]
     pub fn rx(&self) -> RX_R {
-        RX_R::new(((self.bits >> 7) & 0x01) != 0)
+        RX_R::new(((self.bits >> 7) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 4 - Loop Back Mode"]
     #[inline(always)]
-    pub fn lbck(&mut self) -> LBCK_W {
-        LBCK_W { w: self }
+    #[must_use]
+    pub fn lbck(&mut self) -> LBCK_W<TEST_SPEC, 4> {
+        LBCK_W::new(self)
     }
     #[doc = "Bits 5:6 - Control of Transmit Pin"]
     #[inline(always)]
-    pub fn tx(&mut self) -> TX_W {
-        TX_W { w: self }
+    #[must_use]
+    pub fn tx(&mut self) -> TX_W<TEST_SPEC, 5> {
+        TX_W::new(self)
     }
     #[doc = "Bit 7 - Receive Pin"]
     #[inline(always)]
-    pub fn rx(&mut self) -> RX_W {
-        RX_W { w: self }
+    #[must_use]
+    pub fn rx(&mut self) -> RX_W<TEST_SPEC, 7> {
+        RX_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Test\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [test](index.html) module"]
+#[doc = "Test\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`test::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`test::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TEST_SPEC;
 impl crate::RegisterSpec for TEST_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [test::R](R) reader structure"]
-impl crate::Readable for TEST_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [test::W](W) writer structure"]
+#[doc = "`read()` method returns [`test::R`](R) reader structure"]
+impl crate::Readable for TEST_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`test::W`](W) writer structure"]
 impl crate::Writable for TEST_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets TEST to value 0"]
 impl crate::Resettable for TEST_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/tocc.rs
+++ b/mcan/src/reg/tocc.rs
@@ -142,7 +142,7 @@ impl W {
         self
     }
 }
-#[doc = "Timeout Counter Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`tocc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`tocc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Timeout Counter Configuration\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`tocc::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`tocc::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TOCC_SPEC;
 impl crate::RegisterSpec for TOCC_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/tocc.rs
+++ b/mcan/src/reg/tocc.rs
@@ -1,80 +1,17 @@
 #[doc = "Register `TOCC` reader"]
-pub struct R(crate::R<TOCC_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<TOCC_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<TOCC_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<TOCC_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<TOCC_SPEC>;
 #[doc = "Register `TOCC` writer"]
-pub struct W(crate::W<TOCC_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<TOCC_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<TOCC_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<TOCC_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<TOCC_SPEC>;
 #[doc = "Field `ETOC` reader - Enable Timeout Counter"]
-pub struct ETOC_R(crate::FieldReader<bool, bool>);
-impl ETOC_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        ETOC_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for ETOC_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type ETOC_R = crate::BitReader;
 #[doc = "Field `ETOC` writer - Enable Timeout Counter"]
-pub struct ETOC_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> ETOC_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x01) | (value as u32 & 0x01);
-        self.w
-    }
-}
+pub type ETOC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `TOS` reader - Timeout Select"]
+pub type TOS_R = crate::FieldReader<TOSSELECT_A>;
 #[doc = "Timeout Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
-pub enum TOS_A {
+pub enum TOSSELECT_A {
     #[doc = "0: Continuout operation"]
     CONT = 0,
     #[doc = "1: Timeout controlled by TX Event FIFO"]
@@ -84,132 +21,90 @@ pub enum TOS_A {
     #[doc = "3: Timeout controlled by Rx FIFO 1"]
     RXF1 = 3,
 }
-impl From<TOS_A> for u8 {
+impl From<TOSSELECT_A> for u8 {
     #[inline(always)]
-    fn from(variant: TOS_A) -> Self {
+    fn from(variant: TOSSELECT_A) -> Self {
         variant as _
     }
 }
-#[doc = "Field `TOS` reader - Timeout Select"]
-pub struct TOS_R(crate::FieldReader<u8, TOS_A>);
+impl crate::FieldSpec for TOSSELECT_A {
+    type Ux = u8;
+}
 impl TOS_R {
+    #[doc = "Get enumerated values variant"]
     #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        TOS_R(crate::FieldReader::new(bits))
-    }
-    #[doc = r"Get enumerated values variant"]
-    #[inline(always)]
-    pub fn variant(&self) -> TOS_A {
+    pub const fn variant(&self) -> TOSSELECT_A {
         match self.bits {
-            0 => TOS_A::CONT,
-            1 => TOS_A::TXEF,
-            2 => TOS_A::RXF0,
-            3 => TOS_A::RXF1,
+            0 => TOSSELECT_A::CONT,
+            1 => TOSSELECT_A::TXEF,
+            2 => TOSSELECT_A::RXF0,
+            3 => TOSSELECT_A::RXF1,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `CONT`"]
-    #[inline(always)]
-    pub fn is_cont(&self) -> bool {
-        **self == TOS_A::CONT
-    }
-    #[doc = "Checks if the value of the field is `TXEF`"]
-    #[inline(always)]
-    pub fn is_txef(&self) -> bool {
-        **self == TOS_A::TXEF
-    }
-    #[doc = "Checks if the value of the field is `RXF0`"]
-    #[inline(always)]
-    pub fn is_rxf0(&self) -> bool {
-        **self == TOS_A::RXF0
-    }
-    #[doc = "Checks if the value of the field is `RXF1`"]
-    #[inline(always)]
-    pub fn is_rxf1(&self) -> bool {
-        **self == TOS_A::RXF1
-    }
-}
-impl core::ops::Deref for TOS_R {
-    type Target = crate::FieldReader<u8, TOS_A>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[doc = "Field `TOS` writer - Timeout Select"]
-pub struct TOS_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TOS_W<'a> {
-    #[doc = r"Writes `variant` to the field"]
-    #[inline(always)]
-    pub fn variant(self, variant: TOS_A) -> &'a mut W {
-        self.bits(variant.into())
-    }
     #[doc = "Continuout operation"]
     #[inline(always)]
-    pub fn cont(self) -> &'a mut W {
-        self.variant(TOS_A::CONT)
+    pub fn is_cont(&self) -> bool {
+        *self == TOSSELECT_A::CONT
     }
     #[doc = "Timeout controlled by TX Event FIFO"]
     #[inline(always)]
-    pub fn txef(self) -> &'a mut W {
-        self.variant(TOS_A::TXEF)
+    pub fn is_txef(&self) -> bool {
+        *self == TOSSELECT_A::TXEF
     }
     #[doc = "Timeout controlled by Rx FIFO 0"]
     #[inline(always)]
-    pub fn rxf0(self) -> &'a mut W {
-        self.variant(TOS_A::RXF0)
+    pub fn is_rxf0(&self) -> bool {
+        *self == TOSSELECT_A::RXF0
     }
     #[doc = "Timeout controlled by Rx FIFO 1"]
     #[inline(always)]
-    pub fn rxf1(self) -> &'a mut W {
-        self.variant(TOS_A::RXF1)
+    pub fn is_rxf1(&self) -> bool {
+        *self == TOSSELECT_A::RXF1
     }
-    #[doc = r"Writes raw bits to the field"]
+}
+#[doc = "Field `TOS` writer - Timeout Select"]
+pub type TOS_W<'a, REG, const O: u8> = crate::FieldWriterSafe<'a, REG, 2, O, TOSSELECT_A>;
+impl<'a, REG, const O: u8> TOS_W<'a, REG, O>
+where
+    REG: crate::Writable + crate::RegisterSpec,
+    REG::Ux: From<u8>,
+{
+    #[doc = "Continuout operation"]
     #[inline(always)]
-    pub fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x03 << 1)) | ((value as u32 & 0x03) << 1);
-        self.w
+    pub fn cont(self) -> &'a mut crate::W<REG> {
+        self.variant(TOSSELECT_A::CONT)
+    }
+    #[doc = "Timeout controlled by TX Event FIFO"]
+    #[inline(always)]
+    pub fn txef(self) -> &'a mut crate::W<REG> {
+        self.variant(TOSSELECT_A::TXEF)
+    }
+    #[doc = "Timeout controlled by Rx FIFO 0"]
+    #[inline(always)]
+    pub fn rxf0(self) -> &'a mut crate::W<REG> {
+        self.variant(TOSSELECT_A::RXF0)
+    }
+    #[doc = "Timeout controlled by Rx FIFO 1"]
+    #[inline(always)]
+    pub fn rxf1(self) -> &'a mut crate::W<REG> {
+        self.variant(TOSSELECT_A::RXF1)
     }
 }
 #[doc = "Field `TOP` reader - Timeout Period"]
-pub struct TOP_R(crate::FieldReader<u16, u16>);
-impl TOP_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u16) -> Self {
-        TOP_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TOP_R {
-    type Target = crate::FieldReader<u16, u16>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TOP_R = crate::FieldReader<u16>;
 #[doc = "Field `TOP` writer - Timeout Period"]
-pub struct TOP_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TOP_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u16) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0xffff << 16)) | ((value as u32 & 0xffff) << 16);
-        self.w
-    }
-}
+pub type TOP_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
 impl R {
     #[doc = "Bit 0 - Enable Timeout Counter"]
     #[inline(always)]
     pub fn etoc(&self) -> ETOC_R {
-        ETOC_R::new((self.bits & 0x01) != 0)
+        ETOC_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bits 1:2 - Timeout Select"]
     #[inline(always)]
     pub fn tos(&self) -> TOS_R {
-        TOS_R::new(((self.bits >> 1) & 0x03) as u8)
+        TOS_R::new(((self.bits >> 1) & 3) as u8)
     }
     #[doc = "Bits 16:31 - Timeout Period"]
     #[inline(always)]
@@ -220,43 +115,46 @@ impl R {
 impl W {
     #[doc = "Bit 0 - Enable Timeout Counter"]
     #[inline(always)]
-    pub fn etoc(&mut self) -> ETOC_W {
-        ETOC_W { w: self }
+    #[must_use]
+    pub fn etoc(&mut self) -> ETOC_W<TOCC_SPEC, 0> {
+        ETOC_W::new(self)
     }
     #[doc = "Bits 1:2 - Timeout Select"]
     #[inline(always)]
-    pub fn tos(&mut self) -> TOS_W {
-        TOS_W { w: self }
+    #[must_use]
+    pub fn tos(&mut self) -> TOS_W<TOCC_SPEC, 1> {
+        TOS_W::new(self)
     }
     #[doc = "Bits 16:31 - Timeout Period"]
     #[inline(always)]
-    pub fn top(&mut self) -> TOP_W {
-        TOP_W { w: self }
+    #[must_use]
+    pub fn top(&mut self) -> TOP_W<TOCC_SPEC, 16> {
+        TOP_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Timeout Counter Configuration\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tocc](index.html) module"]
+#[doc = "Timeout Counter Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`tocc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`tocc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TOCC_SPEC;
 impl crate::RegisterSpec for TOCC_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [tocc::R](R) reader structure"]
-impl crate::Readable for TOCC_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [tocc::W](W) writer structure"]
+#[doc = "`read()` method returns [`tocc::R`](R) reader structure"]
+impl crate::Readable for TOCC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`tocc::W`](W) writer structure"]
 impl crate::Writable for TOCC_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets TOCC to value 0xffff_0000"]
 impl crate::Resettable for TOCC_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0xffff_0000
-    }
+    const RESET_VALUE: Self::Ux = 0xffff_0000;
 }

--- a/mcan/src/reg/tocv.rs
+++ b/mcan/src/reg/tocv.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Timeout Counter Value\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`tocv::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`tocv::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Timeout Counter Value\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`tocv::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`tocv::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TOCV_SPEC;
 impl crate::RegisterSpec for TOCV_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/tocv.rs
+++ b/mcan/src/reg/tocv.rs
@@ -1,66 +1,11 @@
 #[doc = "Register `TOCV` reader"]
-pub struct R(crate::R<TOCV_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<TOCV_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<TOCV_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<TOCV_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<TOCV_SPEC>;
 #[doc = "Register `TOCV` writer"]
-pub struct W(crate::W<TOCV_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<TOCV_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<TOCV_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<TOCV_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<TOCV_SPEC>;
 #[doc = "Field `TOC` reader - Timeout Counter"]
-pub struct TOC_R(crate::FieldReader<u16, u16>);
-impl TOC_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u16) -> Self {
-        TOC_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TOC_R {
-    type Target = crate::FieldReader<u16, u16>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TOC_R = crate::FieldReader<u16>;
 #[doc = "Field `TOC` writer - Timeout Counter"]
-pub struct TOC_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TOC_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u16) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0xffff) | (value as u32 & 0xffff);
-        self.w
-    }
-}
+pub type TOC_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
 impl R {
     #[doc = "Bits 0:15 - Timeout Counter"]
     #[inline(always)]
@@ -71,33 +16,34 @@ impl R {
 impl W {
     #[doc = "Bits 0:15 - Timeout Counter"]
     #[inline(always)]
-    pub fn toc(&mut self) -> TOC_W {
-        TOC_W { w: self }
+    #[must_use]
+    pub fn toc(&mut self) -> TOC_W<TOCV_SPEC, 0> {
+        TOC_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Timeout Counter Value\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tocv](index.html) module"]
+#[doc = "Timeout Counter Value\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`tocv::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`tocv::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TOCV_SPEC;
 impl crate::RegisterSpec for TOCV_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [tocv::R](R) reader structure"]
-impl crate::Readable for TOCV_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [tocv::W](W) writer structure"]
+#[doc = "`read()` method returns [`tocv::R`](R) reader structure"]
+impl crate::Readable for TOCV_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`tocv::W`](W) writer structure"]
 impl crate::Writable for TOCV_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets TOCV to value 0xffff"]
 impl crate::Resettable for TOCV_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0xffff
-    }
+    const RESET_VALUE: Self::Ux = 0xffff;
 }

--- a/mcan/src/reg/tscc.rs
+++ b/mcan/src/reg/tscc.rs
@@ -1,43 +1,13 @@
 #[doc = "Register `TSCC` reader"]
-pub struct R(crate::R<TSCC_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<TSCC_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<TSCC_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<TSCC_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<TSCC_SPEC>;
 #[doc = "Register `TSCC` writer"]
-pub struct W(crate::W<TSCC_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<TSCC_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<TSCC_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<TSCC_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<TSCC_SPEC>;
+#[doc = "Field `TSS` reader - Timestamp Select"]
+pub type TSS_R = crate::FieldReader<TSSSELECT_A>;
 #[doc = "Timestamp Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
-pub enum TSS_A {
+pub enum TSSSELECT_A {
     #[doc = "0: Timestamp counter value always 0x0000"]
     ZERO = 0,
     #[doc = "1: Timestamp counter value incremented by TCP"]
@@ -45,116 +15,74 @@ pub enum TSS_A {
     #[doc = "2: External timestamp counter value used"]
     EXT = 2,
 }
-impl From<TSS_A> for u8 {
+impl From<TSSSELECT_A> for u8 {
     #[inline(always)]
-    fn from(variant: TSS_A) -> Self {
+    fn from(variant: TSSSELECT_A) -> Self {
         variant as _
     }
 }
-#[doc = "Field `TSS` reader - Timestamp Select"]
-pub struct TSS_R(crate::FieldReader<u8, TSS_A>);
+impl crate::FieldSpec for TSSSELECT_A {
+    type Ux = u8;
+}
 impl TSS_R {
+    #[doc = "Get enumerated values variant"]
     #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        TSS_R(crate::FieldReader::new(bits))
-    }
-    #[doc = r"Get enumerated values variant"]
-    #[inline(always)]
-    pub fn variant(&self) -> Option<TSS_A> {
+    pub const fn variant(&self) -> Option<TSSSELECT_A> {
         match self.bits {
-            0 => Some(TSS_A::ZERO),
-            1 => Some(TSS_A::INC),
-            2 => Some(TSS_A::EXT),
+            0 => Some(TSSSELECT_A::ZERO),
+            1 => Some(TSSSELECT_A::INC),
+            2 => Some(TSSSELECT_A::EXT),
             _ => None,
         }
     }
-    #[doc = "Checks if the value of the field is `ZERO`"]
-    #[inline(always)]
-    pub fn is_zero(&self) -> bool {
-        **self == TSS_A::ZERO
-    }
-    #[doc = "Checks if the value of the field is `INC`"]
-    #[inline(always)]
-    pub fn is_inc(&self) -> bool {
-        **self == TSS_A::INC
-    }
-    #[doc = "Checks if the value of the field is `EXT`"]
-    #[inline(always)]
-    pub fn is_ext(&self) -> bool {
-        **self == TSS_A::EXT
-    }
-}
-impl core::ops::Deref for TSS_R {
-    type Target = crate::FieldReader<u8, TSS_A>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[doc = "Field `TSS` writer - Timestamp Select"]
-pub struct TSS_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TSS_W<'a> {
-    #[doc = r"Writes `variant` to the field"]
-    #[inline(always)]
-    pub fn variant(self, variant: TSS_A) -> &'a mut W {
-        unsafe { self.bits(variant.into()) }
-    }
     #[doc = "Timestamp counter value always 0x0000"]
     #[inline(always)]
-    pub fn zero(self) -> &'a mut W {
-        self.variant(TSS_A::ZERO)
+    pub fn is_zero(&self) -> bool {
+        *self == TSSSELECT_A::ZERO
     }
     #[doc = "Timestamp counter value incremented by TCP"]
     #[inline(always)]
-    pub fn inc(self) -> &'a mut W {
-        self.variant(TSS_A::INC)
+    pub fn is_inc(&self) -> bool {
+        *self == TSSSELECT_A::INC
     }
     #[doc = "External timestamp counter value used"]
     #[inline(always)]
-    pub fn ext(self) -> &'a mut W {
-        self.variant(TSS_A::EXT)
+    pub fn is_ext(&self) -> bool {
+        *self == TSSSELECT_A::EXT
     }
-    #[doc = r"Writes raw bits to the field"]
+}
+#[doc = "Field `TSS` writer - Timestamp Select"]
+pub type TSS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 2, O, TSSSELECT_A>;
+impl<'a, REG, const O: u8> TSS_W<'a, REG, O>
+where
+    REG: crate::Writable + crate::RegisterSpec,
+    REG::Ux: From<u8>,
+{
+    #[doc = "Timestamp counter value always 0x0000"]
     #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x03) | (value as u32 & 0x03);
-        self.w
+    pub fn zero(self) -> &'a mut crate::W<REG> {
+        self.variant(TSSSELECT_A::ZERO)
+    }
+    #[doc = "Timestamp counter value incremented by TCP"]
+    #[inline(always)]
+    pub fn inc(self) -> &'a mut crate::W<REG> {
+        self.variant(TSSSELECT_A::INC)
+    }
+    #[doc = "External timestamp counter value used"]
+    #[inline(always)]
+    pub fn ext(self) -> &'a mut crate::W<REG> {
+        self.variant(TSSSELECT_A::EXT)
     }
 }
 #[doc = "Field `TCP` reader - Timestamp Counter Prescaler"]
-pub struct TCP_R(crate::FieldReader<u8, u8>);
-impl TCP_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        TCP_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TCP_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TCP_R = crate::FieldReader;
 #[doc = "Field `TCP` writer - Timestamp Counter Prescaler"]
-pub struct TCP_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TCP_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x0f << 16)) | ((value as u32 & 0x0f) << 16);
-        self.w
-    }
-}
+pub type TCP_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 4, O>;
 impl R {
     #[doc = "Bits 0:1 - Timestamp Select"]
     #[inline(always)]
     pub fn tss(&self) -> TSS_R {
-        TSS_R::new((self.bits & 0x03) as u8)
+        TSS_R::new((self.bits & 3) as u8)
     }
     #[doc = "Bits 16:19 - Timestamp Counter Prescaler"]
     #[inline(always)]
@@ -165,38 +93,40 @@ impl R {
 impl W {
     #[doc = "Bits 0:1 - Timestamp Select"]
     #[inline(always)]
-    pub fn tss(&mut self) -> TSS_W {
-        TSS_W { w: self }
+    #[must_use]
+    pub fn tss(&mut self) -> TSS_W<TSCC_SPEC, 0> {
+        TSS_W::new(self)
     }
     #[doc = "Bits 16:19 - Timestamp Counter Prescaler"]
     #[inline(always)]
-    pub fn tcp(&mut self) -> TCP_W {
-        TCP_W { w: self }
+    #[must_use]
+    pub fn tcp(&mut self) -> TCP_W<TSCC_SPEC, 16> {
+        TCP_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Timestamp Counter Configuration\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tscc](index.html) module"]
+#[doc = "Timestamp Counter Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`tscc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`tscc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TSCC_SPEC;
 impl crate::RegisterSpec for TSCC_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [tscc::R](R) reader structure"]
-impl crate::Readable for TSCC_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [tscc::W](W) writer structure"]
+#[doc = "`read()` method returns [`tscc::R`](R) reader structure"]
+impl crate::Readable for TSCC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`tscc::W`](W) writer structure"]
 impl crate::Writable for TSCC_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets TSCC to value 0"]
 impl crate::Resettable for TSCC_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/tscc.rs
+++ b/mcan/src/reg/tscc.rs
@@ -114,7 +114,7 @@ impl W {
         self
     }
 }
-#[doc = "Timestamp Counter Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`tscc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`tscc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Timestamp Counter Configuration\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`tscc::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`tscc::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TSCC_SPEC;
 impl crate::RegisterSpec for TSCC_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/tscv.rs
+++ b/mcan/src/reg/tscv.rs
@@ -1,33 +1,7 @@
 #[doc = "Register `TSCV` reader"]
-pub struct R(crate::R<TSCV_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<TSCV_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<TSCV_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<TSCV_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<TSCV_SPEC>;
 #[doc = "Field `TSC` reader - Timestamp Counter"]
-pub struct TSC_R(crate::FieldReader<u16, u16>);
-impl TSC_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u16) -> Self {
-        TSC_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TSC_R {
-    type Target = crate::FieldReader<u16, u16>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TSC_R = crate::FieldReader<u16>;
 impl R {
     #[doc = "Bits 0:15 - Timestamp Counter"]
     #[inline(always)]
@@ -35,19 +9,14 @@ impl R {
         TSC_R::new((self.bits & 0xffff) as u16)
     }
 }
-#[doc = "Timestamp Counter Value\n\nThis register you can [`read`](crate::reg::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tscv](index.html) module"]
+#[doc = "Timestamp Counter Value\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`tscv::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TSCV_SPEC;
 impl crate::RegisterSpec for TSCV_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [tscv::R](R) reader structure"]
-impl crate::Readable for TSCV_SPEC {
-    type Reader = R;
-}
+#[doc = "`read()` method returns [`tscv::R`](R) reader structure"]
+impl crate::Readable for TSCV_SPEC {}
 #[doc = "`reset()` method sets TSCV to value 0"]
 impl crate::Resettable for TSCV_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/tscv.rs
+++ b/mcan/src/reg/tscv.rs
@@ -9,7 +9,7 @@ impl R {
         TSC_R::new((self.bits & 0xffff) as u16)
     }
 }
-#[doc = "Timestamp Counter Value\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`tscv::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Timestamp Counter Value\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`tscv::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TSCV_SPEC;
 impl crate::RegisterSpec for TSCV_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/txbar.rs
+++ b/mcan/src/reg/txbar.rs
@@ -1,1570 +1,514 @@
 #[doc = "Register `TXBAR` reader"]
-pub struct R(crate::R<TXBAR_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<TXBAR_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<TXBAR_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<TXBAR_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<TXBAR_SPEC>;
 #[doc = "Register `TXBAR` writer"]
-pub struct W(crate::W<TXBAR_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<TXBAR_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<TXBAR_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<TXBAR_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<TXBAR_SPEC>;
 #[doc = "Field `AR0` reader - Add Request 0"]
-pub struct AR0_R(crate::FieldReader<bool, bool>);
-impl AR0_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR0_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR0_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR0_R = crate::BitReader;
 #[doc = "Field `AR0` writer - Add Request 0"]
-pub struct AR0_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR0_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x01) | (value as u32 & 0x01);
-        self.w
-    }
-}
+pub type AR0_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR1` reader - Add Request 1"]
-pub struct AR1_R(crate::FieldReader<bool, bool>);
-impl AR1_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR1_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR1_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR1_R = crate::BitReader;
 #[doc = "Field `AR1` writer - Add Request 1"]
-pub struct AR1_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR1_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 1)) | ((value as u32 & 0x01) << 1);
-        self.w
-    }
-}
+pub type AR1_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR2` reader - Add Request 2"]
-pub struct AR2_R(crate::FieldReader<bool, bool>);
-impl AR2_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR2_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR2_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR2_R = crate::BitReader;
 #[doc = "Field `AR2` writer - Add Request 2"]
-pub struct AR2_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR2_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 2)) | ((value as u32 & 0x01) << 2);
-        self.w
-    }
-}
+pub type AR2_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR3` reader - Add Request 3"]
-pub struct AR3_R(crate::FieldReader<bool, bool>);
-impl AR3_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR3_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR3_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR3_R = crate::BitReader;
 #[doc = "Field `AR3` writer - Add Request 3"]
-pub struct AR3_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR3_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 3)) | ((value as u32 & 0x01) << 3);
-        self.w
-    }
-}
+pub type AR3_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR4` reader - Add Request 4"]
-pub struct AR4_R(crate::FieldReader<bool, bool>);
-impl AR4_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR4_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR4_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR4_R = crate::BitReader;
 #[doc = "Field `AR4` writer - Add Request 4"]
-pub struct AR4_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR4_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 4)) | ((value as u32 & 0x01) << 4);
-        self.w
-    }
-}
+pub type AR4_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR5` reader - Add Request 5"]
-pub struct AR5_R(crate::FieldReader<bool, bool>);
-impl AR5_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR5_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR5_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR5_R = crate::BitReader;
 #[doc = "Field `AR5` writer - Add Request 5"]
-pub struct AR5_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR5_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 5)) | ((value as u32 & 0x01) << 5);
-        self.w
-    }
-}
+pub type AR5_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR6` reader - Add Request 6"]
-pub struct AR6_R(crate::FieldReader<bool, bool>);
-impl AR6_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR6_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR6_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR6_R = crate::BitReader;
 #[doc = "Field `AR6` writer - Add Request 6"]
-pub struct AR6_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR6_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 6)) | ((value as u32 & 0x01) << 6);
-        self.w
-    }
-}
+pub type AR6_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR7` reader - Add Request 7"]
-pub struct AR7_R(crate::FieldReader<bool, bool>);
-impl AR7_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR7_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR7_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR7_R = crate::BitReader;
 #[doc = "Field `AR7` writer - Add Request 7"]
-pub struct AR7_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR7_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 7)) | ((value as u32 & 0x01) << 7);
-        self.w
-    }
-}
+pub type AR7_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR8` reader - Add Request 8"]
-pub struct AR8_R(crate::FieldReader<bool, bool>);
-impl AR8_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR8_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR8_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR8_R = crate::BitReader;
 #[doc = "Field `AR8` writer - Add Request 8"]
-pub struct AR8_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR8_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 8)) | ((value as u32 & 0x01) << 8);
-        self.w
-    }
-}
+pub type AR8_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR9` reader - Add Request 9"]
-pub struct AR9_R(crate::FieldReader<bool, bool>);
-impl AR9_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR9_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR9_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR9_R = crate::BitReader;
 #[doc = "Field `AR9` writer - Add Request 9"]
-pub struct AR9_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR9_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 9)) | ((value as u32 & 0x01) << 9);
-        self.w
-    }
-}
+pub type AR9_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR10` reader - Add Request 10"]
-pub struct AR10_R(crate::FieldReader<bool, bool>);
-impl AR10_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR10_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR10_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR10_R = crate::BitReader;
 #[doc = "Field `AR10` writer - Add Request 10"]
-pub struct AR10_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR10_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 10)) | ((value as u32 & 0x01) << 10);
-        self.w
-    }
-}
+pub type AR10_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR11` reader - Add Request 11"]
-pub struct AR11_R(crate::FieldReader<bool, bool>);
-impl AR11_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR11_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR11_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR11_R = crate::BitReader;
 #[doc = "Field `AR11` writer - Add Request 11"]
-pub struct AR11_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR11_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 11)) | ((value as u32 & 0x01) << 11);
-        self.w
-    }
-}
+pub type AR11_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR12` reader - Add Request 12"]
-pub struct AR12_R(crate::FieldReader<bool, bool>);
-impl AR12_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR12_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR12_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR12_R = crate::BitReader;
 #[doc = "Field `AR12` writer - Add Request 12"]
-pub struct AR12_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR12_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 12)) | ((value as u32 & 0x01) << 12);
-        self.w
-    }
-}
+pub type AR12_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR13` reader - Add Request 13"]
-pub struct AR13_R(crate::FieldReader<bool, bool>);
-impl AR13_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR13_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR13_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR13_R = crate::BitReader;
 #[doc = "Field `AR13` writer - Add Request 13"]
-pub struct AR13_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR13_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 13)) | ((value as u32 & 0x01) << 13);
-        self.w
-    }
-}
+pub type AR13_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR14` reader - Add Request 14"]
-pub struct AR14_R(crate::FieldReader<bool, bool>);
-impl AR14_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR14_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR14_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR14_R = crate::BitReader;
 #[doc = "Field `AR14` writer - Add Request 14"]
-pub struct AR14_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR14_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 14)) | ((value as u32 & 0x01) << 14);
-        self.w
-    }
-}
+pub type AR14_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR15` reader - Add Request 15"]
-pub struct AR15_R(crate::FieldReader<bool, bool>);
-impl AR15_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR15_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR15_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR15_R = crate::BitReader;
 #[doc = "Field `AR15` writer - Add Request 15"]
-pub struct AR15_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR15_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 15)) | ((value as u32 & 0x01) << 15);
-        self.w
-    }
-}
+pub type AR15_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR16` reader - Add Request 16"]
-pub struct AR16_R(crate::FieldReader<bool, bool>);
-impl AR16_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR16_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR16_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR16_R = crate::BitReader;
 #[doc = "Field `AR16` writer - Add Request 16"]
-pub struct AR16_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR16_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 16)) | ((value as u32 & 0x01) << 16);
-        self.w
-    }
-}
+pub type AR16_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR17` reader - Add Request 17"]
-pub struct AR17_R(crate::FieldReader<bool, bool>);
-impl AR17_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR17_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR17_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR17_R = crate::BitReader;
 #[doc = "Field `AR17` writer - Add Request 17"]
-pub struct AR17_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR17_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 17)) | ((value as u32 & 0x01) << 17);
-        self.w
-    }
-}
+pub type AR17_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR18` reader - Add Request 18"]
-pub struct AR18_R(crate::FieldReader<bool, bool>);
-impl AR18_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR18_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR18_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR18_R = crate::BitReader;
 #[doc = "Field `AR18` writer - Add Request 18"]
-pub struct AR18_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR18_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 18)) | ((value as u32 & 0x01) << 18);
-        self.w
-    }
-}
+pub type AR18_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR19` reader - Add Request 19"]
-pub struct AR19_R(crate::FieldReader<bool, bool>);
-impl AR19_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR19_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR19_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR19_R = crate::BitReader;
 #[doc = "Field `AR19` writer - Add Request 19"]
-pub struct AR19_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR19_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 19)) | ((value as u32 & 0x01) << 19);
-        self.w
-    }
-}
+pub type AR19_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR20` reader - Add Request 20"]
-pub struct AR20_R(crate::FieldReader<bool, bool>);
-impl AR20_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR20_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR20_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR20_R = crate::BitReader;
 #[doc = "Field `AR20` writer - Add Request 20"]
-pub struct AR20_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR20_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 20)) | ((value as u32 & 0x01) << 20);
-        self.w
-    }
-}
+pub type AR20_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR21` reader - Add Request 21"]
-pub struct AR21_R(crate::FieldReader<bool, bool>);
-impl AR21_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR21_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR21_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR21_R = crate::BitReader;
 #[doc = "Field `AR21` writer - Add Request 21"]
-pub struct AR21_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR21_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 21)) | ((value as u32 & 0x01) << 21);
-        self.w
-    }
-}
+pub type AR21_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR22` reader - Add Request 22"]
-pub struct AR22_R(crate::FieldReader<bool, bool>);
-impl AR22_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR22_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR22_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR22_R = crate::BitReader;
 #[doc = "Field `AR22` writer - Add Request 22"]
-pub struct AR22_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR22_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 22)) | ((value as u32 & 0x01) << 22);
-        self.w
-    }
-}
+pub type AR22_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR23` reader - Add Request 23"]
-pub struct AR23_R(crate::FieldReader<bool, bool>);
-impl AR23_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR23_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR23_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR23_R = crate::BitReader;
 #[doc = "Field `AR23` writer - Add Request 23"]
-pub struct AR23_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR23_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 23)) | ((value as u32 & 0x01) << 23);
-        self.w
-    }
-}
+pub type AR23_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR24` reader - Add Request 24"]
-pub struct AR24_R(crate::FieldReader<bool, bool>);
-impl AR24_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR24_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR24_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR24_R = crate::BitReader;
 #[doc = "Field `AR24` writer - Add Request 24"]
-pub struct AR24_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR24_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 24)) | ((value as u32 & 0x01) << 24);
-        self.w
-    }
-}
+pub type AR24_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR25` reader - Add Request 25"]
-pub struct AR25_R(crate::FieldReader<bool, bool>);
-impl AR25_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR25_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR25_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR25_R = crate::BitReader;
 #[doc = "Field `AR25` writer - Add Request 25"]
-pub struct AR25_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR25_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 25)) | ((value as u32 & 0x01) << 25);
-        self.w
-    }
-}
+pub type AR25_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR26` reader - Add Request 26"]
-pub struct AR26_R(crate::FieldReader<bool, bool>);
-impl AR26_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR26_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR26_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR26_R = crate::BitReader;
 #[doc = "Field `AR26` writer - Add Request 26"]
-pub struct AR26_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR26_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 26)) | ((value as u32 & 0x01) << 26);
-        self.w
-    }
-}
+pub type AR26_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR27` reader - Add Request 27"]
-pub struct AR27_R(crate::FieldReader<bool, bool>);
-impl AR27_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR27_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR27_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR27_R = crate::BitReader;
 #[doc = "Field `AR27` writer - Add Request 27"]
-pub struct AR27_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR27_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 27)) | ((value as u32 & 0x01) << 27);
-        self.w
-    }
-}
+pub type AR27_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR28` reader - Add Request 28"]
-pub struct AR28_R(crate::FieldReader<bool, bool>);
-impl AR28_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR28_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR28_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR28_R = crate::BitReader;
 #[doc = "Field `AR28` writer - Add Request 28"]
-pub struct AR28_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR28_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 28)) | ((value as u32 & 0x01) << 28);
-        self.w
-    }
-}
+pub type AR28_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR29` reader - Add Request 29"]
-pub struct AR29_R(crate::FieldReader<bool, bool>);
-impl AR29_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR29_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR29_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR29_R = crate::BitReader;
 #[doc = "Field `AR29` writer - Add Request 29"]
-pub struct AR29_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR29_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 29)) | ((value as u32 & 0x01) << 29);
-        self.w
-    }
-}
+pub type AR29_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR30` reader - Add Request 30"]
-pub struct AR30_R(crate::FieldReader<bool, bool>);
-impl AR30_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR30_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR30_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR30_R = crate::BitReader;
 #[doc = "Field `AR30` writer - Add Request 30"]
-pub struct AR30_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR30_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 30)) | ((value as u32 & 0x01) << 30);
-        self.w
-    }
-}
+pub type AR30_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `AR31` reader - Add Request 31"]
-pub struct AR31_R(crate::FieldReader<bool, bool>);
-impl AR31_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        AR31_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for AR31_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type AR31_R = crate::BitReader;
 #[doc = "Field `AR31` writer - Add Request 31"]
-pub struct AR31_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> AR31_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 31)) | ((value as u32 & 0x01) << 31);
-        self.w
-    }
-}
+pub type AR31_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
     #[doc = "Bit 0 - Add Request 0"]
     #[inline(always)]
     pub fn ar0(&self) -> AR0_R {
-        AR0_R::new((self.bits & 0x01) != 0)
+        AR0_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - Add Request 1"]
     #[inline(always)]
     pub fn ar1(&self) -> AR1_R {
-        AR1_R::new(((self.bits >> 1) & 0x01) != 0)
+        AR1_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - Add Request 2"]
     #[inline(always)]
     pub fn ar2(&self) -> AR2_R {
-        AR2_R::new(((self.bits >> 2) & 0x01) != 0)
+        AR2_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - Add Request 3"]
     #[inline(always)]
     pub fn ar3(&self) -> AR3_R {
-        AR3_R::new(((self.bits >> 3) & 0x01) != 0)
+        AR3_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - Add Request 4"]
     #[inline(always)]
     pub fn ar4(&self) -> AR4_R {
-        AR4_R::new(((self.bits >> 4) & 0x01) != 0)
+        AR4_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - Add Request 5"]
     #[inline(always)]
     pub fn ar5(&self) -> AR5_R {
-        AR5_R::new(((self.bits >> 5) & 0x01) != 0)
+        AR5_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - Add Request 6"]
     #[inline(always)]
     pub fn ar6(&self) -> AR6_R {
-        AR6_R::new(((self.bits >> 6) & 0x01) != 0)
+        AR6_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - Add Request 7"]
     #[inline(always)]
     pub fn ar7(&self) -> AR7_R {
-        AR7_R::new(((self.bits >> 7) & 0x01) != 0)
+        AR7_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - Add Request 8"]
     #[inline(always)]
     pub fn ar8(&self) -> AR8_R {
-        AR8_R::new(((self.bits >> 8) & 0x01) != 0)
+        AR8_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - Add Request 9"]
     #[inline(always)]
     pub fn ar9(&self) -> AR9_R {
-        AR9_R::new(((self.bits >> 9) & 0x01) != 0)
+        AR9_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - Add Request 10"]
     #[inline(always)]
     pub fn ar10(&self) -> AR10_R {
-        AR10_R::new(((self.bits >> 10) & 0x01) != 0)
+        AR10_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Add Request 11"]
     #[inline(always)]
     pub fn ar11(&self) -> AR11_R {
-        AR11_R::new(((self.bits >> 11) & 0x01) != 0)
+        AR11_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - Add Request 12"]
     #[inline(always)]
     pub fn ar12(&self) -> AR12_R {
-        AR12_R::new(((self.bits >> 12) & 0x01) != 0)
+        AR12_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - Add Request 13"]
     #[inline(always)]
     pub fn ar13(&self) -> AR13_R {
-        AR13_R::new(((self.bits >> 13) & 0x01) != 0)
+        AR13_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - Add Request 14"]
     #[inline(always)]
     pub fn ar14(&self) -> AR14_R {
-        AR14_R::new(((self.bits >> 14) & 0x01) != 0)
+        AR14_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - Add Request 15"]
     #[inline(always)]
     pub fn ar15(&self) -> AR15_R {
-        AR15_R::new(((self.bits >> 15) & 0x01) != 0)
+        AR15_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - Add Request 16"]
     #[inline(always)]
     pub fn ar16(&self) -> AR16_R {
-        AR16_R::new(((self.bits >> 16) & 0x01) != 0)
+        AR16_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - Add Request 17"]
     #[inline(always)]
     pub fn ar17(&self) -> AR17_R {
-        AR17_R::new(((self.bits >> 17) & 0x01) != 0)
+        AR17_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - Add Request 18"]
     #[inline(always)]
     pub fn ar18(&self) -> AR18_R {
-        AR18_R::new(((self.bits >> 18) & 0x01) != 0)
+        AR18_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - Add Request 19"]
     #[inline(always)]
     pub fn ar19(&self) -> AR19_R {
-        AR19_R::new(((self.bits >> 19) & 0x01) != 0)
+        AR19_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - Add Request 20"]
     #[inline(always)]
     pub fn ar20(&self) -> AR20_R {
-        AR20_R::new(((self.bits >> 20) & 0x01) != 0)
+        AR20_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - Add Request 21"]
     #[inline(always)]
     pub fn ar21(&self) -> AR21_R {
-        AR21_R::new(((self.bits >> 21) & 0x01) != 0)
+        AR21_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - Add Request 22"]
     #[inline(always)]
     pub fn ar22(&self) -> AR22_R {
-        AR22_R::new(((self.bits >> 22) & 0x01) != 0)
+        AR22_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - Add Request 23"]
     #[inline(always)]
     pub fn ar23(&self) -> AR23_R {
-        AR23_R::new(((self.bits >> 23) & 0x01) != 0)
+        AR23_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - Add Request 24"]
     #[inline(always)]
     pub fn ar24(&self) -> AR24_R {
-        AR24_R::new(((self.bits >> 24) & 0x01) != 0)
+        AR24_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - Add Request 25"]
     #[inline(always)]
     pub fn ar25(&self) -> AR25_R {
-        AR25_R::new(((self.bits >> 25) & 0x01) != 0)
+        AR25_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - Add Request 26"]
     #[inline(always)]
     pub fn ar26(&self) -> AR26_R {
-        AR26_R::new(((self.bits >> 26) & 0x01) != 0)
+        AR26_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - Add Request 27"]
     #[inline(always)]
     pub fn ar27(&self) -> AR27_R {
-        AR27_R::new(((self.bits >> 27) & 0x01) != 0)
+        AR27_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - Add Request 28"]
     #[inline(always)]
     pub fn ar28(&self) -> AR28_R {
-        AR28_R::new(((self.bits >> 28) & 0x01) != 0)
+        AR28_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - Add Request 29"]
     #[inline(always)]
     pub fn ar29(&self) -> AR29_R {
-        AR29_R::new(((self.bits >> 29) & 0x01) != 0)
+        AR29_R::new(((self.bits >> 29) & 1) != 0)
     }
     #[doc = "Bit 30 - Add Request 30"]
     #[inline(always)]
     pub fn ar30(&self) -> AR30_R {
-        AR30_R::new(((self.bits >> 30) & 0x01) != 0)
+        AR30_R::new(((self.bits >> 30) & 1) != 0)
     }
     #[doc = "Bit 31 - Add Request 31"]
     #[inline(always)]
     pub fn ar31(&self) -> AR31_R {
-        AR31_R::new(((self.bits >> 31) & 0x01) != 0)
+        AR31_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - Add Request 0"]
     #[inline(always)]
-    pub fn ar0(&mut self) -> AR0_W {
-        AR0_W { w: self }
+    #[must_use]
+    pub fn ar0(&mut self) -> AR0_W<TXBAR_SPEC, 0> {
+        AR0_W::new(self)
     }
     #[doc = "Bit 1 - Add Request 1"]
     #[inline(always)]
-    pub fn ar1(&mut self) -> AR1_W {
-        AR1_W { w: self }
+    #[must_use]
+    pub fn ar1(&mut self) -> AR1_W<TXBAR_SPEC, 1> {
+        AR1_W::new(self)
     }
     #[doc = "Bit 2 - Add Request 2"]
     #[inline(always)]
-    pub fn ar2(&mut self) -> AR2_W {
-        AR2_W { w: self }
+    #[must_use]
+    pub fn ar2(&mut self) -> AR2_W<TXBAR_SPEC, 2> {
+        AR2_W::new(self)
     }
     #[doc = "Bit 3 - Add Request 3"]
     #[inline(always)]
-    pub fn ar3(&mut self) -> AR3_W {
-        AR3_W { w: self }
+    #[must_use]
+    pub fn ar3(&mut self) -> AR3_W<TXBAR_SPEC, 3> {
+        AR3_W::new(self)
     }
     #[doc = "Bit 4 - Add Request 4"]
     #[inline(always)]
-    pub fn ar4(&mut self) -> AR4_W {
-        AR4_W { w: self }
+    #[must_use]
+    pub fn ar4(&mut self) -> AR4_W<TXBAR_SPEC, 4> {
+        AR4_W::new(self)
     }
     #[doc = "Bit 5 - Add Request 5"]
     #[inline(always)]
-    pub fn ar5(&mut self) -> AR5_W {
-        AR5_W { w: self }
+    #[must_use]
+    pub fn ar5(&mut self) -> AR5_W<TXBAR_SPEC, 5> {
+        AR5_W::new(self)
     }
     #[doc = "Bit 6 - Add Request 6"]
     #[inline(always)]
-    pub fn ar6(&mut self) -> AR6_W {
-        AR6_W { w: self }
+    #[must_use]
+    pub fn ar6(&mut self) -> AR6_W<TXBAR_SPEC, 6> {
+        AR6_W::new(self)
     }
     #[doc = "Bit 7 - Add Request 7"]
     #[inline(always)]
-    pub fn ar7(&mut self) -> AR7_W {
-        AR7_W { w: self }
+    #[must_use]
+    pub fn ar7(&mut self) -> AR7_W<TXBAR_SPEC, 7> {
+        AR7_W::new(self)
     }
     #[doc = "Bit 8 - Add Request 8"]
     #[inline(always)]
-    pub fn ar8(&mut self) -> AR8_W {
-        AR8_W { w: self }
+    #[must_use]
+    pub fn ar8(&mut self) -> AR8_W<TXBAR_SPEC, 8> {
+        AR8_W::new(self)
     }
     #[doc = "Bit 9 - Add Request 9"]
     #[inline(always)]
-    pub fn ar9(&mut self) -> AR9_W {
-        AR9_W { w: self }
+    #[must_use]
+    pub fn ar9(&mut self) -> AR9_W<TXBAR_SPEC, 9> {
+        AR9_W::new(self)
     }
     #[doc = "Bit 10 - Add Request 10"]
     #[inline(always)]
-    pub fn ar10(&mut self) -> AR10_W {
-        AR10_W { w: self }
+    #[must_use]
+    pub fn ar10(&mut self) -> AR10_W<TXBAR_SPEC, 10> {
+        AR10_W::new(self)
     }
     #[doc = "Bit 11 - Add Request 11"]
     #[inline(always)]
-    pub fn ar11(&mut self) -> AR11_W {
-        AR11_W { w: self }
+    #[must_use]
+    pub fn ar11(&mut self) -> AR11_W<TXBAR_SPEC, 11> {
+        AR11_W::new(self)
     }
     #[doc = "Bit 12 - Add Request 12"]
     #[inline(always)]
-    pub fn ar12(&mut self) -> AR12_W {
-        AR12_W { w: self }
+    #[must_use]
+    pub fn ar12(&mut self) -> AR12_W<TXBAR_SPEC, 12> {
+        AR12_W::new(self)
     }
     #[doc = "Bit 13 - Add Request 13"]
     #[inline(always)]
-    pub fn ar13(&mut self) -> AR13_W {
-        AR13_W { w: self }
+    #[must_use]
+    pub fn ar13(&mut self) -> AR13_W<TXBAR_SPEC, 13> {
+        AR13_W::new(self)
     }
     #[doc = "Bit 14 - Add Request 14"]
     #[inline(always)]
-    pub fn ar14(&mut self) -> AR14_W {
-        AR14_W { w: self }
+    #[must_use]
+    pub fn ar14(&mut self) -> AR14_W<TXBAR_SPEC, 14> {
+        AR14_W::new(self)
     }
     #[doc = "Bit 15 - Add Request 15"]
     #[inline(always)]
-    pub fn ar15(&mut self) -> AR15_W {
-        AR15_W { w: self }
+    #[must_use]
+    pub fn ar15(&mut self) -> AR15_W<TXBAR_SPEC, 15> {
+        AR15_W::new(self)
     }
     #[doc = "Bit 16 - Add Request 16"]
     #[inline(always)]
-    pub fn ar16(&mut self) -> AR16_W {
-        AR16_W { w: self }
+    #[must_use]
+    pub fn ar16(&mut self) -> AR16_W<TXBAR_SPEC, 16> {
+        AR16_W::new(self)
     }
     #[doc = "Bit 17 - Add Request 17"]
     #[inline(always)]
-    pub fn ar17(&mut self) -> AR17_W {
-        AR17_W { w: self }
+    #[must_use]
+    pub fn ar17(&mut self) -> AR17_W<TXBAR_SPEC, 17> {
+        AR17_W::new(self)
     }
     #[doc = "Bit 18 - Add Request 18"]
     #[inline(always)]
-    pub fn ar18(&mut self) -> AR18_W {
-        AR18_W { w: self }
+    #[must_use]
+    pub fn ar18(&mut self) -> AR18_W<TXBAR_SPEC, 18> {
+        AR18_W::new(self)
     }
     #[doc = "Bit 19 - Add Request 19"]
     #[inline(always)]
-    pub fn ar19(&mut self) -> AR19_W {
-        AR19_W { w: self }
+    #[must_use]
+    pub fn ar19(&mut self) -> AR19_W<TXBAR_SPEC, 19> {
+        AR19_W::new(self)
     }
     #[doc = "Bit 20 - Add Request 20"]
     #[inline(always)]
-    pub fn ar20(&mut self) -> AR20_W {
-        AR20_W { w: self }
+    #[must_use]
+    pub fn ar20(&mut self) -> AR20_W<TXBAR_SPEC, 20> {
+        AR20_W::new(self)
     }
     #[doc = "Bit 21 - Add Request 21"]
     #[inline(always)]
-    pub fn ar21(&mut self) -> AR21_W {
-        AR21_W { w: self }
+    #[must_use]
+    pub fn ar21(&mut self) -> AR21_W<TXBAR_SPEC, 21> {
+        AR21_W::new(self)
     }
     #[doc = "Bit 22 - Add Request 22"]
     #[inline(always)]
-    pub fn ar22(&mut self) -> AR22_W {
-        AR22_W { w: self }
+    #[must_use]
+    pub fn ar22(&mut self) -> AR22_W<TXBAR_SPEC, 22> {
+        AR22_W::new(self)
     }
     #[doc = "Bit 23 - Add Request 23"]
     #[inline(always)]
-    pub fn ar23(&mut self) -> AR23_W {
-        AR23_W { w: self }
+    #[must_use]
+    pub fn ar23(&mut self) -> AR23_W<TXBAR_SPEC, 23> {
+        AR23_W::new(self)
     }
     #[doc = "Bit 24 - Add Request 24"]
     #[inline(always)]
-    pub fn ar24(&mut self) -> AR24_W {
-        AR24_W { w: self }
+    #[must_use]
+    pub fn ar24(&mut self) -> AR24_W<TXBAR_SPEC, 24> {
+        AR24_W::new(self)
     }
     #[doc = "Bit 25 - Add Request 25"]
     #[inline(always)]
-    pub fn ar25(&mut self) -> AR25_W {
-        AR25_W { w: self }
+    #[must_use]
+    pub fn ar25(&mut self) -> AR25_W<TXBAR_SPEC, 25> {
+        AR25_W::new(self)
     }
     #[doc = "Bit 26 - Add Request 26"]
     #[inline(always)]
-    pub fn ar26(&mut self) -> AR26_W {
-        AR26_W { w: self }
+    #[must_use]
+    pub fn ar26(&mut self) -> AR26_W<TXBAR_SPEC, 26> {
+        AR26_W::new(self)
     }
     #[doc = "Bit 27 - Add Request 27"]
     #[inline(always)]
-    pub fn ar27(&mut self) -> AR27_W {
-        AR27_W { w: self }
+    #[must_use]
+    pub fn ar27(&mut self) -> AR27_W<TXBAR_SPEC, 27> {
+        AR27_W::new(self)
     }
     #[doc = "Bit 28 - Add Request 28"]
     #[inline(always)]
-    pub fn ar28(&mut self) -> AR28_W {
-        AR28_W { w: self }
+    #[must_use]
+    pub fn ar28(&mut self) -> AR28_W<TXBAR_SPEC, 28> {
+        AR28_W::new(self)
     }
     #[doc = "Bit 29 - Add Request 29"]
     #[inline(always)]
-    pub fn ar29(&mut self) -> AR29_W {
-        AR29_W { w: self }
+    #[must_use]
+    pub fn ar29(&mut self) -> AR29_W<TXBAR_SPEC, 29> {
+        AR29_W::new(self)
     }
     #[doc = "Bit 30 - Add Request 30"]
     #[inline(always)]
-    pub fn ar30(&mut self) -> AR30_W {
-        AR30_W { w: self }
+    #[must_use]
+    pub fn ar30(&mut self) -> AR30_W<TXBAR_SPEC, 30> {
+        AR30_W::new(self)
     }
     #[doc = "Bit 31 - Add Request 31"]
     #[inline(always)]
-    pub fn ar31(&mut self) -> AR31_W {
-        AR31_W { w: self }
+    #[must_use]
+    pub fn ar31(&mut self) -> AR31_W<TXBAR_SPEC, 31> {
+        AR31_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Tx Buffer Add Request\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txbar](index.html) module"]
+#[doc = "Tx Buffer Add Request\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txbar::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`txbar::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXBAR_SPEC;
 impl crate::RegisterSpec for TXBAR_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [txbar::R](R) reader structure"]
-impl crate::Readable for TXBAR_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [txbar::W](W) writer structure"]
+#[doc = "`read()` method returns [`txbar::R`](R) reader structure"]
+impl crate::Readable for TXBAR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`txbar::W`](W) writer structure"]
 impl crate::Writable for TXBAR_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets TXBAR to value 0"]
 impl crate::Resettable for TXBAR_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/txbar.rs
+++ b/mcan/src/reg/txbar.rs
@@ -496,7 +496,7 @@ impl W {
         self
     }
 }
-#[doc = "Tx Buffer Add Request\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txbar::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`txbar::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Tx Buffer Add Request\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`txbar::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`txbar::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXBAR_SPEC;
 impl crate::RegisterSpec for TXBAR_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/txbc.rs
+++ b/mcan/src/reg/txbc.rs
@@ -1,157 +1,23 @@
 #[doc = "Register `TXBC` reader"]
-pub struct R(crate::R<TXBC_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<TXBC_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<TXBC_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<TXBC_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<TXBC_SPEC>;
 #[doc = "Register `TXBC` writer"]
-pub struct W(crate::W<TXBC_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<TXBC_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<TXBC_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<TXBC_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<TXBC_SPEC>;
 #[doc = "Field `TBSA` reader - Tx Buffers Start Address"]
-pub struct TBSA_R(crate::FieldReader<u16, u16>);
-impl TBSA_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u16) -> Self {
-        TBSA_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TBSA_R {
-    type Target = crate::FieldReader<u16, u16>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TBSA_R = crate::FieldReader<u16>;
 #[doc = "Field `TBSA` writer - Tx Buffers Start Address"]
-pub struct TBSA_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TBSA_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u16) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0xffff) | (value as u32 & 0xffff);
-        self.w
-    }
-}
+pub type TBSA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
 #[doc = "Field `NDTB` reader - Number of Dedicated Transmit Buffers"]
-pub struct NDTB_R(crate::FieldReader<u8, u8>);
-impl NDTB_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        NDTB_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for NDTB_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type NDTB_R = crate::FieldReader;
 #[doc = "Field `NDTB` writer - Number of Dedicated Transmit Buffers"]
-pub struct NDTB_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> NDTB_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x3f << 16)) | ((value as u32 & 0x3f) << 16);
-        self.w
-    }
-}
+pub type NDTB_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 6, O>;
 #[doc = "Field `TFQS` reader - Transmit FIFO/Queue Size"]
-pub struct TFQS_R(crate::FieldReader<u8, u8>);
-impl TFQS_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        TFQS_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TFQS_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TFQS_R = crate::FieldReader;
 #[doc = "Field `TFQS` writer - Transmit FIFO/Queue Size"]
-pub struct TFQS_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TFQS_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x3f << 24)) | ((value as u32 & 0x3f) << 24);
-        self.w
-    }
-}
+pub type TFQS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 6, O>;
 #[doc = "Field `TFQM` reader - Tx FIFO/Queue Mode"]
-pub struct TFQM_R(crate::FieldReader<bool, bool>);
-impl TFQM_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TFQM_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TFQM_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TFQM_R = crate::BitReader;
 #[doc = "Field `TFQM` writer - Tx FIFO/Queue Mode"]
-pub struct TFQM_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TFQM_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 30)) | ((value as u32 & 0x01) << 30);
-        self.w
-    }
-}
+pub type TFQM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
     #[doc = "Bits 0:15 - Tx Buffers Start Address"]
     #[inline(always)]
@@ -171,54 +37,58 @@ impl R {
     #[doc = "Bit 30 - Tx FIFO/Queue Mode"]
     #[inline(always)]
     pub fn tfqm(&self) -> TFQM_R {
-        TFQM_R::new(((self.bits >> 30) & 0x01) != 0)
+        TFQM_R::new(((self.bits >> 30) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bits 0:15 - Tx Buffers Start Address"]
     #[inline(always)]
-    pub fn tbsa(&mut self) -> TBSA_W {
-        TBSA_W { w: self }
+    #[must_use]
+    pub fn tbsa(&mut self) -> TBSA_W<TXBC_SPEC, 0> {
+        TBSA_W::new(self)
     }
     #[doc = "Bits 16:21 - Number of Dedicated Transmit Buffers"]
     #[inline(always)]
-    pub fn ndtb(&mut self) -> NDTB_W {
-        NDTB_W { w: self }
+    #[must_use]
+    pub fn ndtb(&mut self) -> NDTB_W<TXBC_SPEC, 16> {
+        NDTB_W::new(self)
     }
     #[doc = "Bits 24:29 - Transmit FIFO/Queue Size"]
     #[inline(always)]
-    pub fn tfqs(&mut self) -> TFQS_W {
-        TFQS_W { w: self }
+    #[must_use]
+    pub fn tfqs(&mut self) -> TFQS_W<TXBC_SPEC, 24> {
+        TFQS_W::new(self)
     }
     #[doc = "Bit 30 - Tx FIFO/Queue Mode"]
     #[inline(always)]
-    pub fn tfqm(&mut self) -> TFQM_W {
-        TFQM_W { w: self }
+    #[must_use]
+    pub fn tfqm(&mut self) -> TFQM_W<TXBC_SPEC, 30> {
+        TFQM_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Tx Buffer Configuration\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txbc](index.html) module"]
+#[doc = "Tx Buffer Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txbc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`txbc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXBC_SPEC;
 impl crate::RegisterSpec for TXBC_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [txbc::R](R) reader structure"]
-impl crate::Readable for TXBC_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [txbc::W](W) writer structure"]
+#[doc = "`read()` method returns [`txbc::R`](R) reader structure"]
+impl crate::Readable for TXBC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`txbc::W`](W) writer structure"]
 impl crate::Writable for TXBC_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets TXBC to value 0"]
 impl crate::Resettable for TXBC_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/txbc.rs
+++ b/mcan/src/reg/txbc.rs
@@ -76,7 +76,7 @@ impl W {
         self
     }
 }
-#[doc = "Tx Buffer Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txbc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`txbc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Tx Buffer Configuration\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`txbc::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`txbc::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXBC_SPEC;
 impl crate::RegisterSpec for TXBC_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/txbcf.rs
+++ b/mcan/src/reg/txbcf.rs
@@ -226,7 +226,7 @@ impl R {
         CF31_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
-#[doc = "Tx Buffer Cancellation Finished\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txbcf::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Tx Buffer Cancellation Finished\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`txbcf::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXBCF_SPEC;
 impl crate::RegisterSpec for TXBCF_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/txbcf.rs
+++ b/mcan/src/reg/txbcf.rs
@@ -1,673 +1,239 @@
 #[doc = "Register `TXBCF` reader"]
-pub struct R(crate::R<TXBCF_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<TXBCF_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<TXBCF_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<TXBCF_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<TXBCF_SPEC>;
 #[doc = "Field `CF0` reader - Tx Buffer Cancellation Finished 0"]
-pub struct CF0_R(crate::FieldReader<bool, bool>);
-impl CF0_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF0_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF0_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF0_R = crate::BitReader;
 #[doc = "Field `CF1` reader - Tx Buffer Cancellation Finished 1"]
-pub struct CF1_R(crate::FieldReader<bool, bool>);
-impl CF1_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF1_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF1_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF1_R = crate::BitReader;
 #[doc = "Field `CF2` reader - Tx Buffer Cancellation Finished 2"]
-pub struct CF2_R(crate::FieldReader<bool, bool>);
-impl CF2_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF2_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF2_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF2_R = crate::BitReader;
 #[doc = "Field `CF3` reader - Tx Buffer Cancellation Finished 3"]
-pub struct CF3_R(crate::FieldReader<bool, bool>);
-impl CF3_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF3_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF3_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF3_R = crate::BitReader;
 #[doc = "Field `CF4` reader - Tx Buffer Cancellation Finished 4"]
-pub struct CF4_R(crate::FieldReader<bool, bool>);
-impl CF4_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF4_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF4_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF4_R = crate::BitReader;
 #[doc = "Field `CF5` reader - Tx Buffer Cancellation Finished 5"]
-pub struct CF5_R(crate::FieldReader<bool, bool>);
-impl CF5_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF5_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF5_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF5_R = crate::BitReader;
 #[doc = "Field `CF6` reader - Tx Buffer Cancellation Finished 6"]
-pub struct CF6_R(crate::FieldReader<bool, bool>);
-impl CF6_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF6_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF6_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF6_R = crate::BitReader;
 #[doc = "Field `CF7` reader - Tx Buffer Cancellation Finished 7"]
-pub struct CF7_R(crate::FieldReader<bool, bool>);
-impl CF7_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF7_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF7_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF7_R = crate::BitReader;
 #[doc = "Field `CF8` reader - Tx Buffer Cancellation Finished 8"]
-pub struct CF8_R(crate::FieldReader<bool, bool>);
-impl CF8_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF8_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF8_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF8_R = crate::BitReader;
 #[doc = "Field `CF9` reader - Tx Buffer Cancellation Finished 9"]
-pub struct CF9_R(crate::FieldReader<bool, bool>);
-impl CF9_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF9_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF9_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF9_R = crate::BitReader;
 #[doc = "Field `CF10` reader - Tx Buffer Cancellation Finished 10"]
-pub struct CF10_R(crate::FieldReader<bool, bool>);
-impl CF10_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF10_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF10_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF10_R = crate::BitReader;
 #[doc = "Field `CF11` reader - Tx Buffer Cancellation Finished 11"]
-pub struct CF11_R(crate::FieldReader<bool, bool>);
-impl CF11_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF11_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF11_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF11_R = crate::BitReader;
 #[doc = "Field `CF12` reader - Tx Buffer Cancellation Finished 12"]
-pub struct CF12_R(crate::FieldReader<bool, bool>);
-impl CF12_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF12_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF12_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF12_R = crate::BitReader;
 #[doc = "Field `CF13` reader - Tx Buffer Cancellation Finished 13"]
-pub struct CF13_R(crate::FieldReader<bool, bool>);
-impl CF13_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF13_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF13_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF13_R = crate::BitReader;
 #[doc = "Field `CF14` reader - Tx Buffer Cancellation Finished 14"]
-pub struct CF14_R(crate::FieldReader<bool, bool>);
-impl CF14_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF14_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF14_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF14_R = crate::BitReader;
 #[doc = "Field `CF15` reader - Tx Buffer Cancellation Finished 15"]
-pub struct CF15_R(crate::FieldReader<bool, bool>);
-impl CF15_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF15_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF15_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF15_R = crate::BitReader;
 #[doc = "Field `CF16` reader - Tx Buffer Cancellation Finished 16"]
-pub struct CF16_R(crate::FieldReader<bool, bool>);
-impl CF16_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF16_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF16_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF16_R = crate::BitReader;
 #[doc = "Field `CF17` reader - Tx Buffer Cancellation Finished 17"]
-pub struct CF17_R(crate::FieldReader<bool, bool>);
-impl CF17_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF17_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF17_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF17_R = crate::BitReader;
 #[doc = "Field `CF18` reader - Tx Buffer Cancellation Finished 18"]
-pub struct CF18_R(crate::FieldReader<bool, bool>);
-impl CF18_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF18_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF18_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF18_R = crate::BitReader;
 #[doc = "Field `CF19` reader - Tx Buffer Cancellation Finished 19"]
-pub struct CF19_R(crate::FieldReader<bool, bool>);
-impl CF19_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF19_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF19_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF19_R = crate::BitReader;
 #[doc = "Field `CF20` reader - Tx Buffer Cancellation Finished 20"]
-pub struct CF20_R(crate::FieldReader<bool, bool>);
-impl CF20_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF20_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF20_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF20_R = crate::BitReader;
 #[doc = "Field `CF21` reader - Tx Buffer Cancellation Finished 21"]
-pub struct CF21_R(crate::FieldReader<bool, bool>);
-impl CF21_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF21_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF21_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF21_R = crate::BitReader;
 #[doc = "Field `CF22` reader - Tx Buffer Cancellation Finished 22"]
-pub struct CF22_R(crate::FieldReader<bool, bool>);
-impl CF22_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF22_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF22_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF22_R = crate::BitReader;
 #[doc = "Field `CF23` reader - Tx Buffer Cancellation Finished 23"]
-pub struct CF23_R(crate::FieldReader<bool, bool>);
-impl CF23_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF23_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF23_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF23_R = crate::BitReader;
 #[doc = "Field `CF24` reader - Tx Buffer Cancellation Finished 24"]
-pub struct CF24_R(crate::FieldReader<bool, bool>);
-impl CF24_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF24_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF24_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF24_R = crate::BitReader;
 #[doc = "Field `CF25` reader - Tx Buffer Cancellation Finished 25"]
-pub struct CF25_R(crate::FieldReader<bool, bool>);
-impl CF25_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF25_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF25_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF25_R = crate::BitReader;
 #[doc = "Field `CF26` reader - Tx Buffer Cancellation Finished 26"]
-pub struct CF26_R(crate::FieldReader<bool, bool>);
-impl CF26_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF26_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF26_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF26_R = crate::BitReader;
 #[doc = "Field `CF27` reader - Tx Buffer Cancellation Finished 27"]
-pub struct CF27_R(crate::FieldReader<bool, bool>);
-impl CF27_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF27_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF27_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF27_R = crate::BitReader;
 #[doc = "Field `CF28` reader - Tx Buffer Cancellation Finished 28"]
-pub struct CF28_R(crate::FieldReader<bool, bool>);
-impl CF28_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF28_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF28_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF28_R = crate::BitReader;
 #[doc = "Field `CF29` reader - Tx Buffer Cancellation Finished 29"]
-pub struct CF29_R(crate::FieldReader<bool, bool>);
-impl CF29_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF29_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF29_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF29_R = crate::BitReader;
 #[doc = "Field `CF30` reader - Tx Buffer Cancellation Finished 30"]
-pub struct CF30_R(crate::FieldReader<bool, bool>);
-impl CF30_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF30_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF30_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF30_R = crate::BitReader;
 #[doc = "Field `CF31` reader - Tx Buffer Cancellation Finished 31"]
-pub struct CF31_R(crate::FieldReader<bool, bool>);
-impl CF31_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CF31_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CF31_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CF31_R = crate::BitReader;
 impl R {
     #[doc = "Bit 0 - Tx Buffer Cancellation Finished 0"]
     #[inline(always)]
     pub fn cf0(&self) -> CF0_R {
-        CF0_R::new((self.bits & 0x01) != 0)
+        CF0_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - Tx Buffer Cancellation Finished 1"]
     #[inline(always)]
     pub fn cf1(&self) -> CF1_R {
-        CF1_R::new(((self.bits >> 1) & 0x01) != 0)
+        CF1_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - Tx Buffer Cancellation Finished 2"]
     #[inline(always)]
     pub fn cf2(&self) -> CF2_R {
-        CF2_R::new(((self.bits >> 2) & 0x01) != 0)
+        CF2_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - Tx Buffer Cancellation Finished 3"]
     #[inline(always)]
     pub fn cf3(&self) -> CF3_R {
-        CF3_R::new(((self.bits >> 3) & 0x01) != 0)
+        CF3_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - Tx Buffer Cancellation Finished 4"]
     #[inline(always)]
     pub fn cf4(&self) -> CF4_R {
-        CF4_R::new(((self.bits >> 4) & 0x01) != 0)
+        CF4_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - Tx Buffer Cancellation Finished 5"]
     #[inline(always)]
     pub fn cf5(&self) -> CF5_R {
-        CF5_R::new(((self.bits >> 5) & 0x01) != 0)
+        CF5_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - Tx Buffer Cancellation Finished 6"]
     #[inline(always)]
     pub fn cf6(&self) -> CF6_R {
-        CF6_R::new(((self.bits >> 6) & 0x01) != 0)
+        CF6_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - Tx Buffer Cancellation Finished 7"]
     #[inline(always)]
     pub fn cf7(&self) -> CF7_R {
-        CF7_R::new(((self.bits >> 7) & 0x01) != 0)
+        CF7_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - Tx Buffer Cancellation Finished 8"]
     #[inline(always)]
     pub fn cf8(&self) -> CF8_R {
-        CF8_R::new(((self.bits >> 8) & 0x01) != 0)
+        CF8_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - Tx Buffer Cancellation Finished 9"]
     #[inline(always)]
     pub fn cf9(&self) -> CF9_R {
-        CF9_R::new(((self.bits >> 9) & 0x01) != 0)
+        CF9_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - Tx Buffer Cancellation Finished 10"]
     #[inline(always)]
     pub fn cf10(&self) -> CF10_R {
-        CF10_R::new(((self.bits >> 10) & 0x01) != 0)
+        CF10_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Tx Buffer Cancellation Finished 11"]
     #[inline(always)]
     pub fn cf11(&self) -> CF11_R {
-        CF11_R::new(((self.bits >> 11) & 0x01) != 0)
+        CF11_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - Tx Buffer Cancellation Finished 12"]
     #[inline(always)]
     pub fn cf12(&self) -> CF12_R {
-        CF12_R::new(((self.bits >> 12) & 0x01) != 0)
+        CF12_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - Tx Buffer Cancellation Finished 13"]
     #[inline(always)]
     pub fn cf13(&self) -> CF13_R {
-        CF13_R::new(((self.bits >> 13) & 0x01) != 0)
+        CF13_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - Tx Buffer Cancellation Finished 14"]
     #[inline(always)]
     pub fn cf14(&self) -> CF14_R {
-        CF14_R::new(((self.bits >> 14) & 0x01) != 0)
+        CF14_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - Tx Buffer Cancellation Finished 15"]
     #[inline(always)]
     pub fn cf15(&self) -> CF15_R {
-        CF15_R::new(((self.bits >> 15) & 0x01) != 0)
+        CF15_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - Tx Buffer Cancellation Finished 16"]
     #[inline(always)]
     pub fn cf16(&self) -> CF16_R {
-        CF16_R::new(((self.bits >> 16) & 0x01) != 0)
+        CF16_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - Tx Buffer Cancellation Finished 17"]
     #[inline(always)]
     pub fn cf17(&self) -> CF17_R {
-        CF17_R::new(((self.bits >> 17) & 0x01) != 0)
+        CF17_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - Tx Buffer Cancellation Finished 18"]
     #[inline(always)]
     pub fn cf18(&self) -> CF18_R {
-        CF18_R::new(((self.bits >> 18) & 0x01) != 0)
+        CF18_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - Tx Buffer Cancellation Finished 19"]
     #[inline(always)]
     pub fn cf19(&self) -> CF19_R {
-        CF19_R::new(((self.bits >> 19) & 0x01) != 0)
+        CF19_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - Tx Buffer Cancellation Finished 20"]
     #[inline(always)]
     pub fn cf20(&self) -> CF20_R {
-        CF20_R::new(((self.bits >> 20) & 0x01) != 0)
+        CF20_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - Tx Buffer Cancellation Finished 21"]
     #[inline(always)]
     pub fn cf21(&self) -> CF21_R {
-        CF21_R::new(((self.bits >> 21) & 0x01) != 0)
+        CF21_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - Tx Buffer Cancellation Finished 22"]
     #[inline(always)]
     pub fn cf22(&self) -> CF22_R {
-        CF22_R::new(((self.bits >> 22) & 0x01) != 0)
+        CF22_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - Tx Buffer Cancellation Finished 23"]
     #[inline(always)]
     pub fn cf23(&self) -> CF23_R {
-        CF23_R::new(((self.bits >> 23) & 0x01) != 0)
+        CF23_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - Tx Buffer Cancellation Finished 24"]
     #[inline(always)]
     pub fn cf24(&self) -> CF24_R {
-        CF24_R::new(((self.bits >> 24) & 0x01) != 0)
+        CF24_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - Tx Buffer Cancellation Finished 25"]
     #[inline(always)]
     pub fn cf25(&self) -> CF25_R {
-        CF25_R::new(((self.bits >> 25) & 0x01) != 0)
+        CF25_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - Tx Buffer Cancellation Finished 26"]
     #[inline(always)]
     pub fn cf26(&self) -> CF26_R {
-        CF26_R::new(((self.bits >> 26) & 0x01) != 0)
+        CF26_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - Tx Buffer Cancellation Finished 27"]
     #[inline(always)]
     pub fn cf27(&self) -> CF27_R {
-        CF27_R::new(((self.bits >> 27) & 0x01) != 0)
+        CF27_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - Tx Buffer Cancellation Finished 28"]
     #[inline(always)]
     pub fn cf28(&self) -> CF28_R {
-        CF28_R::new(((self.bits >> 28) & 0x01) != 0)
+        CF28_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - Tx Buffer Cancellation Finished 29"]
     #[inline(always)]
     pub fn cf29(&self) -> CF29_R {
-        CF29_R::new(((self.bits >> 29) & 0x01) != 0)
+        CF29_R::new(((self.bits >> 29) & 1) != 0)
     }
     #[doc = "Bit 30 - Tx Buffer Cancellation Finished 30"]
     #[inline(always)]
     pub fn cf30(&self) -> CF30_R {
-        CF30_R::new(((self.bits >> 30) & 0x01) != 0)
+        CF30_R::new(((self.bits >> 30) & 1) != 0)
     }
     #[doc = "Bit 31 - Tx Buffer Cancellation Finished 31"]
     #[inline(always)]
     pub fn cf31(&self) -> CF31_R {
-        CF31_R::new(((self.bits >> 31) & 0x01) != 0)
+        CF31_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
-#[doc = "Tx Buffer Cancellation Finished\n\nThis register you can [`read`](crate::reg::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txbcf](index.html) module"]
+#[doc = "Tx Buffer Cancellation Finished\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txbcf::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXBCF_SPEC;
 impl crate::RegisterSpec for TXBCF_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [txbcf::R](R) reader structure"]
-impl crate::Readable for TXBCF_SPEC {
-    type Reader = R;
-}
+#[doc = "`read()` method returns [`txbcf::R`](R) reader structure"]
+impl crate::Readable for TXBCF_SPEC {}
 #[doc = "`reset()` method sets TXBCF to value 0"]
 impl crate::Resettable for TXBCF_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/txbcie.rs
+++ b/mcan/src/reg/txbcie.rs
@@ -1,1570 +1,514 @@
 #[doc = "Register `TXBCIE` reader"]
-pub struct R(crate::R<TXBCIE_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<TXBCIE_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<TXBCIE_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<TXBCIE_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<TXBCIE_SPEC>;
 #[doc = "Register `TXBCIE` writer"]
-pub struct W(crate::W<TXBCIE_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<TXBCIE_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<TXBCIE_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<TXBCIE_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<TXBCIE_SPEC>;
 #[doc = "Field `CFIE0` reader - Cancellation Finished Interrupt Enable 0"]
-pub struct CFIE0_R(crate::FieldReader<bool, bool>);
-impl CFIE0_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE0_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE0_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE0_R = crate::BitReader;
 #[doc = "Field `CFIE0` writer - Cancellation Finished Interrupt Enable 0"]
-pub struct CFIE0_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE0_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x01) | (value as u32 & 0x01);
-        self.w
-    }
-}
+pub type CFIE0_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE1` reader - Cancellation Finished Interrupt Enable 1"]
-pub struct CFIE1_R(crate::FieldReader<bool, bool>);
-impl CFIE1_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE1_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE1_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE1_R = crate::BitReader;
 #[doc = "Field `CFIE1` writer - Cancellation Finished Interrupt Enable 1"]
-pub struct CFIE1_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE1_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 1)) | ((value as u32 & 0x01) << 1);
-        self.w
-    }
-}
+pub type CFIE1_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE2` reader - Cancellation Finished Interrupt Enable 2"]
-pub struct CFIE2_R(crate::FieldReader<bool, bool>);
-impl CFIE2_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE2_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE2_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE2_R = crate::BitReader;
 #[doc = "Field `CFIE2` writer - Cancellation Finished Interrupt Enable 2"]
-pub struct CFIE2_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE2_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 2)) | ((value as u32 & 0x01) << 2);
-        self.w
-    }
-}
+pub type CFIE2_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE3` reader - Cancellation Finished Interrupt Enable 3"]
-pub struct CFIE3_R(crate::FieldReader<bool, bool>);
-impl CFIE3_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE3_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE3_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE3_R = crate::BitReader;
 #[doc = "Field `CFIE3` writer - Cancellation Finished Interrupt Enable 3"]
-pub struct CFIE3_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE3_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 3)) | ((value as u32 & 0x01) << 3);
-        self.w
-    }
-}
+pub type CFIE3_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE4` reader - Cancellation Finished Interrupt Enable 4"]
-pub struct CFIE4_R(crate::FieldReader<bool, bool>);
-impl CFIE4_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE4_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE4_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE4_R = crate::BitReader;
 #[doc = "Field `CFIE4` writer - Cancellation Finished Interrupt Enable 4"]
-pub struct CFIE4_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE4_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 4)) | ((value as u32 & 0x01) << 4);
-        self.w
-    }
-}
+pub type CFIE4_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE5` reader - Cancellation Finished Interrupt Enable 5"]
-pub struct CFIE5_R(crate::FieldReader<bool, bool>);
-impl CFIE5_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE5_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE5_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE5_R = crate::BitReader;
 #[doc = "Field `CFIE5` writer - Cancellation Finished Interrupt Enable 5"]
-pub struct CFIE5_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE5_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 5)) | ((value as u32 & 0x01) << 5);
-        self.w
-    }
-}
+pub type CFIE5_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE6` reader - Cancellation Finished Interrupt Enable 6"]
-pub struct CFIE6_R(crate::FieldReader<bool, bool>);
-impl CFIE6_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE6_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE6_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE6_R = crate::BitReader;
 #[doc = "Field `CFIE6` writer - Cancellation Finished Interrupt Enable 6"]
-pub struct CFIE6_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE6_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 6)) | ((value as u32 & 0x01) << 6);
-        self.w
-    }
-}
+pub type CFIE6_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE7` reader - Cancellation Finished Interrupt Enable 7"]
-pub struct CFIE7_R(crate::FieldReader<bool, bool>);
-impl CFIE7_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE7_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE7_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE7_R = crate::BitReader;
 #[doc = "Field `CFIE7` writer - Cancellation Finished Interrupt Enable 7"]
-pub struct CFIE7_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE7_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 7)) | ((value as u32 & 0x01) << 7);
-        self.w
-    }
-}
+pub type CFIE7_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE8` reader - Cancellation Finished Interrupt Enable 8"]
-pub struct CFIE8_R(crate::FieldReader<bool, bool>);
-impl CFIE8_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE8_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE8_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE8_R = crate::BitReader;
 #[doc = "Field `CFIE8` writer - Cancellation Finished Interrupt Enable 8"]
-pub struct CFIE8_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE8_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 8)) | ((value as u32 & 0x01) << 8);
-        self.w
-    }
-}
+pub type CFIE8_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE9` reader - Cancellation Finished Interrupt Enable 9"]
-pub struct CFIE9_R(crate::FieldReader<bool, bool>);
-impl CFIE9_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE9_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE9_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE9_R = crate::BitReader;
 #[doc = "Field `CFIE9` writer - Cancellation Finished Interrupt Enable 9"]
-pub struct CFIE9_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE9_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 9)) | ((value as u32 & 0x01) << 9);
-        self.w
-    }
-}
+pub type CFIE9_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE10` reader - Cancellation Finished Interrupt Enable 10"]
-pub struct CFIE10_R(crate::FieldReader<bool, bool>);
-impl CFIE10_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE10_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE10_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE10_R = crate::BitReader;
 #[doc = "Field `CFIE10` writer - Cancellation Finished Interrupt Enable 10"]
-pub struct CFIE10_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE10_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 10)) | ((value as u32 & 0x01) << 10);
-        self.w
-    }
-}
+pub type CFIE10_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE11` reader - Cancellation Finished Interrupt Enable 11"]
-pub struct CFIE11_R(crate::FieldReader<bool, bool>);
-impl CFIE11_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE11_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE11_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE11_R = crate::BitReader;
 #[doc = "Field `CFIE11` writer - Cancellation Finished Interrupt Enable 11"]
-pub struct CFIE11_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE11_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 11)) | ((value as u32 & 0x01) << 11);
-        self.w
-    }
-}
+pub type CFIE11_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE12` reader - Cancellation Finished Interrupt Enable 12"]
-pub struct CFIE12_R(crate::FieldReader<bool, bool>);
-impl CFIE12_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE12_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE12_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE12_R = crate::BitReader;
 #[doc = "Field `CFIE12` writer - Cancellation Finished Interrupt Enable 12"]
-pub struct CFIE12_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE12_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 12)) | ((value as u32 & 0x01) << 12);
-        self.w
-    }
-}
+pub type CFIE12_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE13` reader - Cancellation Finished Interrupt Enable 13"]
-pub struct CFIE13_R(crate::FieldReader<bool, bool>);
-impl CFIE13_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE13_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE13_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE13_R = crate::BitReader;
 #[doc = "Field `CFIE13` writer - Cancellation Finished Interrupt Enable 13"]
-pub struct CFIE13_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE13_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 13)) | ((value as u32 & 0x01) << 13);
-        self.w
-    }
-}
+pub type CFIE13_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE14` reader - Cancellation Finished Interrupt Enable 14"]
-pub struct CFIE14_R(crate::FieldReader<bool, bool>);
-impl CFIE14_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE14_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE14_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE14_R = crate::BitReader;
 #[doc = "Field `CFIE14` writer - Cancellation Finished Interrupt Enable 14"]
-pub struct CFIE14_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE14_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 14)) | ((value as u32 & 0x01) << 14);
-        self.w
-    }
-}
+pub type CFIE14_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE15` reader - Cancellation Finished Interrupt Enable 15"]
-pub struct CFIE15_R(crate::FieldReader<bool, bool>);
-impl CFIE15_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE15_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE15_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE15_R = crate::BitReader;
 #[doc = "Field `CFIE15` writer - Cancellation Finished Interrupt Enable 15"]
-pub struct CFIE15_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE15_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 15)) | ((value as u32 & 0x01) << 15);
-        self.w
-    }
-}
+pub type CFIE15_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE16` reader - Cancellation Finished Interrupt Enable 16"]
-pub struct CFIE16_R(crate::FieldReader<bool, bool>);
-impl CFIE16_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE16_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE16_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE16_R = crate::BitReader;
 #[doc = "Field `CFIE16` writer - Cancellation Finished Interrupt Enable 16"]
-pub struct CFIE16_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE16_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 16)) | ((value as u32 & 0x01) << 16);
-        self.w
-    }
-}
+pub type CFIE16_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE17` reader - Cancellation Finished Interrupt Enable 17"]
-pub struct CFIE17_R(crate::FieldReader<bool, bool>);
-impl CFIE17_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE17_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE17_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE17_R = crate::BitReader;
 #[doc = "Field `CFIE17` writer - Cancellation Finished Interrupt Enable 17"]
-pub struct CFIE17_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE17_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 17)) | ((value as u32 & 0x01) << 17);
-        self.w
-    }
-}
+pub type CFIE17_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE18` reader - Cancellation Finished Interrupt Enable 18"]
-pub struct CFIE18_R(crate::FieldReader<bool, bool>);
-impl CFIE18_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE18_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE18_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE18_R = crate::BitReader;
 #[doc = "Field `CFIE18` writer - Cancellation Finished Interrupt Enable 18"]
-pub struct CFIE18_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE18_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 18)) | ((value as u32 & 0x01) << 18);
-        self.w
-    }
-}
+pub type CFIE18_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE19` reader - Cancellation Finished Interrupt Enable 19"]
-pub struct CFIE19_R(crate::FieldReader<bool, bool>);
-impl CFIE19_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE19_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE19_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE19_R = crate::BitReader;
 #[doc = "Field `CFIE19` writer - Cancellation Finished Interrupt Enable 19"]
-pub struct CFIE19_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE19_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 19)) | ((value as u32 & 0x01) << 19);
-        self.w
-    }
-}
+pub type CFIE19_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE20` reader - Cancellation Finished Interrupt Enable 20"]
-pub struct CFIE20_R(crate::FieldReader<bool, bool>);
-impl CFIE20_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE20_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE20_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE20_R = crate::BitReader;
 #[doc = "Field `CFIE20` writer - Cancellation Finished Interrupt Enable 20"]
-pub struct CFIE20_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE20_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 20)) | ((value as u32 & 0x01) << 20);
-        self.w
-    }
-}
+pub type CFIE20_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE21` reader - Cancellation Finished Interrupt Enable 21"]
-pub struct CFIE21_R(crate::FieldReader<bool, bool>);
-impl CFIE21_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE21_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE21_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE21_R = crate::BitReader;
 #[doc = "Field `CFIE21` writer - Cancellation Finished Interrupt Enable 21"]
-pub struct CFIE21_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE21_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 21)) | ((value as u32 & 0x01) << 21);
-        self.w
-    }
-}
+pub type CFIE21_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE22` reader - Cancellation Finished Interrupt Enable 22"]
-pub struct CFIE22_R(crate::FieldReader<bool, bool>);
-impl CFIE22_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE22_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE22_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE22_R = crate::BitReader;
 #[doc = "Field `CFIE22` writer - Cancellation Finished Interrupt Enable 22"]
-pub struct CFIE22_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE22_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 22)) | ((value as u32 & 0x01) << 22);
-        self.w
-    }
-}
+pub type CFIE22_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE23` reader - Cancellation Finished Interrupt Enable 23"]
-pub struct CFIE23_R(crate::FieldReader<bool, bool>);
-impl CFIE23_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE23_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE23_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE23_R = crate::BitReader;
 #[doc = "Field `CFIE23` writer - Cancellation Finished Interrupt Enable 23"]
-pub struct CFIE23_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE23_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 23)) | ((value as u32 & 0x01) << 23);
-        self.w
-    }
-}
+pub type CFIE23_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE24` reader - Cancellation Finished Interrupt Enable 24"]
-pub struct CFIE24_R(crate::FieldReader<bool, bool>);
-impl CFIE24_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE24_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE24_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE24_R = crate::BitReader;
 #[doc = "Field `CFIE24` writer - Cancellation Finished Interrupt Enable 24"]
-pub struct CFIE24_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE24_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 24)) | ((value as u32 & 0x01) << 24);
-        self.w
-    }
-}
+pub type CFIE24_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE25` reader - Cancellation Finished Interrupt Enable 25"]
-pub struct CFIE25_R(crate::FieldReader<bool, bool>);
-impl CFIE25_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE25_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE25_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE25_R = crate::BitReader;
 #[doc = "Field `CFIE25` writer - Cancellation Finished Interrupt Enable 25"]
-pub struct CFIE25_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE25_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 25)) | ((value as u32 & 0x01) << 25);
-        self.w
-    }
-}
+pub type CFIE25_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE26` reader - Cancellation Finished Interrupt Enable 26"]
-pub struct CFIE26_R(crate::FieldReader<bool, bool>);
-impl CFIE26_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE26_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE26_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE26_R = crate::BitReader;
 #[doc = "Field `CFIE26` writer - Cancellation Finished Interrupt Enable 26"]
-pub struct CFIE26_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE26_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 26)) | ((value as u32 & 0x01) << 26);
-        self.w
-    }
-}
+pub type CFIE26_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE27` reader - Cancellation Finished Interrupt Enable 27"]
-pub struct CFIE27_R(crate::FieldReader<bool, bool>);
-impl CFIE27_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE27_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE27_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE27_R = crate::BitReader;
 #[doc = "Field `CFIE27` writer - Cancellation Finished Interrupt Enable 27"]
-pub struct CFIE27_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE27_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 27)) | ((value as u32 & 0x01) << 27);
-        self.w
-    }
-}
+pub type CFIE27_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE28` reader - Cancellation Finished Interrupt Enable 28"]
-pub struct CFIE28_R(crate::FieldReader<bool, bool>);
-impl CFIE28_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE28_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE28_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE28_R = crate::BitReader;
 #[doc = "Field `CFIE28` writer - Cancellation Finished Interrupt Enable 28"]
-pub struct CFIE28_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE28_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 28)) | ((value as u32 & 0x01) << 28);
-        self.w
-    }
-}
+pub type CFIE28_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE29` reader - Cancellation Finished Interrupt Enable 29"]
-pub struct CFIE29_R(crate::FieldReader<bool, bool>);
-impl CFIE29_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE29_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE29_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE29_R = crate::BitReader;
 #[doc = "Field `CFIE29` writer - Cancellation Finished Interrupt Enable 29"]
-pub struct CFIE29_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE29_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 29)) | ((value as u32 & 0x01) << 29);
-        self.w
-    }
-}
+pub type CFIE29_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE30` reader - Cancellation Finished Interrupt Enable 30"]
-pub struct CFIE30_R(crate::FieldReader<bool, bool>);
-impl CFIE30_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE30_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE30_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE30_R = crate::BitReader;
 #[doc = "Field `CFIE30` writer - Cancellation Finished Interrupt Enable 30"]
-pub struct CFIE30_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE30_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 30)) | ((value as u32 & 0x01) << 30);
-        self.w
-    }
-}
+pub type CFIE30_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CFIE31` reader - Cancellation Finished Interrupt Enable 31"]
-pub struct CFIE31_R(crate::FieldReader<bool, bool>);
-impl CFIE31_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CFIE31_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CFIE31_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CFIE31_R = crate::BitReader;
 #[doc = "Field `CFIE31` writer - Cancellation Finished Interrupt Enable 31"]
-pub struct CFIE31_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CFIE31_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 31)) | ((value as u32 & 0x01) << 31);
-        self.w
-    }
-}
+pub type CFIE31_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
     #[doc = "Bit 0 - Cancellation Finished Interrupt Enable 0"]
     #[inline(always)]
     pub fn cfie0(&self) -> CFIE0_R {
-        CFIE0_R::new((self.bits & 0x01) != 0)
+        CFIE0_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - Cancellation Finished Interrupt Enable 1"]
     #[inline(always)]
     pub fn cfie1(&self) -> CFIE1_R {
-        CFIE1_R::new(((self.bits >> 1) & 0x01) != 0)
+        CFIE1_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - Cancellation Finished Interrupt Enable 2"]
     #[inline(always)]
     pub fn cfie2(&self) -> CFIE2_R {
-        CFIE2_R::new(((self.bits >> 2) & 0x01) != 0)
+        CFIE2_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - Cancellation Finished Interrupt Enable 3"]
     #[inline(always)]
     pub fn cfie3(&self) -> CFIE3_R {
-        CFIE3_R::new(((self.bits >> 3) & 0x01) != 0)
+        CFIE3_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - Cancellation Finished Interrupt Enable 4"]
     #[inline(always)]
     pub fn cfie4(&self) -> CFIE4_R {
-        CFIE4_R::new(((self.bits >> 4) & 0x01) != 0)
+        CFIE4_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - Cancellation Finished Interrupt Enable 5"]
     #[inline(always)]
     pub fn cfie5(&self) -> CFIE5_R {
-        CFIE5_R::new(((self.bits >> 5) & 0x01) != 0)
+        CFIE5_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - Cancellation Finished Interrupt Enable 6"]
     #[inline(always)]
     pub fn cfie6(&self) -> CFIE6_R {
-        CFIE6_R::new(((self.bits >> 6) & 0x01) != 0)
+        CFIE6_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - Cancellation Finished Interrupt Enable 7"]
     #[inline(always)]
     pub fn cfie7(&self) -> CFIE7_R {
-        CFIE7_R::new(((self.bits >> 7) & 0x01) != 0)
+        CFIE7_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - Cancellation Finished Interrupt Enable 8"]
     #[inline(always)]
     pub fn cfie8(&self) -> CFIE8_R {
-        CFIE8_R::new(((self.bits >> 8) & 0x01) != 0)
+        CFIE8_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - Cancellation Finished Interrupt Enable 9"]
     #[inline(always)]
     pub fn cfie9(&self) -> CFIE9_R {
-        CFIE9_R::new(((self.bits >> 9) & 0x01) != 0)
+        CFIE9_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - Cancellation Finished Interrupt Enable 10"]
     #[inline(always)]
     pub fn cfie10(&self) -> CFIE10_R {
-        CFIE10_R::new(((self.bits >> 10) & 0x01) != 0)
+        CFIE10_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Cancellation Finished Interrupt Enable 11"]
     #[inline(always)]
     pub fn cfie11(&self) -> CFIE11_R {
-        CFIE11_R::new(((self.bits >> 11) & 0x01) != 0)
+        CFIE11_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - Cancellation Finished Interrupt Enable 12"]
     #[inline(always)]
     pub fn cfie12(&self) -> CFIE12_R {
-        CFIE12_R::new(((self.bits >> 12) & 0x01) != 0)
+        CFIE12_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - Cancellation Finished Interrupt Enable 13"]
     #[inline(always)]
     pub fn cfie13(&self) -> CFIE13_R {
-        CFIE13_R::new(((self.bits >> 13) & 0x01) != 0)
+        CFIE13_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - Cancellation Finished Interrupt Enable 14"]
     #[inline(always)]
     pub fn cfie14(&self) -> CFIE14_R {
-        CFIE14_R::new(((self.bits >> 14) & 0x01) != 0)
+        CFIE14_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - Cancellation Finished Interrupt Enable 15"]
     #[inline(always)]
     pub fn cfie15(&self) -> CFIE15_R {
-        CFIE15_R::new(((self.bits >> 15) & 0x01) != 0)
+        CFIE15_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - Cancellation Finished Interrupt Enable 16"]
     #[inline(always)]
     pub fn cfie16(&self) -> CFIE16_R {
-        CFIE16_R::new(((self.bits >> 16) & 0x01) != 0)
+        CFIE16_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - Cancellation Finished Interrupt Enable 17"]
     #[inline(always)]
     pub fn cfie17(&self) -> CFIE17_R {
-        CFIE17_R::new(((self.bits >> 17) & 0x01) != 0)
+        CFIE17_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - Cancellation Finished Interrupt Enable 18"]
     #[inline(always)]
     pub fn cfie18(&self) -> CFIE18_R {
-        CFIE18_R::new(((self.bits >> 18) & 0x01) != 0)
+        CFIE18_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - Cancellation Finished Interrupt Enable 19"]
     #[inline(always)]
     pub fn cfie19(&self) -> CFIE19_R {
-        CFIE19_R::new(((self.bits >> 19) & 0x01) != 0)
+        CFIE19_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - Cancellation Finished Interrupt Enable 20"]
     #[inline(always)]
     pub fn cfie20(&self) -> CFIE20_R {
-        CFIE20_R::new(((self.bits >> 20) & 0x01) != 0)
+        CFIE20_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - Cancellation Finished Interrupt Enable 21"]
     #[inline(always)]
     pub fn cfie21(&self) -> CFIE21_R {
-        CFIE21_R::new(((self.bits >> 21) & 0x01) != 0)
+        CFIE21_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - Cancellation Finished Interrupt Enable 22"]
     #[inline(always)]
     pub fn cfie22(&self) -> CFIE22_R {
-        CFIE22_R::new(((self.bits >> 22) & 0x01) != 0)
+        CFIE22_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - Cancellation Finished Interrupt Enable 23"]
     #[inline(always)]
     pub fn cfie23(&self) -> CFIE23_R {
-        CFIE23_R::new(((self.bits >> 23) & 0x01) != 0)
+        CFIE23_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - Cancellation Finished Interrupt Enable 24"]
     #[inline(always)]
     pub fn cfie24(&self) -> CFIE24_R {
-        CFIE24_R::new(((self.bits >> 24) & 0x01) != 0)
+        CFIE24_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - Cancellation Finished Interrupt Enable 25"]
     #[inline(always)]
     pub fn cfie25(&self) -> CFIE25_R {
-        CFIE25_R::new(((self.bits >> 25) & 0x01) != 0)
+        CFIE25_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - Cancellation Finished Interrupt Enable 26"]
     #[inline(always)]
     pub fn cfie26(&self) -> CFIE26_R {
-        CFIE26_R::new(((self.bits >> 26) & 0x01) != 0)
+        CFIE26_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - Cancellation Finished Interrupt Enable 27"]
     #[inline(always)]
     pub fn cfie27(&self) -> CFIE27_R {
-        CFIE27_R::new(((self.bits >> 27) & 0x01) != 0)
+        CFIE27_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - Cancellation Finished Interrupt Enable 28"]
     #[inline(always)]
     pub fn cfie28(&self) -> CFIE28_R {
-        CFIE28_R::new(((self.bits >> 28) & 0x01) != 0)
+        CFIE28_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - Cancellation Finished Interrupt Enable 29"]
     #[inline(always)]
     pub fn cfie29(&self) -> CFIE29_R {
-        CFIE29_R::new(((self.bits >> 29) & 0x01) != 0)
+        CFIE29_R::new(((self.bits >> 29) & 1) != 0)
     }
     #[doc = "Bit 30 - Cancellation Finished Interrupt Enable 30"]
     #[inline(always)]
     pub fn cfie30(&self) -> CFIE30_R {
-        CFIE30_R::new(((self.bits >> 30) & 0x01) != 0)
+        CFIE30_R::new(((self.bits >> 30) & 1) != 0)
     }
     #[doc = "Bit 31 - Cancellation Finished Interrupt Enable 31"]
     #[inline(always)]
     pub fn cfie31(&self) -> CFIE31_R {
-        CFIE31_R::new(((self.bits >> 31) & 0x01) != 0)
+        CFIE31_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - Cancellation Finished Interrupt Enable 0"]
     #[inline(always)]
-    pub fn cfie0(&mut self) -> CFIE0_W {
-        CFIE0_W { w: self }
+    #[must_use]
+    pub fn cfie0(&mut self) -> CFIE0_W<TXBCIE_SPEC, 0> {
+        CFIE0_W::new(self)
     }
     #[doc = "Bit 1 - Cancellation Finished Interrupt Enable 1"]
     #[inline(always)]
-    pub fn cfie1(&mut self) -> CFIE1_W {
-        CFIE1_W { w: self }
+    #[must_use]
+    pub fn cfie1(&mut self) -> CFIE1_W<TXBCIE_SPEC, 1> {
+        CFIE1_W::new(self)
     }
     #[doc = "Bit 2 - Cancellation Finished Interrupt Enable 2"]
     #[inline(always)]
-    pub fn cfie2(&mut self) -> CFIE2_W {
-        CFIE2_W { w: self }
+    #[must_use]
+    pub fn cfie2(&mut self) -> CFIE2_W<TXBCIE_SPEC, 2> {
+        CFIE2_W::new(self)
     }
     #[doc = "Bit 3 - Cancellation Finished Interrupt Enable 3"]
     #[inline(always)]
-    pub fn cfie3(&mut self) -> CFIE3_W {
-        CFIE3_W { w: self }
+    #[must_use]
+    pub fn cfie3(&mut self) -> CFIE3_W<TXBCIE_SPEC, 3> {
+        CFIE3_W::new(self)
     }
     #[doc = "Bit 4 - Cancellation Finished Interrupt Enable 4"]
     #[inline(always)]
-    pub fn cfie4(&mut self) -> CFIE4_W {
-        CFIE4_W { w: self }
+    #[must_use]
+    pub fn cfie4(&mut self) -> CFIE4_W<TXBCIE_SPEC, 4> {
+        CFIE4_W::new(self)
     }
     #[doc = "Bit 5 - Cancellation Finished Interrupt Enable 5"]
     #[inline(always)]
-    pub fn cfie5(&mut self) -> CFIE5_W {
-        CFIE5_W { w: self }
+    #[must_use]
+    pub fn cfie5(&mut self) -> CFIE5_W<TXBCIE_SPEC, 5> {
+        CFIE5_W::new(self)
     }
     #[doc = "Bit 6 - Cancellation Finished Interrupt Enable 6"]
     #[inline(always)]
-    pub fn cfie6(&mut self) -> CFIE6_W {
-        CFIE6_W { w: self }
+    #[must_use]
+    pub fn cfie6(&mut self) -> CFIE6_W<TXBCIE_SPEC, 6> {
+        CFIE6_W::new(self)
     }
     #[doc = "Bit 7 - Cancellation Finished Interrupt Enable 7"]
     #[inline(always)]
-    pub fn cfie7(&mut self) -> CFIE7_W {
-        CFIE7_W { w: self }
+    #[must_use]
+    pub fn cfie7(&mut self) -> CFIE7_W<TXBCIE_SPEC, 7> {
+        CFIE7_W::new(self)
     }
     #[doc = "Bit 8 - Cancellation Finished Interrupt Enable 8"]
     #[inline(always)]
-    pub fn cfie8(&mut self) -> CFIE8_W {
-        CFIE8_W { w: self }
+    #[must_use]
+    pub fn cfie8(&mut self) -> CFIE8_W<TXBCIE_SPEC, 8> {
+        CFIE8_W::new(self)
     }
     #[doc = "Bit 9 - Cancellation Finished Interrupt Enable 9"]
     #[inline(always)]
-    pub fn cfie9(&mut self) -> CFIE9_W {
-        CFIE9_W { w: self }
+    #[must_use]
+    pub fn cfie9(&mut self) -> CFIE9_W<TXBCIE_SPEC, 9> {
+        CFIE9_W::new(self)
     }
     #[doc = "Bit 10 - Cancellation Finished Interrupt Enable 10"]
     #[inline(always)]
-    pub fn cfie10(&mut self) -> CFIE10_W {
-        CFIE10_W { w: self }
+    #[must_use]
+    pub fn cfie10(&mut self) -> CFIE10_W<TXBCIE_SPEC, 10> {
+        CFIE10_W::new(self)
     }
     #[doc = "Bit 11 - Cancellation Finished Interrupt Enable 11"]
     #[inline(always)]
-    pub fn cfie11(&mut self) -> CFIE11_W {
-        CFIE11_W { w: self }
+    #[must_use]
+    pub fn cfie11(&mut self) -> CFIE11_W<TXBCIE_SPEC, 11> {
+        CFIE11_W::new(self)
     }
     #[doc = "Bit 12 - Cancellation Finished Interrupt Enable 12"]
     #[inline(always)]
-    pub fn cfie12(&mut self) -> CFIE12_W {
-        CFIE12_W { w: self }
+    #[must_use]
+    pub fn cfie12(&mut self) -> CFIE12_W<TXBCIE_SPEC, 12> {
+        CFIE12_W::new(self)
     }
     #[doc = "Bit 13 - Cancellation Finished Interrupt Enable 13"]
     #[inline(always)]
-    pub fn cfie13(&mut self) -> CFIE13_W {
-        CFIE13_W { w: self }
+    #[must_use]
+    pub fn cfie13(&mut self) -> CFIE13_W<TXBCIE_SPEC, 13> {
+        CFIE13_W::new(self)
     }
     #[doc = "Bit 14 - Cancellation Finished Interrupt Enable 14"]
     #[inline(always)]
-    pub fn cfie14(&mut self) -> CFIE14_W {
-        CFIE14_W { w: self }
+    #[must_use]
+    pub fn cfie14(&mut self) -> CFIE14_W<TXBCIE_SPEC, 14> {
+        CFIE14_W::new(self)
     }
     #[doc = "Bit 15 - Cancellation Finished Interrupt Enable 15"]
     #[inline(always)]
-    pub fn cfie15(&mut self) -> CFIE15_W {
-        CFIE15_W { w: self }
+    #[must_use]
+    pub fn cfie15(&mut self) -> CFIE15_W<TXBCIE_SPEC, 15> {
+        CFIE15_W::new(self)
     }
     #[doc = "Bit 16 - Cancellation Finished Interrupt Enable 16"]
     #[inline(always)]
-    pub fn cfie16(&mut self) -> CFIE16_W {
-        CFIE16_W { w: self }
+    #[must_use]
+    pub fn cfie16(&mut self) -> CFIE16_W<TXBCIE_SPEC, 16> {
+        CFIE16_W::new(self)
     }
     #[doc = "Bit 17 - Cancellation Finished Interrupt Enable 17"]
     #[inline(always)]
-    pub fn cfie17(&mut self) -> CFIE17_W {
-        CFIE17_W { w: self }
+    #[must_use]
+    pub fn cfie17(&mut self) -> CFIE17_W<TXBCIE_SPEC, 17> {
+        CFIE17_W::new(self)
     }
     #[doc = "Bit 18 - Cancellation Finished Interrupt Enable 18"]
     #[inline(always)]
-    pub fn cfie18(&mut self) -> CFIE18_W {
-        CFIE18_W { w: self }
+    #[must_use]
+    pub fn cfie18(&mut self) -> CFIE18_W<TXBCIE_SPEC, 18> {
+        CFIE18_W::new(self)
     }
     #[doc = "Bit 19 - Cancellation Finished Interrupt Enable 19"]
     #[inline(always)]
-    pub fn cfie19(&mut self) -> CFIE19_W {
-        CFIE19_W { w: self }
+    #[must_use]
+    pub fn cfie19(&mut self) -> CFIE19_W<TXBCIE_SPEC, 19> {
+        CFIE19_W::new(self)
     }
     #[doc = "Bit 20 - Cancellation Finished Interrupt Enable 20"]
     #[inline(always)]
-    pub fn cfie20(&mut self) -> CFIE20_W {
-        CFIE20_W { w: self }
+    #[must_use]
+    pub fn cfie20(&mut self) -> CFIE20_W<TXBCIE_SPEC, 20> {
+        CFIE20_W::new(self)
     }
     #[doc = "Bit 21 - Cancellation Finished Interrupt Enable 21"]
     #[inline(always)]
-    pub fn cfie21(&mut self) -> CFIE21_W {
-        CFIE21_W { w: self }
+    #[must_use]
+    pub fn cfie21(&mut self) -> CFIE21_W<TXBCIE_SPEC, 21> {
+        CFIE21_W::new(self)
     }
     #[doc = "Bit 22 - Cancellation Finished Interrupt Enable 22"]
     #[inline(always)]
-    pub fn cfie22(&mut self) -> CFIE22_W {
-        CFIE22_W { w: self }
+    #[must_use]
+    pub fn cfie22(&mut self) -> CFIE22_W<TXBCIE_SPEC, 22> {
+        CFIE22_W::new(self)
     }
     #[doc = "Bit 23 - Cancellation Finished Interrupt Enable 23"]
     #[inline(always)]
-    pub fn cfie23(&mut self) -> CFIE23_W {
-        CFIE23_W { w: self }
+    #[must_use]
+    pub fn cfie23(&mut self) -> CFIE23_W<TXBCIE_SPEC, 23> {
+        CFIE23_W::new(self)
     }
     #[doc = "Bit 24 - Cancellation Finished Interrupt Enable 24"]
     #[inline(always)]
-    pub fn cfie24(&mut self) -> CFIE24_W {
-        CFIE24_W { w: self }
+    #[must_use]
+    pub fn cfie24(&mut self) -> CFIE24_W<TXBCIE_SPEC, 24> {
+        CFIE24_W::new(self)
     }
     #[doc = "Bit 25 - Cancellation Finished Interrupt Enable 25"]
     #[inline(always)]
-    pub fn cfie25(&mut self) -> CFIE25_W {
-        CFIE25_W { w: self }
+    #[must_use]
+    pub fn cfie25(&mut self) -> CFIE25_W<TXBCIE_SPEC, 25> {
+        CFIE25_W::new(self)
     }
     #[doc = "Bit 26 - Cancellation Finished Interrupt Enable 26"]
     #[inline(always)]
-    pub fn cfie26(&mut self) -> CFIE26_W {
-        CFIE26_W { w: self }
+    #[must_use]
+    pub fn cfie26(&mut self) -> CFIE26_W<TXBCIE_SPEC, 26> {
+        CFIE26_W::new(self)
     }
     #[doc = "Bit 27 - Cancellation Finished Interrupt Enable 27"]
     #[inline(always)]
-    pub fn cfie27(&mut self) -> CFIE27_W {
-        CFIE27_W { w: self }
+    #[must_use]
+    pub fn cfie27(&mut self) -> CFIE27_W<TXBCIE_SPEC, 27> {
+        CFIE27_W::new(self)
     }
     #[doc = "Bit 28 - Cancellation Finished Interrupt Enable 28"]
     #[inline(always)]
-    pub fn cfie28(&mut self) -> CFIE28_W {
-        CFIE28_W { w: self }
+    #[must_use]
+    pub fn cfie28(&mut self) -> CFIE28_W<TXBCIE_SPEC, 28> {
+        CFIE28_W::new(self)
     }
     #[doc = "Bit 29 - Cancellation Finished Interrupt Enable 29"]
     #[inline(always)]
-    pub fn cfie29(&mut self) -> CFIE29_W {
-        CFIE29_W { w: self }
+    #[must_use]
+    pub fn cfie29(&mut self) -> CFIE29_W<TXBCIE_SPEC, 29> {
+        CFIE29_W::new(self)
     }
     #[doc = "Bit 30 - Cancellation Finished Interrupt Enable 30"]
     #[inline(always)]
-    pub fn cfie30(&mut self) -> CFIE30_W {
-        CFIE30_W { w: self }
+    #[must_use]
+    pub fn cfie30(&mut self) -> CFIE30_W<TXBCIE_SPEC, 30> {
+        CFIE30_W::new(self)
     }
     #[doc = "Bit 31 - Cancellation Finished Interrupt Enable 31"]
     #[inline(always)]
-    pub fn cfie31(&mut self) -> CFIE31_W {
-        CFIE31_W { w: self }
+    #[must_use]
+    pub fn cfie31(&mut self) -> CFIE31_W<TXBCIE_SPEC, 31> {
+        CFIE31_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Tx Buffer Cancellation Finished Interrupt Enable\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txbcie](index.html) module"]
+#[doc = "Tx Buffer Cancellation Finished Interrupt Enable\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txbcie::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`txbcie::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXBCIE_SPEC;
 impl crate::RegisterSpec for TXBCIE_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [txbcie::R](R) reader structure"]
-impl crate::Readable for TXBCIE_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [txbcie::W](W) writer structure"]
+#[doc = "`read()` method returns [`txbcie::R`](R) reader structure"]
+impl crate::Readable for TXBCIE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`txbcie::W`](W) writer structure"]
 impl crate::Writable for TXBCIE_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets TXBCIE to value 0"]
 impl crate::Resettable for TXBCIE_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/txbcie.rs
+++ b/mcan/src/reg/txbcie.rs
@@ -496,7 +496,7 @@ impl W {
         self
     }
 }
-#[doc = "Tx Buffer Cancellation Finished Interrupt Enable\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txbcie::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`txbcie::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Tx Buffer Cancellation Finished Interrupt Enable\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`txbcie::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`txbcie::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXBCIE_SPEC;
 impl crate::RegisterSpec for TXBCIE_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/txbcr.rs
+++ b/mcan/src/reg/txbcr.rs
@@ -496,7 +496,7 @@ impl W {
         self
     }
 }
-#[doc = "Tx Buffer Cancellation Request\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txbcr::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`txbcr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Tx Buffer Cancellation Request\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`txbcr::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`txbcr::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXBCR_SPEC;
 impl crate::RegisterSpec for TXBCR_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/txbcr.rs
+++ b/mcan/src/reg/txbcr.rs
@@ -1,1570 +1,514 @@
 #[doc = "Register `TXBCR` reader"]
-pub struct R(crate::R<TXBCR_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<TXBCR_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<TXBCR_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<TXBCR_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<TXBCR_SPEC>;
 #[doc = "Register `TXBCR` writer"]
-pub struct W(crate::W<TXBCR_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<TXBCR_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<TXBCR_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<TXBCR_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<TXBCR_SPEC>;
 #[doc = "Field `CR0` reader - Cancellation Request 0"]
-pub struct CR0_R(crate::FieldReader<bool, bool>);
-impl CR0_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR0_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR0_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR0_R = crate::BitReader;
 #[doc = "Field `CR0` writer - Cancellation Request 0"]
-pub struct CR0_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR0_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x01) | (value as u32 & 0x01);
-        self.w
-    }
-}
+pub type CR0_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR1` reader - Cancellation Request 1"]
-pub struct CR1_R(crate::FieldReader<bool, bool>);
-impl CR1_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR1_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR1_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR1_R = crate::BitReader;
 #[doc = "Field `CR1` writer - Cancellation Request 1"]
-pub struct CR1_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR1_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 1)) | ((value as u32 & 0x01) << 1);
-        self.w
-    }
-}
+pub type CR1_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR2` reader - Cancellation Request 2"]
-pub struct CR2_R(crate::FieldReader<bool, bool>);
-impl CR2_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR2_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR2_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR2_R = crate::BitReader;
 #[doc = "Field `CR2` writer - Cancellation Request 2"]
-pub struct CR2_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR2_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 2)) | ((value as u32 & 0x01) << 2);
-        self.w
-    }
-}
+pub type CR2_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR3` reader - Cancellation Request 3"]
-pub struct CR3_R(crate::FieldReader<bool, bool>);
-impl CR3_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR3_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR3_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR3_R = crate::BitReader;
 #[doc = "Field `CR3` writer - Cancellation Request 3"]
-pub struct CR3_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR3_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 3)) | ((value as u32 & 0x01) << 3);
-        self.w
-    }
-}
+pub type CR3_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR4` reader - Cancellation Request 4"]
-pub struct CR4_R(crate::FieldReader<bool, bool>);
-impl CR4_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR4_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR4_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR4_R = crate::BitReader;
 #[doc = "Field `CR4` writer - Cancellation Request 4"]
-pub struct CR4_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR4_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 4)) | ((value as u32 & 0x01) << 4);
-        self.w
-    }
-}
+pub type CR4_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR5` reader - Cancellation Request 5"]
-pub struct CR5_R(crate::FieldReader<bool, bool>);
-impl CR5_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR5_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR5_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR5_R = crate::BitReader;
 #[doc = "Field `CR5` writer - Cancellation Request 5"]
-pub struct CR5_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR5_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 5)) | ((value as u32 & 0x01) << 5);
-        self.w
-    }
-}
+pub type CR5_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR6` reader - Cancellation Request 6"]
-pub struct CR6_R(crate::FieldReader<bool, bool>);
-impl CR6_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR6_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR6_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR6_R = crate::BitReader;
 #[doc = "Field `CR6` writer - Cancellation Request 6"]
-pub struct CR6_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR6_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 6)) | ((value as u32 & 0x01) << 6);
-        self.w
-    }
-}
+pub type CR6_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR7` reader - Cancellation Request 7"]
-pub struct CR7_R(crate::FieldReader<bool, bool>);
-impl CR7_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR7_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR7_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR7_R = crate::BitReader;
 #[doc = "Field `CR7` writer - Cancellation Request 7"]
-pub struct CR7_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR7_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 7)) | ((value as u32 & 0x01) << 7);
-        self.w
-    }
-}
+pub type CR7_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR8` reader - Cancellation Request 8"]
-pub struct CR8_R(crate::FieldReader<bool, bool>);
-impl CR8_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR8_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR8_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR8_R = crate::BitReader;
 #[doc = "Field `CR8` writer - Cancellation Request 8"]
-pub struct CR8_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR8_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 8)) | ((value as u32 & 0x01) << 8);
-        self.w
-    }
-}
+pub type CR8_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR9` reader - Cancellation Request 9"]
-pub struct CR9_R(crate::FieldReader<bool, bool>);
-impl CR9_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR9_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR9_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR9_R = crate::BitReader;
 #[doc = "Field `CR9` writer - Cancellation Request 9"]
-pub struct CR9_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR9_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 9)) | ((value as u32 & 0x01) << 9);
-        self.w
-    }
-}
+pub type CR9_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR10` reader - Cancellation Request 10"]
-pub struct CR10_R(crate::FieldReader<bool, bool>);
-impl CR10_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR10_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR10_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR10_R = crate::BitReader;
 #[doc = "Field `CR10` writer - Cancellation Request 10"]
-pub struct CR10_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR10_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 10)) | ((value as u32 & 0x01) << 10);
-        self.w
-    }
-}
+pub type CR10_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR11` reader - Cancellation Request 11"]
-pub struct CR11_R(crate::FieldReader<bool, bool>);
-impl CR11_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR11_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR11_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR11_R = crate::BitReader;
 #[doc = "Field `CR11` writer - Cancellation Request 11"]
-pub struct CR11_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR11_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 11)) | ((value as u32 & 0x01) << 11);
-        self.w
-    }
-}
+pub type CR11_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR12` reader - Cancellation Request 12"]
-pub struct CR12_R(crate::FieldReader<bool, bool>);
-impl CR12_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR12_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR12_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR12_R = crate::BitReader;
 #[doc = "Field `CR12` writer - Cancellation Request 12"]
-pub struct CR12_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR12_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 12)) | ((value as u32 & 0x01) << 12);
-        self.w
-    }
-}
+pub type CR12_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR13` reader - Cancellation Request 13"]
-pub struct CR13_R(crate::FieldReader<bool, bool>);
-impl CR13_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR13_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR13_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR13_R = crate::BitReader;
 #[doc = "Field `CR13` writer - Cancellation Request 13"]
-pub struct CR13_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR13_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 13)) | ((value as u32 & 0x01) << 13);
-        self.w
-    }
-}
+pub type CR13_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR14` reader - Cancellation Request 14"]
-pub struct CR14_R(crate::FieldReader<bool, bool>);
-impl CR14_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR14_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR14_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR14_R = crate::BitReader;
 #[doc = "Field `CR14` writer - Cancellation Request 14"]
-pub struct CR14_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR14_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 14)) | ((value as u32 & 0x01) << 14);
-        self.w
-    }
-}
+pub type CR14_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR15` reader - Cancellation Request 15"]
-pub struct CR15_R(crate::FieldReader<bool, bool>);
-impl CR15_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR15_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR15_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR15_R = crate::BitReader;
 #[doc = "Field `CR15` writer - Cancellation Request 15"]
-pub struct CR15_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR15_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 15)) | ((value as u32 & 0x01) << 15);
-        self.w
-    }
-}
+pub type CR15_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR16` reader - Cancellation Request 16"]
-pub struct CR16_R(crate::FieldReader<bool, bool>);
-impl CR16_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR16_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR16_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR16_R = crate::BitReader;
 #[doc = "Field `CR16` writer - Cancellation Request 16"]
-pub struct CR16_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR16_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 16)) | ((value as u32 & 0x01) << 16);
-        self.w
-    }
-}
+pub type CR16_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR17` reader - Cancellation Request 17"]
-pub struct CR17_R(crate::FieldReader<bool, bool>);
-impl CR17_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR17_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR17_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR17_R = crate::BitReader;
 #[doc = "Field `CR17` writer - Cancellation Request 17"]
-pub struct CR17_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR17_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 17)) | ((value as u32 & 0x01) << 17);
-        self.w
-    }
-}
+pub type CR17_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR18` reader - Cancellation Request 18"]
-pub struct CR18_R(crate::FieldReader<bool, bool>);
-impl CR18_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR18_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR18_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR18_R = crate::BitReader;
 #[doc = "Field `CR18` writer - Cancellation Request 18"]
-pub struct CR18_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR18_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 18)) | ((value as u32 & 0x01) << 18);
-        self.w
-    }
-}
+pub type CR18_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR19` reader - Cancellation Request 19"]
-pub struct CR19_R(crate::FieldReader<bool, bool>);
-impl CR19_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR19_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR19_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR19_R = crate::BitReader;
 #[doc = "Field `CR19` writer - Cancellation Request 19"]
-pub struct CR19_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR19_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 19)) | ((value as u32 & 0x01) << 19);
-        self.w
-    }
-}
+pub type CR19_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR20` reader - Cancellation Request 20"]
-pub struct CR20_R(crate::FieldReader<bool, bool>);
-impl CR20_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR20_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR20_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR20_R = crate::BitReader;
 #[doc = "Field `CR20` writer - Cancellation Request 20"]
-pub struct CR20_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR20_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 20)) | ((value as u32 & 0x01) << 20);
-        self.w
-    }
-}
+pub type CR20_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR21` reader - Cancellation Request 21"]
-pub struct CR21_R(crate::FieldReader<bool, bool>);
-impl CR21_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR21_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR21_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR21_R = crate::BitReader;
 #[doc = "Field `CR21` writer - Cancellation Request 21"]
-pub struct CR21_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR21_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 21)) | ((value as u32 & 0x01) << 21);
-        self.w
-    }
-}
+pub type CR21_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR22` reader - Cancellation Request 22"]
-pub struct CR22_R(crate::FieldReader<bool, bool>);
-impl CR22_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR22_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR22_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR22_R = crate::BitReader;
 #[doc = "Field `CR22` writer - Cancellation Request 22"]
-pub struct CR22_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR22_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 22)) | ((value as u32 & 0x01) << 22);
-        self.w
-    }
-}
+pub type CR22_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR23` reader - Cancellation Request 23"]
-pub struct CR23_R(crate::FieldReader<bool, bool>);
-impl CR23_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR23_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR23_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR23_R = crate::BitReader;
 #[doc = "Field `CR23` writer - Cancellation Request 23"]
-pub struct CR23_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR23_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 23)) | ((value as u32 & 0x01) << 23);
-        self.w
-    }
-}
+pub type CR23_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR24` reader - Cancellation Request 24"]
-pub struct CR24_R(crate::FieldReader<bool, bool>);
-impl CR24_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR24_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR24_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR24_R = crate::BitReader;
 #[doc = "Field `CR24` writer - Cancellation Request 24"]
-pub struct CR24_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR24_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 24)) | ((value as u32 & 0x01) << 24);
-        self.w
-    }
-}
+pub type CR24_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR25` reader - Cancellation Request 25"]
-pub struct CR25_R(crate::FieldReader<bool, bool>);
-impl CR25_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR25_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR25_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR25_R = crate::BitReader;
 #[doc = "Field `CR25` writer - Cancellation Request 25"]
-pub struct CR25_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR25_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 25)) | ((value as u32 & 0x01) << 25);
-        self.w
-    }
-}
+pub type CR25_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR26` reader - Cancellation Request 26"]
-pub struct CR26_R(crate::FieldReader<bool, bool>);
-impl CR26_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR26_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR26_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR26_R = crate::BitReader;
 #[doc = "Field `CR26` writer - Cancellation Request 26"]
-pub struct CR26_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR26_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 26)) | ((value as u32 & 0x01) << 26);
-        self.w
-    }
-}
+pub type CR26_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR27` reader - Cancellation Request 27"]
-pub struct CR27_R(crate::FieldReader<bool, bool>);
-impl CR27_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR27_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR27_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR27_R = crate::BitReader;
 #[doc = "Field `CR27` writer - Cancellation Request 27"]
-pub struct CR27_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR27_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 27)) | ((value as u32 & 0x01) << 27);
-        self.w
-    }
-}
+pub type CR27_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR28` reader - Cancellation Request 28"]
-pub struct CR28_R(crate::FieldReader<bool, bool>);
-impl CR28_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR28_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR28_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR28_R = crate::BitReader;
 #[doc = "Field `CR28` writer - Cancellation Request 28"]
-pub struct CR28_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR28_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 28)) | ((value as u32 & 0x01) << 28);
-        self.w
-    }
-}
+pub type CR28_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR29` reader - Cancellation Request 29"]
-pub struct CR29_R(crate::FieldReader<bool, bool>);
-impl CR29_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR29_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR29_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR29_R = crate::BitReader;
 #[doc = "Field `CR29` writer - Cancellation Request 29"]
-pub struct CR29_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR29_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 29)) | ((value as u32 & 0x01) << 29);
-        self.w
-    }
-}
+pub type CR29_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR30` reader - Cancellation Request 30"]
-pub struct CR30_R(crate::FieldReader<bool, bool>);
-impl CR30_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR30_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR30_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR30_R = crate::BitReader;
 #[doc = "Field `CR30` writer - Cancellation Request 30"]
-pub struct CR30_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR30_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 30)) | ((value as u32 & 0x01) << 30);
-        self.w
-    }
-}
+pub type CR30_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `CR31` reader - Cancellation Request 31"]
-pub struct CR31_R(crate::FieldReader<bool, bool>);
-impl CR31_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        CR31_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for CR31_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type CR31_R = crate::BitReader;
 #[doc = "Field `CR31` writer - Cancellation Request 31"]
-pub struct CR31_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> CR31_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 31)) | ((value as u32 & 0x01) << 31);
-        self.w
-    }
-}
+pub type CR31_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
     #[doc = "Bit 0 - Cancellation Request 0"]
     #[inline(always)]
     pub fn cr0(&self) -> CR0_R {
-        CR0_R::new((self.bits & 0x01) != 0)
+        CR0_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - Cancellation Request 1"]
     #[inline(always)]
     pub fn cr1(&self) -> CR1_R {
-        CR1_R::new(((self.bits >> 1) & 0x01) != 0)
+        CR1_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - Cancellation Request 2"]
     #[inline(always)]
     pub fn cr2(&self) -> CR2_R {
-        CR2_R::new(((self.bits >> 2) & 0x01) != 0)
+        CR2_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - Cancellation Request 3"]
     #[inline(always)]
     pub fn cr3(&self) -> CR3_R {
-        CR3_R::new(((self.bits >> 3) & 0x01) != 0)
+        CR3_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - Cancellation Request 4"]
     #[inline(always)]
     pub fn cr4(&self) -> CR4_R {
-        CR4_R::new(((self.bits >> 4) & 0x01) != 0)
+        CR4_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - Cancellation Request 5"]
     #[inline(always)]
     pub fn cr5(&self) -> CR5_R {
-        CR5_R::new(((self.bits >> 5) & 0x01) != 0)
+        CR5_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - Cancellation Request 6"]
     #[inline(always)]
     pub fn cr6(&self) -> CR6_R {
-        CR6_R::new(((self.bits >> 6) & 0x01) != 0)
+        CR6_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - Cancellation Request 7"]
     #[inline(always)]
     pub fn cr7(&self) -> CR7_R {
-        CR7_R::new(((self.bits >> 7) & 0x01) != 0)
+        CR7_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - Cancellation Request 8"]
     #[inline(always)]
     pub fn cr8(&self) -> CR8_R {
-        CR8_R::new(((self.bits >> 8) & 0x01) != 0)
+        CR8_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - Cancellation Request 9"]
     #[inline(always)]
     pub fn cr9(&self) -> CR9_R {
-        CR9_R::new(((self.bits >> 9) & 0x01) != 0)
+        CR9_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - Cancellation Request 10"]
     #[inline(always)]
     pub fn cr10(&self) -> CR10_R {
-        CR10_R::new(((self.bits >> 10) & 0x01) != 0)
+        CR10_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Cancellation Request 11"]
     #[inline(always)]
     pub fn cr11(&self) -> CR11_R {
-        CR11_R::new(((self.bits >> 11) & 0x01) != 0)
+        CR11_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - Cancellation Request 12"]
     #[inline(always)]
     pub fn cr12(&self) -> CR12_R {
-        CR12_R::new(((self.bits >> 12) & 0x01) != 0)
+        CR12_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - Cancellation Request 13"]
     #[inline(always)]
     pub fn cr13(&self) -> CR13_R {
-        CR13_R::new(((self.bits >> 13) & 0x01) != 0)
+        CR13_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - Cancellation Request 14"]
     #[inline(always)]
     pub fn cr14(&self) -> CR14_R {
-        CR14_R::new(((self.bits >> 14) & 0x01) != 0)
+        CR14_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - Cancellation Request 15"]
     #[inline(always)]
     pub fn cr15(&self) -> CR15_R {
-        CR15_R::new(((self.bits >> 15) & 0x01) != 0)
+        CR15_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - Cancellation Request 16"]
     #[inline(always)]
     pub fn cr16(&self) -> CR16_R {
-        CR16_R::new(((self.bits >> 16) & 0x01) != 0)
+        CR16_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - Cancellation Request 17"]
     #[inline(always)]
     pub fn cr17(&self) -> CR17_R {
-        CR17_R::new(((self.bits >> 17) & 0x01) != 0)
+        CR17_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - Cancellation Request 18"]
     #[inline(always)]
     pub fn cr18(&self) -> CR18_R {
-        CR18_R::new(((self.bits >> 18) & 0x01) != 0)
+        CR18_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - Cancellation Request 19"]
     #[inline(always)]
     pub fn cr19(&self) -> CR19_R {
-        CR19_R::new(((self.bits >> 19) & 0x01) != 0)
+        CR19_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - Cancellation Request 20"]
     #[inline(always)]
     pub fn cr20(&self) -> CR20_R {
-        CR20_R::new(((self.bits >> 20) & 0x01) != 0)
+        CR20_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - Cancellation Request 21"]
     #[inline(always)]
     pub fn cr21(&self) -> CR21_R {
-        CR21_R::new(((self.bits >> 21) & 0x01) != 0)
+        CR21_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - Cancellation Request 22"]
     #[inline(always)]
     pub fn cr22(&self) -> CR22_R {
-        CR22_R::new(((self.bits >> 22) & 0x01) != 0)
+        CR22_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - Cancellation Request 23"]
     #[inline(always)]
     pub fn cr23(&self) -> CR23_R {
-        CR23_R::new(((self.bits >> 23) & 0x01) != 0)
+        CR23_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - Cancellation Request 24"]
     #[inline(always)]
     pub fn cr24(&self) -> CR24_R {
-        CR24_R::new(((self.bits >> 24) & 0x01) != 0)
+        CR24_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - Cancellation Request 25"]
     #[inline(always)]
     pub fn cr25(&self) -> CR25_R {
-        CR25_R::new(((self.bits >> 25) & 0x01) != 0)
+        CR25_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - Cancellation Request 26"]
     #[inline(always)]
     pub fn cr26(&self) -> CR26_R {
-        CR26_R::new(((self.bits >> 26) & 0x01) != 0)
+        CR26_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - Cancellation Request 27"]
     #[inline(always)]
     pub fn cr27(&self) -> CR27_R {
-        CR27_R::new(((self.bits >> 27) & 0x01) != 0)
+        CR27_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - Cancellation Request 28"]
     #[inline(always)]
     pub fn cr28(&self) -> CR28_R {
-        CR28_R::new(((self.bits >> 28) & 0x01) != 0)
+        CR28_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - Cancellation Request 29"]
     #[inline(always)]
     pub fn cr29(&self) -> CR29_R {
-        CR29_R::new(((self.bits >> 29) & 0x01) != 0)
+        CR29_R::new(((self.bits >> 29) & 1) != 0)
     }
     #[doc = "Bit 30 - Cancellation Request 30"]
     #[inline(always)]
     pub fn cr30(&self) -> CR30_R {
-        CR30_R::new(((self.bits >> 30) & 0x01) != 0)
+        CR30_R::new(((self.bits >> 30) & 1) != 0)
     }
     #[doc = "Bit 31 - Cancellation Request 31"]
     #[inline(always)]
     pub fn cr31(&self) -> CR31_R {
-        CR31_R::new(((self.bits >> 31) & 0x01) != 0)
+        CR31_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - Cancellation Request 0"]
     #[inline(always)]
-    pub fn cr0(&mut self) -> CR0_W {
-        CR0_W { w: self }
+    #[must_use]
+    pub fn cr0(&mut self) -> CR0_W<TXBCR_SPEC, 0> {
+        CR0_W::new(self)
     }
     #[doc = "Bit 1 - Cancellation Request 1"]
     #[inline(always)]
-    pub fn cr1(&mut self) -> CR1_W {
-        CR1_W { w: self }
+    #[must_use]
+    pub fn cr1(&mut self) -> CR1_W<TXBCR_SPEC, 1> {
+        CR1_W::new(self)
     }
     #[doc = "Bit 2 - Cancellation Request 2"]
     #[inline(always)]
-    pub fn cr2(&mut self) -> CR2_W {
-        CR2_W { w: self }
+    #[must_use]
+    pub fn cr2(&mut self) -> CR2_W<TXBCR_SPEC, 2> {
+        CR2_W::new(self)
     }
     #[doc = "Bit 3 - Cancellation Request 3"]
     #[inline(always)]
-    pub fn cr3(&mut self) -> CR3_W {
-        CR3_W { w: self }
+    #[must_use]
+    pub fn cr3(&mut self) -> CR3_W<TXBCR_SPEC, 3> {
+        CR3_W::new(self)
     }
     #[doc = "Bit 4 - Cancellation Request 4"]
     #[inline(always)]
-    pub fn cr4(&mut self) -> CR4_W {
-        CR4_W { w: self }
+    #[must_use]
+    pub fn cr4(&mut self) -> CR4_W<TXBCR_SPEC, 4> {
+        CR4_W::new(self)
     }
     #[doc = "Bit 5 - Cancellation Request 5"]
     #[inline(always)]
-    pub fn cr5(&mut self) -> CR5_W {
-        CR5_W { w: self }
+    #[must_use]
+    pub fn cr5(&mut self) -> CR5_W<TXBCR_SPEC, 5> {
+        CR5_W::new(self)
     }
     #[doc = "Bit 6 - Cancellation Request 6"]
     #[inline(always)]
-    pub fn cr6(&mut self) -> CR6_W {
-        CR6_W { w: self }
+    #[must_use]
+    pub fn cr6(&mut self) -> CR6_W<TXBCR_SPEC, 6> {
+        CR6_W::new(self)
     }
     #[doc = "Bit 7 - Cancellation Request 7"]
     #[inline(always)]
-    pub fn cr7(&mut self) -> CR7_W {
-        CR7_W { w: self }
+    #[must_use]
+    pub fn cr7(&mut self) -> CR7_W<TXBCR_SPEC, 7> {
+        CR7_W::new(self)
     }
     #[doc = "Bit 8 - Cancellation Request 8"]
     #[inline(always)]
-    pub fn cr8(&mut self) -> CR8_W {
-        CR8_W { w: self }
+    #[must_use]
+    pub fn cr8(&mut self) -> CR8_W<TXBCR_SPEC, 8> {
+        CR8_W::new(self)
     }
     #[doc = "Bit 9 - Cancellation Request 9"]
     #[inline(always)]
-    pub fn cr9(&mut self) -> CR9_W {
-        CR9_W { w: self }
+    #[must_use]
+    pub fn cr9(&mut self) -> CR9_W<TXBCR_SPEC, 9> {
+        CR9_W::new(self)
     }
     #[doc = "Bit 10 - Cancellation Request 10"]
     #[inline(always)]
-    pub fn cr10(&mut self) -> CR10_W {
-        CR10_W { w: self }
+    #[must_use]
+    pub fn cr10(&mut self) -> CR10_W<TXBCR_SPEC, 10> {
+        CR10_W::new(self)
     }
     #[doc = "Bit 11 - Cancellation Request 11"]
     #[inline(always)]
-    pub fn cr11(&mut self) -> CR11_W {
-        CR11_W { w: self }
+    #[must_use]
+    pub fn cr11(&mut self) -> CR11_W<TXBCR_SPEC, 11> {
+        CR11_W::new(self)
     }
     #[doc = "Bit 12 - Cancellation Request 12"]
     #[inline(always)]
-    pub fn cr12(&mut self) -> CR12_W {
-        CR12_W { w: self }
+    #[must_use]
+    pub fn cr12(&mut self) -> CR12_W<TXBCR_SPEC, 12> {
+        CR12_W::new(self)
     }
     #[doc = "Bit 13 - Cancellation Request 13"]
     #[inline(always)]
-    pub fn cr13(&mut self) -> CR13_W {
-        CR13_W { w: self }
+    #[must_use]
+    pub fn cr13(&mut self) -> CR13_W<TXBCR_SPEC, 13> {
+        CR13_W::new(self)
     }
     #[doc = "Bit 14 - Cancellation Request 14"]
     #[inline(always)]
-    pub fn cr14(&mut self) -> CR14_W {
-        CR14_W { w: self }
+    #[must_use]
+    pub fn cr14(&mut self) -> CR14_W<TXBCR_SPEC, 14> {
+        CR14_W::new(self)
     }
     #[doc = "Bit 15 - Cancellation Request 15"]
     #[inline(always)]
-    pub fn cr15(&mut self) -> CR15_W {
-        CR15_W { w: self }
+    #[must_use]
+    pub fn cr15(&mut self) -> CR15_W<TXBCR_SPEC, 15> {
+        CR15_W::new(self)
     }
     #[doc = "Bit 16 - Cancellation Request 16"]
     #[inline(always)]
-    pub fn cr16(&mut self) -> CR16_W {
-        CR16_W { w: self }
+    #[must_use]
+    pub fn cr16(&mut self) -> CR16_W<TXBCR_SPEC, 16> {
+        CR16_W::new(self)
     }
     #[doc = "Bit 17 - Cancellation Request 17"]
     #[inline(always)]
-    pub fn cr17(&mut self) -> CR17_W {
-        CR17_W { w: self }
+    #[must_use]
+    pub fn cr17(&mut self) -> CR17_W<TXBCR_SPEC, 17> {
+        CR17_W::new(self)
     }
     #[doc = "Bit 18 - Cancellation Request 18"]
     #[inline(always)]
-    pub fn cr18(&mut self) -> CR18_W {
-        CR18_W { w: self }
+    #[must_use]
+    pub fn cr18(&mut self) -> CR18_W<TXBCR_SPEC, 18> {
+        CR18_W::new(self)
     }
     #[doc = "Bit 19 - Cancellation Request 19"]
     #[inline(always)]
-    pub fn cr19(&mut self) -> CR19_W {
-        CR19_W { w: self }
+    #[must_use]
+    pub fn cr19(&mut self) -> CR19_W<TXBCR_SPEC, 19> {
+        CR19_W::new(self)
     }
     #[doc = "Bit 20 - Cancellation Request 20"]
     #[inline(always)]
-    pub fn cr20(&mut self) -> CR20_W {
-        CR20_W { w: self }
+    #[must_use]
+    pub fn cr20(&mut self) -> CR20_W<TXBCR_SPEC, 20> {
+        CR20_W::new(self)
     }
     #[doc = "Bit 21 - Cancellation Request 21"]
     #[inline(always)]
-    pub fn cr21(&mut self) -> CR21_W {
-        CR21_W { w: self }
+    #[must_use]
+    pub fn cr21(&mut self) -> CR21_W<TXBCR_SPEC, 21> {
+        CR21_W::new(self)
     }
     #[doc = "Bit 22 - Cancellation Request 22"]
     #[inline(always)]
-    pub fn cr22(&mut self) -> CR22_W {
-        CR22_W { w: self }
+    #[must_use]
+    pub fn cr22(&mut self) -> CR22_W<TXBCR_SPEC, 22> {
+        CR22_W::new(self)
     }
     #[doc = "Bit 23 - Cancellation Request 23"]
     #[inline(always)]
-    pub fn cr23(&mut self) -> CR23_W {
-        CR23_W { w: self }
+    #[must_use]
+    pub fn cr23(&mut self) -> CR23_W<TXBCR_SPEC, 23> {
+        CR23_W::new(self)
     }
     #[doc = "Bit 24 - Cancellation Request 24"]
     #[inline(always)]
-    pub fn cr24(&mut self) -> CR24_W {
-        CR24_W { w: self }
+    #[must_use]
+    pub fn cr24(&mut self) -> CR24_W<TXBCR_SPEC, 24> {
+        CR24_W::new(self)
     }
     #[doc = "Bit 25 - Cancellation Request 25"]
     #[inline(always)]
-    pub fn cr25(&mut self) -> CR25_W {
-        CR25_W { w: self }
+    #[must_use]
+    pub fn cr25(&mut self) -> CR25_W<TXBCR_SPEC, 25> {
+        CR25_W::new(self)
     }
     #[doc = "Bit 26 - Cancellation Request 26"]
     #[inline(always)]
-    pub fn cr26(&mut self) -> CR26_W {
-        CR26_W { w: self }
+    #[must_use]
+    pub fn cr26(&mut self) -> CR26_W<TXBCR_SPEC, 26> {
+        CR26_W::new(self)
     }
     #[doc = "Bit 27 - Cancellation Request 27"]
     #[inline(always)]
-    pub fn cr27(&mut self) -> CR27_W {
-        CR27_W { w: self }
+    #[must_use]
+    pub fn cr27(&mut self) -> CR27_W<TXBCR_SPEC, 27> {
+        CR27_W::new(self)
     }
     #[doc = "Bit 28 - Cancellation Request 28"]
     #[inline(always)]
-    pub fn cr28(&mut self) -> CR28_W {
-        CR28_W { w: self }
+    #[must_use]
+    pub fn cr28(&mut self) -> CR28_W<TXBCR_SPEC, 28> {
+        CR28_W::new(self)
     }
     #[doc = "Bit 29 - Cancellation Request 29"]
     #[inline(always)]
-    pub fn cr29(&mut self) -> CR29_W {
-        CR29_W { w: self }
+    #[must_use]
+    pub fn cr29(&mut self) -> CR29_W<TXBCR_SPEC, 29> {
+        CR29_W::new(self)
     }
     #[doc = "Bit 30 - Cancellation Request 30"]
     #[inline(always)]
-    pub fn cr30(&mut self) -> CR30_W {
-        CR30_W { w: self }
+    #[must_use]
+    pub fn cr30(&mut self) -> CR30_W<TXBCR_SPEC, 30> {
+        CR30_W::new(self)
     }
     #[doc = "Bit 31 - Cancellation Request 31"]
     #[inline(always)]
-    pub fn cr31(&mut self) -> CR31_W {
-        CR31_W { w: self }
+    #[must_use]
+    pub fn cr31(&mut self) -> CR31_W<TXBCR_SPEC, 31> {
+        CR31_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Tx Buffer Cancellation Request\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txbcr](index.html) module"]
+#[doc = "Tx Buffer Cancellation Request\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txbcr::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`txbcr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXBCR_SPEC;
 impl crate::RegisterSpec for TXBCR_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [txbcr::R](R) reader structure"]
-impl crate::Readable for TXBCR_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [txbcr::W](W) writer structure"]
+#[doc = "`read()` method returns [`txbcr::R`](R) reader structure"]
+impl crate::Readable for TXBCR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`txbcr::W`](W) writer structure"]
 impl crate::Writable for TXBCR_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets TXBCR to value 0"]
 impl crate::Resettable for TXBCR_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/txbrp.rs
+++ b/mcan/src/reg/txbrp.rs
@@ -1,673 +1,239 @@
 #[doc = "Register `TXBRP` reader"]
-pub struct R(crate::R<TXBRP_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<TXBRP_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<TXBRP_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<TXBRP_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<TXBRP_SPEC>;
 #[doc = "Field `TRP0` reader - Transmission Request Pending 0"]
-pub struct TRP0_R(crate::FieldReader<bool, bool>);
-impl TRP0_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP0_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP0_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP0_R = crate::BitReader;
 #[doc = "Field `TRP1` reader - Transmission Request Pending 1"]
-pub struct TRP1_R(crate::FieldReader<bool, bool>);
-impl TRP1_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP1_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP1_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP1_R = crate::BitReader;
 #[doc = "Field `TRP2` reader - Transmission Request Pending 2"]
-pub struct TRP2_R(crate::FieldReader<bool, bool>);
-impl TRP2_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP2_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP2_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP2_R = crate::BitReader;
 #[doc = "Field `TRP3` reader - Transmission Request Pending 3"]
-pub struct TRP3_R(crate::FieldReader<bool, bool>);
-impl TRP3_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP3_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP3_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP3_R = crate::BitReader;
 #[doc = "Field `TRP4` reader - Transmission Request Pending 4"]
-pub struct TRP4_R(crate::FieldReader<bool, bool>);
-impl TRP4_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP4_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP4_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP4_R = crate::BitReader;
 #[doc = "Field `TRP5` reader - Transmission Request Pending 5"]
-pub struct TRP5_R(crate::FieldReader<bool, bool>);
-impl TRP5_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP5_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP5_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP5_R = crate::BitReader;
 #[doc = "Field `TRP6` reader - Transmission Request Pending 6"]
-pub struct TRP6_R(crate::FieldReader<bool, bool>);
-impl TRP6_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP6_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP6_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP6_R = crate::BitReader;
 #[doc = "Field `TRP7` reader - Transmission Request Pending 7"]
-pub struct TRP7_R(crate::FieldReader<bool, bool>);
-impl TRP7_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP7_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP7_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP7_R = crate::BitReader;
 #[doc = "Field `TRP8` reader - Transmission Request Pending 8"]
-pub struct TRP8_R(crate::FieldReader<bool, bool>);
-impl TRP8_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP8_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP8_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP8_R = crate::BitReader;
 #[doc = "Field `TRP9` reader - Transmission Request Pending 9"]
-pub struct TRP9_R(crate::FieldReader<bool, bool>);
-impl TRP9_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP9_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP9_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP9_R = crate::BitReader;
 #[doc = "Field `TRP10` reader - Transmission Request Pending 10"]
-pub struct TRP10_R(crate::FieldReader<bool, bool>);
-impl TRP10_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP10_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP10_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP10_R = crate::BitReader;
 #[doc = "Field `TRP11` reader - Transmission Request Pending 11"]
-pub struct TRP11_R(crate::FieldReader<bool, bool>);
-impl TRP11_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP11_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP11_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP11_R = crate::BitReader;
 #[doc = "Field `TRP12` reader - Transmission Request Pending 12"]
-pub struct TRP12_R(crate::FieldReader<bool, bool>);
-impl TRP12_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP12_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP12_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP12_R = crate::BitReader;
 #[doc = "Field `TRP13` reader - Transmission Request Pending 13"]
-pub struct TRP13_R(crate::FieldReader<bool, bool>);
-impl TRP13_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP13_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP13_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP13_R = crate::BitReader;
 #[doc = "Field `TRP14` reader - Transmission Request Pending 14"]
-pub struct TRP14_R(crate::FieldReader<bool, bool>);
-impl TRP14_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP14_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP14_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP14_R = crate::BitReader;
 #[doc = "Field `TRP15` reader - Transmission Request Pending 15"]
-pub struct TRP15_R(crate::FieldReader<bool, bool>);
-impl TRP15_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP15_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP15_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP15_R = crate::BitReader;
 #[doc = "Field `TRP16` reader - Transmission Request Pending 16"]
-pub struct TRP16_R(crate::FieldReader<bool, bool>);
-impl TRP16_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP16_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP16_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP16_R = crate::BitReader;
 #[doc = "Field `TRP17` reader - Transmission Request Pending 17"]
-pub struct TRP17_R(crate::FieldReader<bool, bool>);
-impl TRP17_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP17_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP17_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP17_R = crate::BitReader;
 #[doc = "Field `TRP18` reader - Transmission Request Pending 18"]
-pub struct TRP18_R(crate::FieldReader<bool, bool>);
-impl TRP18_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP18_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP18_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP18_R = crate::BitReader;
 #[doc = "Field `TRP19` reader - Transmission Request Pending 19"]
-pub struct TRP19_R(crate::FieldReader<bool, bool>);
-impl TRP19_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP19_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP19_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP19_R = crate::BitReader;
 #[doc = "Field `TRP20` reader - Transmission Request Pending 20"]
-pub struct TRP20_R(crate::FieldReader<bool, bool>);
-impl TRP20_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP20_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP20_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP20_R = crate::BitReader;
 #[doc = "Field `TRP21` reader - Transmission Request Pending 21"]
-pub struct TRP21_R(crate::FieldReader<bool, bool>);
-impl TRP21_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP21_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP21_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP21_R = crate::BitReader;
 #[doc = "Field `TRP22` reader - Transmission Request Pending 22"]
-pub struct TRP22_R(crate::FieldReader<bool, bool>);
-impl TRP22_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP22_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP22_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP22_R = crate::BitReader;
 #[doc = "Field `TRP23` reader - Transmission Request Pending 23"]
-pub struct TRP23_R(crate::FieldReader<bool, bool>);
-impl TRP23_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP23_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP23_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP23_R = crate::BitReader;
 #[doc = "Field `TRP24` reader - Transmission Request Pending 24"]
-pub struct TRP24_R(crate::FieldReader<bool, bool>);
-impl TRP24_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP24_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP24_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP24_R = crate::BitReader;
 #[doc = "Field `TRP25` reader - Transmission Request Pending 25"]
-pub struct TRP25_R(crate::FieldReader<bool, bool>);
-impl TRP25_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP25_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP25_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP25_R = crate::BitReader;
 #[doc = "Field `TRP26` reader - Transmission Request Pending 26"]
-pub struct TRP26_R(crate::FieldReader<bool, bool>);
-impl TRP26_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP26_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP26_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP26_R = crate::BitReader;
 #[doc = "Field `TRP27` reader - Transmission Request Pending 27"]
-pub struct TRP27_R(crate::FieldReader<bool, bool>);
-impl TRP27_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP27_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP27_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP27_R = crate::BitReader;
 #[doc = "Field `TRP28` reader - Transmission Request Pending 28"]
-pub struct TRP28_R(crate::FieldReader<bool, bool>);
-impl TRP28_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP28_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP28_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP28_R = crate::BitReader;
 #[doc = "Field `TRP29` reader - Transmission Request Pending 29"]
-pub struct TRP29_R(crate::FieldReader<bool, bool>);
-impl TRP29_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP29_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP29_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP29_R = crate::BitReader;
 #[doc = "Field `TRP30` reader - Transmission Request Pending 30"]
-pub struct TRP30_R(crate::FieldReader<bool, bool>);
-impl TRP30_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP30_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP30_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP30_R = crate::BitReader;
 #[doc = "Field `TRP31` reader - Transmission Request Pending 31"]
-pub struct TRP31_R(crate::FieldReader<bool, bool>);
-impl TRP31_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TRP31_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TRP31_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TRP31_R = crate::BitReader;
 impl R {
     #[doc = "Bit 0 - Transmission Request Pending 0"]
     #[inline(always)]
     pub fn trp0(&self) -> TRP0_R {
-        TRP0_R::new((self.bits & 0x01) != 0)
+        TRP0_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - Transmission Request Pending 1"]
     #[inline(always)]
     pub fn trp1(&self) -> TRP1_R {
-        TRP1_R::new(((self.bits >> 1) & 0x01) != 0)
+        TRP1_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - Transmission Request Pending 2"]
     #[inline(always)]
     pub fn trp2(&self) -> TRP2_R {
-        TRP2_R::new(((self.bits >> 2) & 0x01) != 0)
+        TRP2_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - Transmission Request Pending 3"]
     #[inline(always)]
     pub fn trp3(&self) -> TRP3_R {
-        TRP3_R::new(((self.bits >> 3) & 0x01) != 0)
+        TRP3_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - Transmission Request Pending 4"]
     #[inline(always)]
     pub fn trp4(&self) -> TRP4_R {
-        TRP4_R::new(((self.bits >> 4) & 0x01) != 0)
+        TRP4_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - Transmission Request Pending 5"]
     #[inline(always)]
     pub fn trp5(&self) -> TRP5_R {
-        TRP5_R::new(((self.bits >> 5) & 0x01) != 0)
+        TRP5_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - Transmission Request Pending 6"]
     #[inline(always)]
     pub fn trp6(&self) -> TRP6_R {
-        TRP6_R::new(((self.bits >> 6) & 0x01) != 0)
+        TRP6_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - Transmission Request Pending 7"]
     #[inline(always)]
     pub fn trp7(&self) -> TRP7_R {
-        TRP7_R::new(((self.bits >> 7) & 0x01) != 0)
+        TRP7_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - Transmission Request Pending 8"]
     #[inline(always)]
     pub fn trp8(&self) -> TRP8_R {
-        TRP8_R::new(((self.bits >> 8) & 0x01) != 0)
+        TRP8_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - Transmission Request Pending 9"]
     #[inline(always)]
     pub fn trp9(&self) -> TRP9_R {
-        TRP9_R::new(((self.bits >> 9) & 0x01) != 0)
+        TRP9_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - Transmission Request Pending 10"]
     #[inline(always)]
     pub fn trp10(&self) -> TRP10_R {
-        TRP10_R::new(((self.bits >> 10) & 0x01) != 0)
+        TRP10_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Transmission Request Pending 11"]
     #[inline(always)]
     pub fn trp11(&self) -> TRP11_R {
-        TRP11_R::new(((self.bits >> 11) & 0x01) != 0)
+        TRP11_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - Transmission Request Pending 12"]
     #[inline(always)]
     pub fn trp12(&self) -> TRP12_R {
-        TRP12_R::new(((self.bits >> 12) & 0x01) != 0)
+        TRP12_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - Transmission Request Pending 13"]
     #[inline(always)]
     pub fn trp13(&self) -> TRP13_R {
-        TRP13_R::new(((self.bits >> 13) & 0x01) != 0)
+        TRP13_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - Transmission Request Pending 14"]
     #[inline(always)]
     pub fn trp14(&self) -> TRP14_R {
-        TRP14_R::new(((self.bits >> 14) & 0x01) != 0)
+        TRP14_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - Transmission Request Pending 15"]
     #[inline(always)]
     pub fn trp15(&self) -> TRP15_R {
-        TRP15_R::new(((self.bits >> 15) & 0x01) != 0)
+        TRP15_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - Transmission Request Pending 16"]
     #[inline(always)]
     pub fn trp16(&self) -> TRP16_R {
-        TRP16_R::new(((self.bits >> 16) & 0x01) != 0)
+        TRP16_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - Transmission Request Pending 17"]
     #[inline(always)]
     pub fn trp17(&self) -> TRP17_R {
-        TRP17_R::new(((self.bits >> 17) & 0x01) != 0)
+        TRP17_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - Transmission Request Pending 18"]
     #[inline(always)]
     pub fn trp18(&self) -> TRP18_R {
-        TRP18_R::new(((self.bits >> 18) & 0x01) != 0)
+        TRP18_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - Transmission Request Pending 19"]
     #[inline(always)]
     pub fn trp19(&self) -> TRP19_R {
-        TRP19_R::new(((self.bits >> 19) & 0x01) != 0)
+        TRP19_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - Transmission Request Pending 20"]
     #[inline(always)]
     pub fn trp20(&self) -> TRP20_R {
-        TRP20_R::new(((self.bits >> 20) & 0x01) != 0)
+        TRP20_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - Transmission Request Pending 21"]
     #[inline(always)]
     pub fn trp21(&self) -> TRP21_R {
-        TRP21_R::new(((self.bits >> 21) & 0x01) != 0)
+        TRP21_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - Transmission Request Pending 22"]
     #[inline(always)]
     pub fn trp22(&self) -> TRP22_R {
-        TRP22_R::new(((self.bits >> 22) & 0x01) != 0)
+        TRP22_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - Transmission Request Pending 23"]
     #[inline(always)]
     pub fn trp23(&self) -> TRP23_R {
-        TRP23_R::new(((self.bits >> 23) & 0x01) != 0)
+        TRP23_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - Transmission Request Pending 24"]
     #[inline(always)]
     pub fn trp24(&self) -> TRP24_R {
-        TRP24_R::new(((self.bits >> 24) & 0x01) != 0)
+        TRP24_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - Transmission Request Pending 25"]
     #[inline(always)]
     pub fn trp25(&self) -> TRP25_R {
-        TRP25_R::new(((self.bits >> 25) & 0x01) != 0)
+        TRP25_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - Transmission Request Pending 26"]
     #[inline(always)]
     pub fn trp26(&self) -> TRP26_R {
-        TRP26_R::new(((self.bits >> 26) & 0x01) != 0)
+        TRP26_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - Transmission Request Pending 27"]
     #[inline(always)]
     pub fn trp27(&self) -> TRP27_R {
-        TRP27_R::new(((self.bits >> 27) & 0x01) != 0)
+        TRP27_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - Transmission Request Pending 28"]
     #[inline(always)]
     pub fn trp28(&self) -> TRP28_R {
-        TRP28_R::new(((self.bits >> 28) & 0x01) != 0)
+        TRP28_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - Transmission Request Pending 29"]
     #[inline(always)]
     pub fn trp29(&self) -> TRP29_R {
-        TRP29_R::new(((self.bits >> 29) & 0x01) != 0)
+        TRP29_R::new(((self.bits >> 29) & 1) != 0)
     }
     #[doc = "Bit 30 - Transmission Request Pending 30"]
     #[inline(always)]
     pub fn trp30(&self) -> TRP30_R {
-        TRP30_R::new(((self.bits >> 30) & 0x01) != 0)
+        TRP30_R::new(((self.bits >> 30) & 1) != 0)
     }
     #[doc = "Bit 31 - Transmission Request Pending 31"]
     #[inline(always)]
     pub fn trp31(&self) -> TRP31_R {
-        TRP31_R::new(((self.bits >> 31) & 0x01) != 0)
+        TRP31_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
-#[doc = "Tx Buffer Request Pending\n\nThis register you can [`read`](crate::reg::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txbrp](index.html) module"]
+#[doc = "Tx Buffer Request Pending\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txbrp::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXBRP_SPEC;
 impl crate::RegisterSpec for TXBRP_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [txbrp::R](R) reader structure"]
-impl crate::Readable for TXBRP_SPEC {
-    type Reader = R;
-}
+#[doc = "`read()` method returns [`txbrp::R`](R) reader structure"]
+impl crate::Readable for TXBRP_SPEC {}
 #[doc = "`reset()` method sets TXBRP to value 0"]
 impl crate::Resettable for TXBRP_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/txbrp.rs
+++ b/mcan/src/reg/txbrp.rs
@@ -226,7 +226,7 @@ impl R {
         TRP31_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
-#[doc = "Tx Buffer Request Pending\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txbrp::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Tx Buffer Request Pending\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`txbrp::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXBRP_SPEC;
 impl crate::RegisterSpec for TXBRP_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/txbtie.rs
+++ b/mcan/src/reg/txbtie.rs
@@ -1,1570 +1,514 @@
 #[doc = "Register `TXBTIE` reader"]
-pub struct R(crate::R<TXBTIE_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<TXBTIE_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<TXBTIE_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<TXBTIE_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<TXBTIE_SPEC>;
 #[doc = "Register `TXBTIE` writer"]
-pub struct W(crate::W<TXBTIE_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<TXBTIE_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<TXBTIE_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<TXBTIE_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<TXBTIE_SPEC>;
 #[doc = "Field `TIE0` reader - Transmission Interrupt Enable 0"]
-pub struct TIE0_R(crate::FieldReader<bool, bool>);
-impl TIE0_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE0_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE0_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE0_R = crate::BitReader;
 #[doc = "Field `TIE0` writer - Transmission Interrupt Enable 0"]
-pub struct TIE0_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE0_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x01) | (value as u32 & 0x01);
-        self.w
-    }
-}
+pub type TIE0_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE1` reader - Transmission Interrupt Enable 1"]
-pub struct TIE1_R(crate::FieldReader<bool, bool>);
-impl TIE1_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE1_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE1_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE1_R = crate::BitReader;
 #[doc = "Field `TIE1` writer - Transmission Interrupt Enable 1"]
-pub struct TIE1_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE1_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 1)) | ((value as u32 & 0x01) << 1);
-        self.w
-    }
-}
+pub type TIE1_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE2` reader - Transmission Interrupt Enable 2"]
-pub struct TIE2_R(crate::FieldReader<bool, bool>);
-impl TIE2_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE2_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE2_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE2_R = crate::BitReader;
 #[doc = "Field `TIE2` writer - Transmission Interrupt Enable 2"]
-pub struct TIE2_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE2_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 2)) | ((value as u32 & 0x01) << 2);
-        self.w
-    }
-}
+pub type TIE2_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE3` reader - Transmission Interrupt Enable 3"]
-pub struct TIE3_R(crate::FieldReader<bool, bool>);
-impl TIE3_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE3_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE3_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE3_R = crate::BitReader;
 #[doc = "Field `TIE3` writer - Transmission Interrupt Enable 3"]
-pub struct TIE3_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE3_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 3)) | ((value as u32 & 0x01) << 3);
-        self.w
-    }
-}
+pub type TIE3_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE4` reader - Transmission Interrupt Enable 4"]
-pub struct TIE4_R(crate::FieldReader<bool, bool>);
-impl TIE4_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE4_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE4_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE4_R = crate::BitReader;
 #[doc = "Field `TIE4` writer - Transmission Interrupt Enable 4"]
-pub struct TIE4_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE4_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 4)) | ((value as u32 & 0x01) << 4);
-        self.w
-    }
-}
+pub type TIE4_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE5` reader - Transmission Interrupt Enable 5"]
-pub struct TIE5_R(crate::FieldReader<bool, bool>);
-impl TIE5_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE5_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE5_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE5_R = crate::BitReader;
 #[doc = "Field `TIE5` writer - Transmission Interrupt Enable 5"]
-pub struct TIE5_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE5_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 5)) | ((value as u32 & 0x01) << 5);
-        self.w
-    }
-}
+pub type TIE5_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE6` reader - Transmission Interrupt Enable 6"]
-pub struct TIE6_R(crate::FieldReader<bool, bool>);
-impl TIE6_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE6_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE6_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE6_R = crate::BitReader;
 #[doc = "Field `TIE6` writer - Transmission Interrupt Enable 6"]
-pub struct TIE6_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE6_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 6)) | ((value as u32 & 0x01) << 6);
-        self.w
-    }
-}
+pub type TIE6_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE7` reader - Transmission Interrupt Enable 7"]
-pub struct TIE7_R(crate::FieldReader<bool, bool>);
-impl TIE7_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE7_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE7_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE7_R = crate::BitReader;
 #[doc = "Field `TIE7` writer - Transmission Interrupt Enable 7"]
-pub struct TIE7_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE7_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 7)) | ((value as u32 & 0x01) << 7);
-        self.w
-    }
-}
+pub type TIE7_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE8` reader - Transmission Interrupt Enable 8"]
-pub struct TIE8_R(crate::FieldReader<bool, bool>);
-impl TIE8_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE8_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE8_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE8_R = crate::BitReader;
 #[doc = "Field `TIE8` writer - Transmission Interrupt Enable 8"]
-pub struct TIE8_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE8_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 8)) | ((value as u32 & 0x01) << 8);
-        self.w
-    }
-}
+pub type TIE8_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE9` reader - Transmission Interrupt Enable 9"]
-pub struct TIE9_R(crate::FieldReader<bool, bool>);
-impl TIE9_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE9_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE9_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE9_R = crate::BitReader;
 #[doc = "Field `TIE9` writer - Transmission Interrupt Enable 9"]
-pub struct TIE9_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE9_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 9)) | ((value as u32 & 0x01) << 9);
-        self.w
-    }
-}
+pub type TIE9_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE10` reader - Transmission Interrupt Enable 10"]
-pub struct TIE10_R(crate::FieldReader<bool, bool>);
-impl TIE10_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE10_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE10_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE10_R = crate::BitReader;
 #[doc = "Field `TIE10` writer - Transmission Interrupt Enable 10"]
-pub struct TIE10_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE10_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 10)) | ((value as u32 & 0x01) << 10);
-        self.w
-    }
-}
+pub type TIE10_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE11` reader - Transmission Interrupt Enable 11"]
-pub struct TIE11_R(crate::FieldReader<bool, bool>);
-impl TIE11_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE11_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE11_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE11_R = crate::BitReader;
 #[doc = "Field `TIE11` writer - Transmission Interrupt Enable 11"]
-pub struct TIE11_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE11_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 11)) | ((value as u32 & 0x01) << 11);
-        self.w
-    }
-}
+pub type TIE11_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE12` reader - Transmission Interrupt Enable 12"]
-pub struct TIE12_R(crate::FieldReader<bool, bool>);
-impl TIE12_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE12_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE12_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE12_R = crate::BitReader;
 #[doc = "Field `TIE12` writer - Transmission Interrupt Enable 12"]
-pub struct TIE12_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE12_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 12)) | ((value as u32 & 0x01) << 12);
-        self.w
-    }
-}
+pub type TIE12_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE13` reader - Transmission Interrupt Enable 13"]
-pub struct TIE13_R(crate::FieldReader<bool, bool>);
-impl TIE13_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE13_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE13_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE13_R = crate::BitReader;
 #[doc = "Field `TIE13` writer - Transmission Interrupt Enable 13"]
-pub struct TIE13_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE13_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 13)) | ((value as u32 & 0x01) << 13);
-        self.w
-    }
-}
+pub type TIE13_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE14` reader - Transmission Interrupt Enable 14"]
-pub struct TIE14_R(crate::FieldReader<bool, bool>);
-impl TIE14_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE14_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE14_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE14_R = crate::BitReader;
 #[doc = "Field `TIE14` writer - Transmission Interrupt Enable 14"]
-pub struct TIE14_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE14_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 14)) | ((value as u32 & 0x01) << 14);
-        self.w
-    }
-}
+pub type TIE14_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE15` reader - Transmission Interrupt Enable 15"]
-pub struct TIE15_R(crate::FieldReader<bool, bool>);
-impl TIE15_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE15_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE15_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE15_R = crate::BitReader;
 #[doc = "Field `TIE15` writer - Transmission Interrupt Enable 15"]
-pub struct TIE15_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE15_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 15)) | ((value as u32 & 0x01) << 15);
-        self.w
-    }
-}
+pub type TIE15_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE16` reader - Transmission Interrupt Enable 16"]
-pub struct TIE16_R(crate::FieldReader<bool, bool>);
-impl TIE16_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE16_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE16_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE16_R = crate::BitReader;
 #[doc = "Field `TIE16` writer - Transmission Interrupt Enable 16"]
-pub struct TIE16_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE16_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 16)) | ((value as u32 & 0x01) << 16);
-        self.w
-    }
-}
+pub type TIE16_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE17` reader - Transmission Interrupt Enable 17"]
-pub struct TIE17_R(crate::FieldReader<bool, bool>);
-impl TIE17_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE17_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE17_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE17_R = crate::BitReader;
 #[doc = "Field `TIE17` writer - Transmission Interrupt Enable 17"]
-pub struct TIE17_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE17_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 17)) | ((value as u32 & 0x01) << 17);
-        self.w
-    }
-}
+pub type TIE17_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE18` reader - Transmission Interrupt Enable 18"]
-pub struct TIE18_R(crate::FieldReader<bool, bool>);
-impl TIE18_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE18_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE18_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE18_R = crate::BitReader;
 #[doc = "Field `TIE18` writer - Transmission Interrupt Enable 18"]
-pub struct TIE18_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE18_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 18)) | ((value as u32 & 0x01) << 18);
-        self.w
-    }
-}
+pub type TIE18_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE19` reader - Transmission Interrupt Enable 19"]
-pub struct TIE19_R(crate::FieldReader<bool, bool>);
-impl TIE19_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE19_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE19_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE19_R = crate::BitReader;
 #[doc = "Field `TIE19` writer - Transmission Interrupt Enable 19"]
-pub struct TIE19_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE19_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 19)) | ((value as u32 & 0x01) << 19);
-        self.w
-    }
-}
+pub type TIE19_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE20` reader - Transmission Interrupt Enable 20"]
-pub struct TIE20_R(crate::FieldReader<bool, bool>);
-impl TIE20_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE20_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE20_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE20_R = crate::BitReader;
 #[doc = "Field `TIE20` writer - Transmission Interrupt Enable 20"]
-pub struct TIE20_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE20_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 20)) | ((value as u32 & 0x01) << 20);
-        self.w
-    }
-}
+pub type TIE20_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE21` reader - Transmission Interrupt Enable 21"]
-pub struct TIE21_R(crate::FieldReader<bool, bool>);
-impl TIE21_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE21_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE21_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE21_R = crate::BitReader;
 #[doc = "Field `TIE21` writer - Transmission Interrupt Enable 21"]
-pub struct TIE21_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE21_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 21)) | ((value as u32 & 0x01) << 21);
-        self.w
-    }
-}
+pub type TIE21_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE22` reader - Transmission Interrupt Enable 22"]
-pub struct TIE22_R(crate::FieldReader<bool, bool>);
-impl TIE22_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE22_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE22_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE22_R = crate::BitReader;
 #[doc = "Field `TIE22` writer - Transmission Interrupt Enable 22"]
-pub struct TIE22_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE22_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 22)) | ((value as u32 & 0x01) << 22);
-        self.w
-    }
-}
+pub type TIE22_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE23` reader - Transmission Interrupt Enable 23"]
-pub struct TIE23_R(crate::FieldReader<bool, bool>);
-impl TIE23_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE23_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE23_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE23_R = crate::BitReader;
 #[doc = "Field `TIE23` writer - Transmission Interrupt Enable 23"]
-pub struct TIE23_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE23_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 23)) | ((value as u32 & 0x01) << 23);
-        self.w
-    }
-}
+pub type TIE23_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE24` reader - Transmission Interrupt Enable 24"]
-pub struct TIE24_R(crate::FieldReader<bool, bool>);
-impl TIE24_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE24_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE24_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE24_R = crate::BitReader;
 #[doc = "Field `TIE24` writer - Transmission Interrupt Enable 24"]
-pub struct TIE24_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE24_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 24)) | ((value as u32 & 0x01) << 24);
-        self.w
-    }
-}
+pub type TIE24_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE25` reader - Transmission Interrupt Enable 25"]
-pub struct TIE25_R(crate::FieldReader<bool, bool>);
-impl TIE25_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE25_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE25_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE25_R = crate::BitReader;
 #[doc = "Field `TIE25` writer - Transmission Interrupt Enable 25"]
-pub struct TIE25_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE25_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 25)) | ((value as u32 & 0x01) << 25);
-        self.w
-    }
-}
+pub type TIE25_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE26` reader - Transmission Interrupt Enable 26"]
-pub struct TIE26_R(crate::FieldReader<bool, bool>);
-impl TIE26_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE26_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE26_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE26_R = crate::BitReader;
 #[doc = "Field `TIE26` writer - Transmission Interrupt Enable 26"]
-pub struct TIE26_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE26_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 26)) | ((value as u32 & 0x01) << 26);
-        self.w
-    }
-}
+pub type TIE26_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE27` reader - Transmission Interrupt Enable 27"]
-pub struct TIE27_R(crate::FieldReader<bool, bool>);
-impl TIE27_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE27_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE27_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE27_R = crate::BitReader;
 #[doc = "Field `TIE27` writer - Transmission Interrupt Enable 27"]
-pub struct TIE27_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE27_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 27)) | ((value as u32 & 0x01) << 27);
-        self.w
-    }
-}
+pub type TIE27_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE28` reader - Transmission Interrupt Enable 28"]
-pub struct TIE28_R(crate::FieldReader<bool, bool>);
-impl TIE28_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE28_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE28_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE28_R = crate::BitReader;
 #[doc = "Field `TIE28` writer - Transmission Interrupt Enable 28"]
-pub struct TIE28_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE28_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 28)) | ((value as u32 & 0x01) << 28);
-        self.w
-    }
-}
+pub type TIE28_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE29` reader - Transmission Interrupt Enable 29"]
-pub struct TIE29_R(crate::FieldReader<bool, bool>);
-impl TIE29_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE29_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE29_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE29_R = crate::BitReader;
 #[doc = "Field `TIE29` writer - Transmission Interrupt Enable 29"]
-pub struct TIE29_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE29_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 29)) | ((value as u32 & 0x01) << 29);
-        self.w
-    }
-}
+pub type TIE29_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE30` reader - Transmission Interrupt Enable 30"]
-pub struct TIE30_R(crate::FieldReader<bool, bool>);
-impl TIE30_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE30_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE30_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE30_R = crate::BitReader;
 #[doc = "Field `TIE30` writer - Transmission Interrupt Enable 30"]
-pub struct TIE30_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE30_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 30)) | ((value as u32 & 0x01) << 30);
-        self.w
-    }
-}
+pub type TIE30_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `TIE31` reader - Transmission Interrupt Enable 31"]
-pub struct TIE31_R(crate::FieldReader<bool, bool>);
-impl TIE31_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TIE31_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TIE31_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TIE31_R = crate::BitReader;
 #[doc = "Field `TIE31` writer - Transmission Interrupt Enable 31"]
-pub struct TIE31_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TIE31_W<'a> {
-    #[doc = r"Sets the field bit"]
-    #[inline(always)]
-    pub fn set_bit(self) -> &'a mut W {
-        self.bit(true)
-    }
-    #[doc = r"Clears the field bit"]
-    #[inline(always)]
-    pub fn clear_bit(self) -> &'a mut W {
-        self.bit(false)
-    }
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub fn bit(self, value: bool) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x01 << 31)) | ((value as u32 & 0x01) << 31);
-        self.w
-    }
-}
+pub type TIE31_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
     #[doc = "Bit 0 - Transmission Interrupt Enable 0"]
     #[inline(always)]
     pub fn tie0(&self) -> TIE0_R {
-        TIE0_R::new((self.bits & 0x01) != 0)
+        TIE0_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - Transmission Interrupt Enable 1"]
     #[inline(always)]
     pub fn tie1(&self) -> TIE1_R {
-        TIE1_R::new(((self.bits >> 1) & 0x01) != 0)
+        TIE1_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - Transmission Interrupt Enable 2"]
     #[inline(always)]
     pub fn tie2(&self) -> TIE2_R {
-        TIE2_R::new(((self.bits >> 2) & 0x01) != 0)
+        TIE2_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - Transmission Interrupt Enable 3"]
     #[inline(always)]
     pub fn tie3(&self) -> TIE3_R {
-        TIE3_R::new(((self.bits >> 3) & 0x01) != 0)
+        TIE3_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - Transmission Interrupt Enable 4"]
     #[inline(always)]
     pub fn tie4(&self) -> TIE4_R {
-        TIE4_R::new(((self.bits >> 4) & 0x01) != 0)
+        TIE4_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - Transmission Interrupt Enable 5"]
     #[inline(always)]
     pub fn tie5(&self) -> TIE5_R {
-        TIE5_R::new(((self.bits >> 5) & 0x01) != 0)
+        TIE5_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - Transmission Interrupt Enable 6"]
     #[inline(always)]
     pub fn tie6(&self) -> TIE6_R {
-        TIE6_R::new(((self.bits >> 6) & 0x01) != 0)
+        TIE6_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - Transmission Interrupt Enable 7"]
     #[inline(always)]
     pub fn tie7(&self) -> TIE7_R {
-        TIE7_R::new(((self.bits >> 7) & 0x01) != 0)
+        TIE7_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - Transmission Interrupt Enable 8"]
     #[inline(always)]
     pub fn tie8(&self) -> TIE8_R {
-        TIE8_R::new(((self.bits >> 8) & 0x01) != 0)
+        TIE8_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - Transmission Interrupt Enable 9"]
     #[inline(always)]
     pub fn tie9(&self) -> TIE9_R {
-        TIE9_R::new(((self.bits >> 9) & 0x01) != 0)
+        TIE9_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - Transmission Interrupt Enable 10"]
     #[inline(always)]
     pub fn tie10(&self) -> TIE10_R {
-        TIE10_R::new(((self.bits >> 10) & 0x01) != 0)
+        TIE10_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Transmission Interrupt Enable 11"]
     #[inline(always)]
     pub fn tie11(&self) -> TIE11_R {
-        TIE11_R::new(((self.bits >> 11) & 0x01) != 0)
+        TIE11_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - Transmission Interrupt Enable 12"]
     #[inline(always)]
     pub fn tie12(&self) -> TIE12_R {
-        TIE12_R::new(((self.bits >> 12) & 0x01) != 0)
+        TIE12_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - Transmission Interrupt Enable 13"]
     #[inline(always)]
     pub fn tie13(&self) -> TIE13_R {
-        TIE13_R::new(((self.bits >> 13) & 0x01) != 0)
+        TIE13_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - Transmission Interrupt Enable 14"]
     #[inline(always)]
     pub fn tie14(&self) -> TIE14_R {
-        TIE14_R::new(((self.bits >> 14) & 0x01) != 0)
+        TIE14_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - Transmission Interrupt Enable 15"]
     #[inline(always)]
     pub fn tie15(&self) -> TIE15_R {
-        TIE15_R::new(((self.bits >> 15) & 0x01) != 0)
+        TIE15_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - Transmission Interrupt Enable 16"]
     #[inline(always)]
     pub fn tie16(&self) -> TIE16_R {
-        TIE16_R::new(((self.bits >> 16) & 0x01) != 0)
+        TIE16_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - Transmission Interrupt Enable 17"]
     #[inline(always)]
     pub fn tie17(&self) -> TIE17_R {
-        TIE17_R::new(((self.bits >> 17) & 0x01) != 0)
+        TIE17_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - Transmission Interrupt Enable 18"]
     #[inline(always)]
     pub fn tie18(&self) -> TIE18_R {
-        TIE18_R::new(((self.bits >> 18) & 0x01) != 0)
+        TIE18_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - Transmission Interrupt Enable 19"]
     #[inline(always)]
     pub fn tie19(&self) -> TIE19_R {
-        TIE19_R::new(((self.bits >> 19) & 0x01) != 0)
+        TIE19_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - Transmission Interrupt Enable 20"]
     #[inline(always)]
     pub fn tie20(&self) -> TIE20_R {
-        TIE20_R::new(((self.bits >> 20) & 0x01) != 0)
+        TIE20_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - Transmission Interrupt Enable 21"]
     #[inline(always)]
     pub fn tie21(&self) -> TIE21_R {
-        TIE21_R::new(((self.bits >> 21) & 0x01) != 0)
+        TIE21_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - Transmission Interrupt Enable 22"]
     #[inline(always)]
     pub fn tie22(&self) -> TIE22_R {
-        TIE22_R::new(((self.bits >> 22) & 0x01) != 0)
+        TIE22_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - Transmission Interrupt Enable 23"]
     #[inline(always)]
     pub fn tie23(&self) -> TIE23_R {
-        TIE23_R::new(((self.bits >> 23) & 0x01) != 0)
+        TIE23_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - Transmission Interrupt Enable 24"]
     #[inline(always)]
     pub fn tie24(&self) -> TIE24_R {
-        TIE24_R::new(((self.bits >> 24) & 0x01) != 0)
+        TIE24_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - Transmission Interrupt Enable 25"]
     #[inline(always)]
     pub fn tie25(&self) -> TIE25_R {
-        TIE25_R::new(((self.bits >> 25) & 0x01) != 0)
+        TIE25_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - Transmission Interrupt Enable 26"]
     #[inline(always)]
     pub fn tie26(&self) -> TIE26_R {
-        TIE26_R::new(((self.bits >> 26) & 0x01) != 0)
+        TIE26_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - Transmission Interrupt Enable 27"]
     #[inline(always)]
     pub fn tie27(&self) -> TIE27_R {
-        TIE27_R::new(((self.bits >> 27) & 0x01) != 0)
+        TIE27_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - Transmission Interrupt Enable 28"]
     #[inline(always)]
     pub fn tie28(&self) -> TIE28_R {
-        TIE28_R::new(((self.bits >> 28) & 0x01) != 0)
+        TIE28_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - Transmission Interrupt Enable 29"]
     #[inline(always)]
     pub fn tie29(&self) -> TIE29_R {
-        TIE29_R::new(((self.bits >> 29) & 0x01) != 0)
+        TIE29_R::new(((self.bits >> 29) & 1) != 0)
     }
     #[doc = "Bit 30 - Transmission Interrupt Enable 30"]
     #[inline(always)]
     pub fn tie30(&self) -> TIE30_R {
-        TIE30_R::new(((self.bits >> 30) & 0x01) != 0)
+        TIE30_R::new(((self.bits >> 30) & 1) != 0)
     }
     #[doc = "Bit 31 - Transmission Interrupt Enable 31"]
     #[inline(always)]
     pub fn tie31(&self) -> TIE31_R {
-        TIE31_R::new(((self.bits >> 31) & 0x01) != 0)
+        TIE31_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - Transmission Interrupt Enable 0"]
     #[inline(always)]
-    pub fn tie0(&mut self) -> TIE0_W {
-        TIE0_W { w: self }
+    #[must_use]
+    pub fn tie0(&mut self) -> TIE0_W<TXBTIE_SPEC, 0> {
+        TIE0_W::new(self)
     }
     #[doc = "Bit 1 - Transmission Interrupt Enable 1"]
     #[inline(always)]
-    pub fn tie1(&mut self) -> TIE1_W {
-        TIE1_W { w: self }
+    #[must_use]
+    pub fn tie1(&mut self) -> TIE1_W<TXBTIE_SPEC, 1> {
+        TIE1_W::new(self)
     }
     #[doc = "Bit 2 - Transmission Interrupt Enable 2"]
     #[inline(always)]
-    pub fn tie2(&mut self) -> TIE2_W {
-        TIE2_W { w: self }
+    #[must_use]
+    pub fn tie2(&mut self) -> TIE2_W<TXBTIE_SPEC, 2> {
+        TIE2_W::new(self)
     }
     #[doc = "Bit 3 - Transmission Interrupt Enable 3"]
     #[inline(always)]
-    pub fn tie3(&mut self) -> TIE3_W {
-        TIE3_W { w: self }
+    #[must_use]
+    pub fn tie3(&mut self) -> TIE3_W<TXBTIE_SPEC, 3> {
+        TIE3_W::new(self)
     }
     #[doc = "Bit 4 - Transmission Interrupt Enable 4"]
     #[inline(always)]
-    pub fn tie4(&mut self) -> TIE4_W {
-        TIE4_W { w: self }
+    #[must_use]
+    pub fn tie4(&mut self) -> TIE4_W<TXBTIE_SPEC, 4> {
+        TIE4_W::new(self)
     }
     #[doc = "Bit 5 - Transmission Interrupt Enable 5"]
     #[inline(always)]
-    pub fn tie5(&mut self) -> TIE5_W {
-        TIE5_W { w: self }
+    #[must_use]
+    pub fn tie5(&mut self) -> TIE5_W<TXBTIE_SPEC, 5> {
+        TIE5_W::new(self)
     }
     #[doc = "Bit 6 - Transmission Interrupt Enable 6"]
     #[inline(always)]
-    pub fn tie6(&mut self) -> TIE6_W {
-        TIE6_W { w: self }
+    #[must_use]
+    pub fn tie6(&mut self) -> TIE6_W<TXBTIE_SPEC, 6> {
+        TIE6_W::new(self)
     }
     #[doc = "Bit 7 - Transmission Interrupt Enable 7"]
     #[inline(always)]
-    pub fn tie7(&mut self) -> TIE7_W {
-        TIE7_W { w: self }
+    #[must_use]
+    pub fn tie7(&mut self) -> TIE7_W<TXBTIE_SPEC, 7> {
+        TIE7_W::new(self)
     }
     #[doc = "Bit 8 - Transmission Interrupt Enable 8"]
     #[inline(always)]
-    pub fn tie8(&mut self) -> TIE8_W {
-        TIE8_W { w: self }
+    #[must_use]
+    pub fn tie8(&mut self) -> TIE8_W<TXBTIE_SPEC, 8> {
+        TIE8_W::new(self)
     }
     #[doc = "Bit 9 - Transmission Interrupt Enable 9"]
     #[inline(always)]
-    pub fn tie9(&mut self) -> TIE9_W {
-        TIE9_W { w: self }
+    #[must_use]
+    pub fn tie9(&mut self) -> TIE9_W<TXBTIE_SPEC, 9> {
+        TIE9_W::new(self)
     }
     #[doc = "Bit 10 - Transmission Interrupt Enable 10"]
     #[inline(always)]
-    pub fn tie10(&mut self) -> TIE10_W {
-        TIE10_W { w: self }
+    #[must_use]
+    pub fn tie10(&mut self) -> TIE10_W<TXBTIE_SPEC, 10> {
+        TIE10_W::new(self)
     }
     #[doc = "Bit 11 - Transmission Interrupt Enable 11"]
     #[inline(always)]
-    pub fn tie11(&mut self) -> TIE11_W {
-        TIE11_W { w: self }
+    #[must_use]
+    pub fn tie11(&mut self) -> TIE11_W<TXBTIE_SPEC, 11> {
+        TIE11_W::new(self)
     }
     #[doc = "Bit 12 - Transmission Interrupt Enable 12"]
     #[inline(always)]
-    pub fn tie12(&mut self) -> TIE12_W {
-        TIE12_W { w: self }
+    #[must_use]
+    pub fn tie12(&mut self) -> TIE12_W<TXBTIE_SPEC, 12> {
+        TIE12_W::new(self)
     }
     #[doc = "Bit 13 - Transmission Interrupt Enable 13"]
     #[inline(always)]
-    pub fn tie13(&mut self) -> TIE13_W {
-        TIE13_W { w: self }
+    #[must_use]
+    pub fn tie13(&mut self) -> TIE13_W<TXBTIE_SPEC, 13> {
+        TIE13_W::new(self)
     }
     #[doc = "Bit 14 - Transmission Interrupt Enable 14"]
     #[inline(always)]
-    pub fn tie14(&mut self) -> TIE14_W {
-        TIE14_W { w: self }
+    #[must_use]
+    pub fn tie14(&mut self) -> TIE14_W<TXBTIE_SPEC, 14> {
+        TIE14_W::new(self)
     }
     #[doc = "Bit 15 - Transmission Interrupt Enable 15"]
     #[inline(always)]
-    pub fn tie15(&mut self) -> TIE15_W {
-        TIE15_W { w: self }
+    #[must_use]
+    pub fn tie15(&mut self) -> TIE15_W<TXBTIE_SPEC, 15> {
+        TIE15_W::new(self)
     }
     #[doc = "Bit 16 - Transmission Interrupt Enable 16"]
     #[inline(always)]
-    pub fn tie16(&mut self) -> TIE16_W {
-        TIE16_W { w: self }
+    #[must_use]
+    pub fn tie16(&mut self) -> TIE16_W<TXBTIE_SPEC, 16> {
+        TIE16_W::new(self)
     }
     #[doc = "Bit 17 - Transmission Interrupt Enable 17"]
     #[inline(always)]
-    pub fn tie17(&mut self) -> TIE17_W {
-        TIE17_W { w: self }
+    #[must_use]
+    pub fn tie17(&mut self) -> TIE17_W<TXBTIE_SPEC, 17> {
+        TIE17_W::new(self)
     }
     #[doc = "Bit 18 - Transmission Interrupt Enable 18"]
     #[inline(always)]
-    pub fn tie18(&mut self) -> TIE18_W {
-        TIE18_W { w: self }
+    #[must_use]
+    pub fn tie18(&mut self) -> TIE18_W<TXBTIE_SPEC, 18> {
+        TIE18_W::new(self)
     }
     #[doc = "Bit 19 - Transmission Interrupt Enable 19"]
     #[inline(always)]
-    pub fn tie19(&mut self) -> TIE19_W {
-        TIE19_W { w: self }
+    #[must_use]
+    pub fn tie19(&mut self) -> TIE19_W<TXBTIE_SPEC, 19> {
+        TIE19_W::new(self)
     }
     #[doc = "Bit 20 - Transmission Interrupt Enable 20"]
     #[inline(always)]
-    pub fn tie20(&mut self) -> TIE20_W {
-        TIE20_W { w: self }
+    #[must_use]
+    pub fn tie20(&mut self) -> TIE20_W<TXBTIE_SPEC, 20> {
+        TIE20_W::new(self)
     }
     #[doc = "Bit 21 - Transmission Interrupt Enable 21"]
     #[inline(always)]
-    pub fn tie21(&mut self) -> TIE21_W {
-        TIE21_W { w: self }
+    #[must_use]
+    pub fn tie21(&mut self) -> TIE21_W<TXBTIE_SPEC, 21> {
+        TIE21_W::new(self)
     }
     #[doc = "Bit 22 - Transmission Interrupt Enable 22"]
     #[inline(always)]
-    pub fn tie22(&mut self) -> TIE22_W {
-        TIE22_W { w: self }
+    #[must_use]
+    pub fn tie22(&mut self) -> TIE22_W<TXBTIE_SPEC, 22> {
+        TIE22_W::new(self)
     }
     #[doc = "Bit 23 - Transmission Interrupt Enable 23"]
     #[inline(always)]
-    pub fn tie23(&mut self) -> TIE23_W {
-        TIE23_W { w: self }
+    #[must_use]
+    pub fn tie23(&mut self) -> TIE23_W<TXBTIE_SPEC, 23> {
+        TIE23_W::new(self)
     }
     #[doc = "Bit 24 - Transmission Interrupt Enable 24"]
     #[inline(always)]
-    pub fn tie24(&mut self) -> TIE24_W {
-        TIE24_W { w: self }
+    #[must_use]
+    pub fn tie24(&mut self) -> TIE24_W<TXBTIE_SPEC, 24> {
+        TIE24_W::new(self)
     }
     #[doc = "Bit 25 - Transmission Interrupt Enable 25"]
     #[inline(always)]
-    pub fn tie25(&mut self) -> TIE25_W {
-        TIE25_W { w: self }
+    #[must_use]
+    pub fn tie25(&mut self) -> TIE25_W<TXBTIE_SPEC, 25> {
+        TIE25_W::new(self)
     }
     #[doc = "Bit 26 - Transmission Interrupt Enable 26"]
     #[inline(always)]
-    pub fn tie26(&mut self) -> TIE26_W {
-        TIE26_W { w: self }
+    #[must_use]
+    pub fn tie26(&mut self) -> TIE26_W<TXBTIE_SPEC, 26> {
+        TIE26_W::new(self)
     }
     #[doc = "Bit 27 - Transmission Interrupt Enable 27"]
     #[inline(always)]
-    pub fn tie27(&mut self) -> TIE27_W {
-        TIE27_W { w: self }
+    #[must_use]
+    pub fn tie27(&mut self) -> TIE27_W<TXBTIE_SPEC, 27> {
+        TIE27_W::new(self)
     }
     #[doc = "Bit 28 - Transmission Interrupt Enable 28"]
     #[inline(always)]
-    pub fn tie28(&mut self) -> TIE28_W {
-        TIE28_W { w: self }
+    #[must_use]
+    pub fn tie28(&mut self) -> TIE28_W<TXBTIE_SPEC, 28> {
+        TIE28_W::new(self)
     }
     #[doc = "Bit 29 - Transmission Interrupt Enable 29"]
     #[inline(always)]
-    pub fn tie29(&mut self) -> TIE29_W {
-        TIE29_W { w: self }
+    #[must_use]
+    pub fn tie29(&mut self) -> TIE29_W<TXBTIE_SPEC, 29> {
+        TIE29_W::new(self)
     }
     #[doc = "Bit 30 - Transmission Interrupt Enable 30"]
     #[inline(always)]
-    pub fn tie30(&mut self) -> TIE30_W {
-        TIE30_W { w: self }
+    #[must_use]
+    pub fn tie30(&mut self) -> TIE30_W<TXBTIE_SPEC, 30> {
+        TIE30_W::new(self)
     }
     #[doc = "Bit 31 - Transmission Interrupt Enable 31"]
     #[inline(always)]
-    pub fn tie31(&mut self) -> TIE31_W {
-        TIE31_W { w: self }
+    #[must_use]
+    pub fn tie31(&mut self) -> TIE31_W<TXBTIE_SPEC, 31> {
+        TIE31_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Tx Buffer Transmission Interrupt Enable\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txbtie](index.html) module"]
+#[doc = "Tx Buffer Transmission Interrupt Enable\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txbtie::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`txbtie::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXBTIE_SPEC;
 impl crate::RegisterSpec for TXBTIE_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [txbtie::R](R) reader structure"]
-impl crate::Readable for TXBTIE_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [txbtie::W](W) writer structure"]
+#[doc = "`read()` method returns [`txbtie::R`](R) reader structure"]
+impl crate::Readable for TXBTIE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`txbtie::W`](W) writer structure"]
 impl crate::Writable for TXBTIE_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets TXBTIE to value 0"]
 impl crate::Resettable for TXBTIE_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/txbtie.rs
+++ b/mcan/src/reg/txbtie.rs
@@ -496,7 +496,7 @@ impl W {
         self
     }
 }
-#[doc = "Tx Buffer Transmission Interrupt Enable\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txbtie::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`txbtie::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Tx Buffer Transmission Interrupt Enable\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`txbtie::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`txbtie::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXBTIE_SPEC;
 impl crate::RegisterSpec for TXBTIE_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/txbto.rs
+++ b/mcan/src/reg/txbto.rs
@@ -1,673 +1,239 @@
 #[doc = "Register `TXBTO` reader"]
-pub struct R(crate::R<TXBTO_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<TXBTO_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<TXBTO_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<TXBTO_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<TXBTO_SPEC>;
 #[doc = "Field `TO0` reader - Transmission Occurred 0"]
-pub struct TO0_R(crate::FieldReader<bool, bool>);
-impl TO0_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO0_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO0_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO0_R = crate::BitReader;
 #[doc = "Field `TO1` reader - Transmission Occurred 1"]
-pub struct TO1_R(crate::FieldReader<bool, bool>);
-impl TO1_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO1_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO1_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO1_R = crate::BitReader;
 #[doc = "Field `TO2` reader - Transmission Occurred 2"]
-pub struct TO2_R(crate::FieldReader<bool, bool>);
-impl TO2_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO2_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO2_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO2_R = crate::BitReader;
 #[doc = "Field `TO3` reader - Transmission Occurred 3"]
-pub struct TO3_R(crate::FieldReader<bool, bool>);
-impl TO3_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO3_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO3_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO3_R = crate::BitReader;
 #[doc = "Field `TO4` reader - Transmission Occurred 4"]
-pub struct TO4_R(crate::FieldReader<bool, bool>);
-impl TO4_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO4_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO4_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO4_R = crate::BitReader;
 #[doc = "Field `TO5` reader - Transmission Occurred 5"]
-pub struct TO5_R(crate::FieldReader<bool, bool>);
-impl TO5_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO5_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO5_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO5_R = crate::BitReader;
 #[doc = "Field `TO6` reader - Transmission Occurred 6"]
-pub struct TO6_R(crate::FieldReader<bool, bool>);
-impl TO6_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO6_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO6_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO6_R = crate::BitReader;
 #[doc = "Field `TO7` reader - Transmission Occurred 7"]
-pub struct TO7_R(crate::FieldReader<bool, bool>);
-impl TO7_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO7_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO7_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO7_R = crate::BitReader;
 #[doc = "Field `TO8` reader - Transmission Occurred 8"]
-pub struct TO8_R(crate::FieldReader<bool, bool>);
-impl TO8_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO8_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO8_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO8_R = crate::BitReader;
 #[doc = "Field `TO9` reader - Transmission Occurred 9"]
-pub struct TO9_R(crate::FieldReader<bool, bool>);
-impl TO9_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO9_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO9_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO9_R = crate::BitReader;
 #[doc = "Field `TO10` reader - Transmission Occurred 10"]
-pub struct TO10_R(crate::FieldReader<bool, bool>);
-impl TO10_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO10_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO10_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO10_R = crate::BitReader;
 #[doc = "Field `TO11` reader - Transmission Occurred 11"]
-pub struct TO11_R(crate::FieldReader<bool, bool>);
-impl TO11_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO11_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO11_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO11_R = crate::BitReader;
 #[doc = "Field `TO12` reader - Transmission Occurred 12"]
-pub struct TO12_R(crate::FieldReader<bool, bool>);
-impl TO12_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO12_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO12_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO12_R = crate::BitReader;
 #[doc = "Field `TO13` reader - Transmission Occurred 13"]
-pub struct TO13_R(crate::FieldReader<bool, bool>);
-impl TO13_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO13_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO13_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO13_R = crate::BitReader;
 #[doc = "Field `TO14` reader - Transmission Occurred 14"]
-pub struct TO14_R(crate::FieldReader<bool, bool>);
-impl TO14_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO14_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO14_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO14_R = crate::BitReader;
 #[doc = "Field `TO15` reader - Transmission Occurred 15"]
-pub struct TO15_R(crate::FieldReader<bool, bool>);
-impl TO15_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO15_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO15_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO15_R = crate::BitReader;
 #[doc = "Field `TO16` reader - Transmission Occurred 16"]
-pub struct TO16_R(crate::FieldReader<bool, bool>);
-impl TO16_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO16_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO16_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO16_R = crate::BitReader;
 #[doc = "Field `TO17` reader - Transmission Occurred 17"]
-pub struct TO17_R(crate::FieldReader<bool, bool>);
-impl TO17_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO17_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO17_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO17_R = crate::BitReader;
 #[doc = "Field `TO18` reader - Transmission Occurred 18"]
-pub struct TO18_R(crate::FieldReader<bool, bool>);
-impl TO18_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO18_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO18_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO18_R = crate::BitReader;
 #[doc = "Field `TO19` reader - Transmission Occurred 19"]
-pub struct TO19_R(crate::FieldReader<bool, bool>);
-impl TO19_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO19_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO19_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO19_R = crate::BitReader;
 #[doc = "Field `TO20` reader - Transmission Occurred 20"]
-pub struct TO20_R(crate::FieldReader<bool, bool>);
-impl TO20_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO20_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO20_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO20_R = crate::BitReader;
 #[doc = "Field `TO21` reader - Transmission Occurred 21"]
-pub struct TO21_R(crate::FieldReader<bool, bool>);
-impl TO21_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO21_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO21_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO21_R = crate::BitReader;
 #[doc = "Field `TO22` reader - Transmission Occurred 22"]
-pub struct TO22_R(crate::FieldReader<bool, bool>);
-impl TO22_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO22_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO22_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO22_R = crate::BitReader;
 #[doc = "Field `TO23` reader - Transmission Occurred 23"]
-pub struct TO23_R(crate::FieldReader<bool, bool>);
-impl TO23_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO23_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO23_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO23_R = crate::BitReader;
 #[doc = "Field `TO24` reader - Transmission Occurred 24"]
-pub struct TO24_R(crate::FieldReader<bool, bool>);
-impl TO24_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO24_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO24_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO24_R = crate::BitReader;
 #[doc = "Field `TO25` reader - Transmission Occurred 25"]
-pub struct TO25_R(crate::FieldReader<bool, bool>);
-impl TO25_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO25_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO25_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO25_R = crate::BitReader;
 #[doc = "Field `TO26` reader - Transmission Occurred 26"]
-pub struct TO26_R(crate::FieldReader<bool, bool>);
-impl TO26_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO26_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO26_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO26_R = crate::BitReader;
 #[doc = "Field `TO27` reader - Transmission Occurred 27"]
-pub struct TO27_R(crate::FieldReader<bool, bool>);
-impl TO27_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO27_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO27_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO27_R = crate::BitReader;
 #[doc = "Field `TO28` reader - Transmission Occurred 28"]
-pub struct TO28_R(crate::FieldReader<bool, bool>);
-impl TO28_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO28_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO28_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO28_R = crate::BitReader;
 #[doc = "Field `TO29` reader - Transmission Occurred 29"]
-pub struct TO29_R(crate::FieldReader<bool, bool>);
-impl TO29_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO29_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO29_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO29_R = crate::BitReader;
 #[doc = "Field `TO30` reader - Transmission Occurred 30"]
-pub struct TO30_R(crate::FieldReader<bool, bool>);
-impl TO30_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO30_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO30_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO30_R = crate::BitReader;
 #[doc = "Field `TO31` reader - Transmission Occurred 31"]
-pub struct TO31_R(crate::FieldReader<bool, bool>);
-impl TO31_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TO31_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TO31_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TO31_R = crate::BitReader;
 impl R {
     #[doc = "Bit 0 - Transmission Occurred 0"]
     #[inline(always)]
     pub fn to0(&self) -> TO0_R {
-        TO0_R::new((self.bits & 0x01) != 0)
+        TO0_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - Transmission Occurred 1"]
     #[inline(always)]
     pub fn to1(&self) -> TO1_R {
-        TO1_R::new(((self.bits >> 1) & 0x01) != 0)
+        TO1_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - Transmission Occurred 2"]
     #[inline(always)]
     pub fn to2(&self) -> TO2_R {
-        TO2_R::new(((self.bits >> 2) & 0x01) != 0)
+        TO2_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - Transmission Occurred 3"]
     #[inline(always)]
     pub fn to3(&self) -> TO3_R {
-        TO3_R::new(((self.bits >> 3) & 0x01) != 0)
+        TO3_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - Transmission Occurred 4"]
     #[inline(always)]
     pub fn to4(&self) -> TO4_R {
-        TO4_R::new(((self.bits >> 4) & 0x01) != 0)
+        TO4_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - Transmission Occurred 5"]
     #[inline(always)]
     pub fn to5(&self) -> TO5_R {
-        TO5_R::new(((self.bits >> 5) & 0x01) != 0)
+        TO5_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - Transmission Occurred 6"]
     #[inline(always)]
     pub fn to6(&self) -> TO6_R {
-        TO6_R::new(((self.bits >> 6) & 0x01) != 0)
+        TO6_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - Transmission Occurred 7"]
     #[inline(always)]
     pub fn to7(&self) -> TO7_R {
-        TO7_R::new(((self.bits >> 7) & 0x01) != 0)
+        TO7_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - Transmission Occurred 8"]
     #[inline(always)]
     pub fn to8(&self) -> TO8_R {
-        TO8_R::new(((self.bits >> 8) & 0x01) != 0)
+        TO8_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - Transmission Occurred 9"]
     #[inline(always)]
     pub fn to9(&self) -> TO9_R {
-        TO9_R::new(((self.bits >> 9) & 0x01) != 0)
+        TO9_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - Transmission Occurred 10"]
     #[inline(always)]
     pub fn to10(&self) -> TO10_R {
-        TO10_R::new(((self.bits >> 10) & 0x01) != 0)
+        TO10_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Transmission Occurred 11"]
     #[inline(always)]
     pub fn to11(&self) -> TO11_R {
-        TO11_R::new(((self.bits >> 11) & 0x01) != 0)
+        TO11_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - Transmission Occurred 12"]
     #[inline(always)]
     pub fn to12(&self) -> TO12_R {
-        TO12_R::new(((self.bits >> 12) & 0x01) != 0)
+        TO12_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - Transmission Occurred 13"]
     #[inline(always)]
     pub fn to13(&self) -> TO13_R {
-        TO13_R::new(((self.bits >> 13) & 0x01) != 0)
+        TO13_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - Transmission Occurred 14"]
     #[inline(always)]
     pub fn to14(&self) -> TO14_R {
-        TO14_R::new(((self.bits >> 14) & 0x01) != 0)
+        TO14_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - Transmission Occurred 15"]
     #[inline(always)]
     pub fn to15(&self) -> TO15_R {
-        TO15_R::new(((self.bits >> 15) & 0x01) != 0)
+        TO15_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - Transmission Occurred 16"]
     #[inline(always)]
     pub fn to16(&self) -> TO16_R {
-        TO16_R::new(((self.bits >> 16) & 0x01) != 0)
+        TO16_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - Transmission Occurred 17"]
     #[inline(always)]
     pub fn to17(&self) -> TO17_R {
-        TO17_R::new(((self.bits >> 17) & 0x01) != 0)
+        TO17_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - Transmission Occurred 18"]
     #[inline(always)]
     pub fn to18(&self) -> TO18_R {
-        TO18_R::new(((self.bits >> 18) & 0x01) != 0)
+        TO18_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - Transmission Occurred 19"]
     #[inline(always)]
     pub fn to19(&self) -> TO19_R {
-        TO19_R::new(((self.bits >> 19) & 0x01) != 0)
+        TO19_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - Transmission Occurred 20"]
     #[inline(always)]
     pub fn to20(&self) -> TO20_R {
-        TO20_R::new(((self.bits >> 20) & 0x01) != 0)
+        TO20_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - Transmission Occurred 21"]
     #[inline(always)]
     pub fn to21(&self) -> TO21_R {
-        TO21_R::new(((self.bits >> 21) & 0x01) != 0)
+        TO21_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - Transmission Occurred 22"]
     #[inline(always)]
     pub fn to22(&self) -> TO22_R {
-        TO22_R::new(((self.bits >> 22) & 0x01) != 0)
+        TO22_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - Transmission Occurred 23"]
     #[inline(always)]
     pub fn to23(&self) -> TO23_R {
-        TO23_R::new(((self.bits >> 23) & 0x01) != 0)
+        TO23_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - Transmission Occurred 24"]
     #[inline(always)]
     pub fn to24(&self) -> TO24_R {
-        TO24_R::new(((self.bits >> 24) & 0x01) != 0)
+        TO24_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - Transmission Occurred 25"]
     #[inline(always)]
     pub fn to25(&self) -> TO25_R {
-        TO25_R::new(((self.bits >> 25) & 0x01) != 0)
+        TO25_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - Transmission Occurred 26"]
     #[inline(always)]
     pub fn to26(&self) -> TO26_R {
-        TO26_R::new(((self.bits >> 26) & 0x01) != 0)
+        TO26_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - Transmission Occurred 27"]
     #[inline(always)]
     pub fn to27(&self) -> TO27_R {
-        TO27_R::new(((self.bits >> 27) & 0x01) != 0)
+        TO27_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - Transmission Occurred 28"]
     #[inline(always)]
     pub fn to28(&self) -> TO28_R {
-        TO28_R::new(((self.bits >> 28) & 0x01) != 0)
+        TO28_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - Transmission Occurred 29"]
     #[inline(always)]
     pub fn to29(&self) -> TO29_R {
-        TO29_R::new(((self.bits >> 29) & 0x01) != 0)
+        TO29_R::new(((self.bits >> 29) & 1) != 0)
     }
     #[doc = "Bit 30 - Transmission Occurred 30"]
     #[inline(always)]
     pub fn to30(&self) -> TO30_R {
-        TO30_R::new(((self.bits >> 30) & 0x01) != 0)
+        TO30_R::new(((self.bits >> 30) & 1) != 0)
     }
     #[doc = "Bit 31 - Transmission Occurred 31"]
     #[inline(always)]
     pub fn to31(&self) -> TO31_R {
-        TO31_R::new(((self.bits >> 31) & 0x01) != 0)
+        TO31_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
-#[doc = "Tx Buffer Transmission Occurred\n\nThis register you can [`read`](crate::reg::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txbto](index.html) module"]
+#[doc = "Tx Buffer Transmission Occurred\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txbto::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXBTO_SPEC;
 impl crate::RegisterSpec for TXBTO_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [txbto::R](R) reader structure"]
-impl crate::Readable for TXBTO_SPEC {
-    type Reader = R;
-}
+#[doc = "`read()` method returns [`txbto::R`](R) reader structure"]
+impl crate::Readable for TXBTO_SPEC {}
 #[doc = "`reset()` method sets TXBTO to value 0"]
 impl crate::Resettable for TXBTO_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/txbto.rs
+++ b/mcan/src/reg/txbto.rs
@@ -226,7 +226,7 @@ impl R {
         TO31_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
-#[doc = "Tx Buffer Transmission Occurred\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txbto::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Tx Buffer Transmission Occurred\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`txbto::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXBTO_SPEC;
 impl crate::RegisterSpec for TXBTO_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/txefa.rs
+++ b/mcan/src/reg/txefa.rs
@@ -1,66 +1,11 @@
 #[doc = "Register `TXEFA` reader"]
-pub struct R(crate::R<TXEFA_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<TXEFA_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<TXEFA_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<TXEFA_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<TXEFA_SPEC>;
 #[doc = "Register `TXEFA` writer"]
-pub struct W(crate::W<TXEFA_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<TXEFA_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<TXEFA_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<TXEFA_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<TXEFA_SPEC>;
 #[doc = "Field `EFAI` reader - Event FIFO Acknowledge Index"]
-pub struct EFAI_R(crate::FieldReader<u8, u8>);
-impl EFAI_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        EFAI_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for EFAI_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type EFAI_R = crate::FieldReader;
 #[doc = "Field `EFAI` writer - Event FIFO Acknowledge Index"]
-pub struct EFAI_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> EFAI_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x1f) | (value as u32 & 0x1f);
-        self.w
-    }
-}
+pub type EFAI_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 5, O>;
 impl R {
     #[doc = "Bits 0:4 - Event FIFO Acknowledge Index"]
     #[inline(always)]
@@ -71,33 +16,34 @@ impl R {
 impl W {
     #[doc = "Bits 0:4 - Event FIFO Acknowledge Index"]
     #[inline(always)]
-    pub fn efai(&mut self) -> EFAI_W {
-        EFAI_W { w: self }
+    #[must_use]
+    pub fn efai(&mut self) -> EFAI_W<TXEFA_SPEC, 0> {
+        EFAI_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Tx Event FIFO Acknowledge\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txefa](index.html) module"]
+#[doc = "Tx Event FIFO Acknowledge\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txefa::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`txefa::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXEFA_SPEC;
 impl crate::RegisterSpec for TXEFA_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [txefa::R](R) reader structure"]
-impl crate::Readable for TXEFA_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [txefa::W](W) writer structure"]
+#[doc = "`read()` method returns [`txefa::R`](R) reader structure"]
+impl crate::Readable for TXEFA_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`txefa::W`](W) writer structure"]
 impl crate::Writable for TXEFA_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets TXEFA to value 0"]
 impl crate::Resettable for TXEFA_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/txefa.rs
+++ b/mcan/src/reg/txefa.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Tx Event FIFO Acknowledge\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txefa::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`txefa::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Tx Event FIFO Acknowledge\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`txefa::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`txefa::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXEFA_SPEC;
 impl crate::RegisterSpec for TXEFA_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/txefc.rs
+++ b/mcan/src/reg/txefc.rs
@@ -61,7 +61,7 @@ impl W {
         self
     }
 }
-#[doc = "Tx Event FIFO Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txefc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`txefc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Tx Event FIFO Configuration\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`txefc::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`txefc::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXEFC_SPEC;
 impl crate::RegisterSpec for TXEFC_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/txefc.rs
+++ b/mcan/src/reg/txefc.rs
@@ -1,120 +1,19 @@
 #[doc = "Register `TXEFC` reader"]
-pub struct R(crate::R<TXEFC_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<TXEFC_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<TXEFC_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<TXEFC_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<TXEFC_SPEC>;
 #[doc = "Register `TXEFC` writer"]
-pub struct W(crate::W<TXEFC_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<TXEFC_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<TXEFC_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<TXEFC_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<TXEFC_SPEC>;
 #[doc = "Field `EFSA` reader - Event FIFO Start Address"]
-pub struct EFSA_R(crate::FieldReader<u16, u16>);
-impl EFSA_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u16) -> Self {
-        EFSA_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for EFSA_R {
-    type Target = crate::FieldReader<u16, u16>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type EFSA_R = crate::FieldReader<u16>;
 #[doc = "Field `EFSA` writer - Event FIFO Start Address"]
-pub struct EFSA_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> EFSA_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u16) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0xffff) | (value as u32 & 0xffff);
-        self.w
-    }
-}
+pub type EFSA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
 #[doc = "Field `EFS` reader - Event FIFO Size"]
-pub struct EFS_R(crate::FieldReader<u8, u8>);
-impl EFS_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        EFS_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for EFS_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type EFS_R = crate::FieldReader;
 #[doc = "Field `EFS` writer - Event FIFO Size"]
-pub struct EFS_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> EFS_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x3f << 16)) | ((value as u32 & 0x3f) << 16);
-        self.w
-    }
-}
+pub type EFS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 6, O>;
 #[doc = "Field `EFWM` reader - Event FIFO Watermark"]
-pub struct EFWM_R(crate::FieldReader<u8, u8>);
-impl EFWM_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        EFWM_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for EFWM_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type EFWM_R = crate::FieldReader;
 #[doc = "Field `EFWM` writer - Event FIFO Watermark"]
-pub struct EFWM_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> EFWM_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x3f << 24)) | ((value as u32 & 0x3f) << 24);
-        self.w
-    }
-}
+pub type EFWM_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 6, O>;
 impl R {
     #[doc = "Bits 0:15 - Event FIFO Start Address"]
     #[inline(always)]
@@ -135,43 +34,46 @@ impl R {
 impl W {
     #[doc = "Bits 0:15 - Event FIFO Start Address"]
     #[inline(always)]
-    pub fn efsa(&mut self) -> EFSA_W {
-        EFSA_W { w: self }
+    #[must_use]
+    pub fn efsa(&mut self) -> EFSA_W<TXEFC_SPEC, 0> {
+        EFSA_W::new(self)
     }
     #[doc = "Bits 16:21 - Event FIFO Size"]
     #[inline(always)]
-    pub fn efs(&mut self) -> EFS_W {
-        EFS_W { w: self }
+    #[must_use]
+    pub fn efs(&mut self) -> EFS_W<TXEFC_SPEC, 16> {
+        EFS_W::new(self)
     }
     #[doc = "Bits 24:29 - Event FIFO Watermark"]
     #[inline(always)]
-    pub fn efwm(&mut self) -> EFWM_W {
-        EFWM_W { w: self }
+    #[must_use]
+    pub fn efwm(&mut self) -> EFWM_W<TXEFC_SPEC, 24> {
+        EFWM_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Tx Event FIFO Configuration\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txefc](index.html) module"]
+#[doc = "Tx Event FIFO Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txefc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`txefc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXEFC_SPEC;
 impl crate::RegisterSpec for TXEFC_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [txefc::R](R) reader structure"]
-impl crate::Readable for TXEFC_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [txefc::W](W) writer structure"]
+#[doc = "`read()` method returns [`txefc::R`](R) reader structure"]
+impl crate::Readable for TXEFC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`txefc::W`](W) writer structure"]
 impl crate::Writable for TXEFC_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets TXEFC to value 0"]
 impl crate::Resettable for TXEFC_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/txefs.rs
+++ b/mcan/src/reg/txefs.rs
@@ -37,7 +37,7 @@ impl R {
         TEFL_R::new(((self.bits >> 25) & 1) != 0)
     }
 }
-#[doc = "Tx Event FIFO Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txefs::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Tx Event FIFO Status\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`txefs::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXEFS_SPEC;
 impl crate::RegisterSpec for TXEFS_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/txefs.rs
+++ b/mcan/src/reg/txefs.rs
@@ -1,93 +1,15 @@
 #[doc = "Register `TXEFS` reader"]
-pub struct R(crate::R<TXEFS_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<TXEFS_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<TXEFS_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<TXEFS_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<TXEFS_SPEC>;
 #[doc = "Field `EFFL` reader - Event FIFO Fill Level"]
-pub struct EFFL_R(crate::FieldReader<u8, u8>);
-impl EFFL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        EFFL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for EFFL_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type EFFL_R = crate::FieldReader;
 #[doc = "Field `EFGI` reader - Event FIFO Get Index"]
-pub struct EFGI_R(crate::FieldReader<u8, u8>);
-impl EFGI_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        EFGI_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for EFGI_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type EFGI_R = crate::FieldReader;
 #[doc = "Field `EFPI` reader - Event FIFO Put Index"]
-pub struct EFPI_R(crate::FieldReader<u8, u8>);
-impl EFPI_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        EFPI_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for EFPI_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type EFPI_R = crate::FieldReader;
 #[doc = "Field `EFF` reader - Event FIFO Full"]
-pub struct EFF_R(crate::FieldReader<bool, bool>);
-impl EFF_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        EFF_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for EFF_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type EFF_R = crate::BitReader;
 #[doc = "Field `TEFL` reader - Tx Event FIFO Element Lost"]
-pub struct TEFL_R(crate::FieldReader<bool, bool>);
-impl TEFL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TEFL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TEFL_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TEFL_R = crate::BitReader;
 impl R {
     #[doc = "Bits 0:5 - Event FIFO Fill Level"]
     #[inline(always)]
@@ -107,27 +29,22 @@ impl R {
     #[doc = "Bit 24 - Event FIFO Full"]
     #[inline(always)]
     pub fn eff(&self) -> EFF_R {
-        EFF_R::new(((self.bits >> 24) & 0x01) != 0)
+        EFF_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - Tx Event FIFO Element Lost"]
     #[inline(always)]
     pub fn tefl(&self) -> TEFL_R {
-        TEFL_R::new(((self.bits >> 25) & 0x01) != 0)
+        TEFL_R::new(((self.bits >> 25) & 1) != 0)
     }
 }
-#[doc = "Tx Event FIFO Status\n\nThis register you can [`read`](crate::reg::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txefs](index.html) module"]
+#[doc = "Tx Event FIFO Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txefs::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXEFS_SPEC;
 impl crate::RegisterSpec for TXEFS_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [txefs::R](R) reader structure"]
-impl crate::Readable for TXEFS_SPEC {
-    type Reader = R;
-}
+#[doc = "`read()` method returns [`txefs::R`](R) reader structure"]
+impl crate::Readable for TXEFS_SPEC {}
 #[doc = "`reset()` method sets TXEFS to value 0"]
 impl crate::Resettable for TXEFS_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/txesc.rs
+++ b/mcan/src/reg/txesc.rs
@@ -164,7 +164,7 @@ impl W {
         self
     }
 }
-#[doc = "Tx Buffer Element Size Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txesc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`txesc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Tx Buffer Element Size Configuration\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`txesc::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`txesc::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXESC_SPEC;
 impl crate::RegisterSpec for TXESC_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/txesc.rs
+++ b/mcan/src/reg/txesc.rs
@@ -1,43 +1,13 @@
 #[doc = "Register `TXESC` reader"]
-pub struct R(crate::R<TXESC_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<TXESC_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<TXESC_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<TXESC_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<TXESC_SPEC>;
 #[doc = "Register `TXESC` writer"]
-pub struct W(crate::W<TXESC_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<TXESC_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<TXESC_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<TXESC_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<TXESC_SPEC>;
+#[doc = "Field `TBDS` reader - Tx Buffer Data Field Size"]
+pub type TBDS_R = crate::FieldReader<TBDSSELECT_A>;
 #[doc = "Tx Buffer Data Field Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
-pub enum TBDS_A {
+pub enum TBDSSELECT_A {
     #[doc = "0: 8 byte data field"]
     DATA8 = 0,
     #[doc = "1: 12 byte data field"]
@@ -55,176 +25,158 @@ pub enum TBDS_A {
     #[doc = "7: 64 byte data field"]
     DATA64 = 7,
 }
-impl From<TBDS_A> for u8 {
+impl From<TBDSSELECT_A> for u8 {
     #[inline(always)]
-    fn from(variant: TBDS_A) -> Self {
+    fn from(variant: TBDSSELECT_A) -> Self {
         variant as _
     }
 }
-#[doc = "Field `TBDS` reader - Tx Buffer Data Field Size"]
-pub struct TBDS_R(crate::FieldReader<u8, TBDS_A>);
+impl crate::FieldSpec for TBDSSELECT_A {
+    type Ux = u8;
+}
 impl TBDS_R {
+    #[doc = "Get enumerated values variant"]
     #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        TBDS_R(crate::FieldReader::new(bits))
-    }
-    #[doc = r"Get enumerated values variant"]
-    #[inline(always)]
-    pub fn variant(&self) -> TBDS_A {
+    pub const fn variant(&self) -> TBDSSELECT_A {
         match self.bits {
-            0 => TBDS_A::DATA8,
-            1 => TBDS_A::DATA12,
-            2 => TBDS_A::DATA16,
-            3 => TBDS_A::DATA20,
-            4 => TBDS_A::DATA24,
-            5 => TBDS_A::DATA32,
-            6 => TBDS_A::DATA48,
-            7 => TBDS_A::DATA64,
+            0 => TBDSSELECT_A::DATA8,
+            1 => TBDSSELECT_A::DATA12,
+            2 => TBDSSELECT_A::DATA16,
+            3 => TBDSSELECT_A::DATA20,
+            4 => TBDSSELECT_A::DATA24,
+            5 => TBDSSELECT_A::DATA32,
+            6 => TBDSSELECT_A::DATA48,
+            7 => TBDSSELECT_A::DATA64,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `DATA8`"]
-    #[inline(always)]
-    pub fn is_data8(&self) -> bool {
-        **self == TBDS_A::DATA8
-    }
-    #[doc = "Checks if the value of the field is `DATA12`"]
-    #[inline(always)]
-    pub fn is_data12(&self) -> bool {
-        **self == TBDS_A::DATA12
-    }
-    #[doc = "Checks if the value of the field is `DATA16`"]
-    #[inline(always)]
-    pub fn is_data16(&self) -> bool {
-        **self == TBDS_A::DATA16
-    }
-    #[doc = "Checks if the value of the field is `DATA20`"]
-    #[inline(always)]
-    pub fn is_data20(&self) -> bool {
-        **self == TBDS_A::DATA20
-    }
-    #[doc = "Checks if the value of the field is `DATA24`"]
-    #[inline(always)]
-    pub fn is_data24(&self) -> bool {
-        **self == TBDS_A::DATA24
-    }
-    #[doc = "Checks if the value of the field is `DATA32`"]
-    #[inline(always)]
-    pub fn is_data32(&self) -> bool {
-        **self == TBDS_A::DATA32
-    }
-    #[doc = "Checks if the value of the field is `DATA48`"]
-    #[inline(always)]
-    pub fn is_data48(&self) -> bool {
-        **self == TBDS_A::DATA48
-    }
-    #[doc = "Checks if the value of the field is `DATA64`"]
-    #[inline(always)]
-    pub fn is_data64(&self) -> bool {
-        **self == TBDS_A::DATA64
-    }
-}
-impl core::ops::Deref for TBDS_R {
-    type Target = crate::FieldReader<u8, TBDS_A>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[doc = "Field `TBDS` writer - Tx Buffer Data Field Size"]
-pub struct TBDS_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> TBDS_W<'a> {
-    #[doc = r"Writes `variant` to the field"]
-    #[inline(always)]
-    pub fn variant(self, variant: TBDS_A) -> &'a mut W {
-        self.bits(variant.into())
-    }
     #[doc = "8 byte data field"]
     #[inline(always)]
-    pub fn data8(self) -> &'a mut W {
-        self.variant(TBDS_A::DATA8)
+    pub fn is_data8(&self) -> bool {
+        *self == TBDSSELECT_A::DATA8
     }
     #[doc = "12 byte data field"]
     #[inline(always)]
-    pub fn data12(self) -> &'a mut W {
-        self.variant(TBDS_A::DATA12)
+    pub fn is_data12(&self) -> bool {
+        *self == TBDSSELECT_A::DATA12
     }
     #[doc = "16 byte data field"]
     #[inline(always)]
-    pub fn data16(self) -> &'a mut W {
-        self.variant(TBDS_A::DATA16)
+    pub fn is_data16(&self) -> bool {
+        *self == TBDSSELECT_A::DATA16
     }
     #[doc = "20 byte data field"]
     #[inline(always)]
-    pub fn data20(self) -> &'a mut W {
-        self.variant(TBDS_A::DATA20)
+    pub fn is_data20(&self) -> bool {
+        *self == TBDSSELECT_A::DATA20
     }
     #[doc = "24 byte data field"]
     #[inline(always)]
-    pub fn data24(self) -> &'a mut W {
-        self.variant(TBDS_A::DATA24)
+    pub fn is_data24(&self) -> bool {
+        *self == TBDSSELECT_A::DATA24
     }
     #[doc = "32 byte data field"]
     #[inline(always)]
-    pub fn data32(self) -> &'a mut W {
-        self.variant(TBDS_A::DATA32)
+    pub fn is_data32(&self) -> bool {
+        *self == TBDSSELECT_A::DATA32
     }
     #[doc = "48 byte data field"]
     #[inline(always)]
-    pub fn data48(self) -> &'a mut W {
-        self.variant(TBDS_A::DATA48)
+    pub fn is_data48(&self) -> bool {
+        *self == TBDSSELECT_A::DATA48
     }
     #[doc = "64 byte data field"]
     #[inline(always)]
-    pub fn data64(self) -> &'a mut W {
-        self.variant(TBDS_A::DATA64)
+    pub fn is_data64(&self) -> bool {
+        *self == TBDSSELECT_A::DATA64
     }
-    #[doc = r"Writes raw bits to the field"]
+}
+#[doc = "Field `TBDS` writer - Tx Buffer Data Field Size"]
+pub type TBDS_W<'a, REG, const O: u8> = crate::FieldWriterSafe<'a, REG, 3, O, TBDSSELECT_A>;
+impl<'a, REG, const O: u8> TBDS_W<'a, REG, O>
+where
+    REG: crate::Writable + crate::RegisterSpec,
+    REG::Ux: From<u8>,
+{
+    #[doc = "8 byte data field"]
     #[inline(always)]
-    pub fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x07) | (value as u32 & 0x07);
-        self.w
+    pub fn data8(self) -> &'a mut crate::W<REG> {
+        self.variant(TBDSSELECT_A::DATA8)
+    }
+    #[doc = "12 byte data field"]
+    #[inline(always)]
+    pub fn data12(self) -> &'a mut crate::W<REG> {
+        self.variant(TBDSSELECT_A::DATA12)
+    }
+    #[doc = "16 byte data field"]
+    #[inline(always)]
+    pub fn data16(self) -> &'a mut crate::W<REG> {
+        self.variant(TBDSSELECT_A::DATA16)
+    }
+    #[doc = "20 byte data field"]
+    #[inline(always)]
+    pub fn data20(self) -> &'a mut crate::W<REG> {
+        self.variant(TBDSSELECT_A::DATA20)
+    }
+    #[doc = "24 byte data field"]
+    #[inline(always)]
+    pub fn data24(self) -> &'a mut crate::W<REG> {
+        self.variant(TBDSSELECT_A::DATA24)
+    }
+    #[doc = "32 byte data field"]
+    #[inline(always)]
+    pub fn data32(self) -> &'a mut crate::W<REG> {
+        self.variant(TBDSSELECT_A::DATA32)
+    }
+    #[doc = "48 byte data field"]
+    #[inline(always)]
+    pub fn data48(self) -> &'a mut crate::W<REG> {
+        self.variant(TBDSSELECT_A::DATA48)
+    }
+    #[doc = "64 byte data field"]
+    #[inline(always)]
+    pub fn data64(self) -> &'a mut crate::W<REG> {
+        self.variant(TBDSSELECT_A::DATA64)
     }
 }
 impl R {
     #[doc = "Bits 0:2 - Tx Buffer Data Field Size"]
     #[inline(always)]
     pub fn tbds(&self) -> TBDS_R {
-        TBDS_R::new((self.bits & 0x07) as u8)
+        TBDS_R::new((self.bits & 7) as u8)
     }
 }
 impl W {
     #[doc = "Bits 0:2 - Tx Buffer Data Field Size"]
     #[inline(always)]
-    pub fn tbds(&mut self) -> TBDS_W {
-        TBDS_W { w: self }
+    #[must_use]
+    pub fn tbds(&mut self) -> TBDS_W<TXESC_SPEC, 0> {
+        TBDS_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Tx Buffer Element Size Configuration\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txesc](index.html) module"]
+#[doc = "Tx Buffer Element Size Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txesc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`txesc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXESC_SPEC;
 impl crate::RegisterSpec for TXESC_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [txesc::R](R) reader structure"]
-impl crate::Readable for TXESC_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [txesc::W](W) writer structure"]
+#[doc = "`read()` method returns [`txesc::R`](R) reader structure"]
+impl crate::Readable for TXESC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`txesc::W`](W) writer structure"]
 impl crate::Writable for TXESC_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets TXESC to value 0"]
 impl crate::Resettable for TXESC_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/txfqs.rs
+++ b/mcan/src/reg/txfqs.rs
@@ -1,78 +1,13 @@
 #[doc = "Register `TXFQS` reader"]
-pub struct R(crate::R<TXFQS_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<TXFQS_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<TXFQS_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<TXFQS_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<TXFQS_SPEC>;
 #[doc = "Field `TFFL` reader - Tx FIFO Free Level"]
-pub struct TFFL_R(crate::FieldReader<u8, u8>);
-impl TFFL_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        TFFL_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TFFL_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TFFL_R = crate::FieldReader;
 #[doc = "Field `TFGI` reader - Tx FIFO Get Index"]
-pub struct TFGI_R(crate::FieldReader<u8, u8>);
-impl TFGI_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        TFGI_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TFGI_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TFGI_R = crate::FieldReader;
 #[doc = "Field `TFQPI` reader - Tx FIFO/Queue Put Index"]
-pub struct TFQPI_R(crate::FieldReader<u8, u8>);
-impl TFQPI_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        TFQPI_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TFQPI_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TFQPI_R = crate::FieldReader;
 #[doc = "Field `TFQF` reader - Tx FIFO/Queue Full"]
-pub struct TFQF_R(crate::FieldReader<bool, bool>);
-impl TFQF_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: bool) -> Self {
-        TFQF_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for TFQF_R {
-    type Target = crate::FieldReader<bool, bool>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type TFQF_R = crate::BitReader;
 impl R {
     #[doc = "Bits 0:5 - Tx FIFO Free Level"]
     #[inline(always)]
@@ -92,22 +27,17 @@ impl R {
     #[doc = "Bit 21 - Tx FIFO/Queue Full"]
     #[inline(always)]
     pub fn tfqf(&self) -> TFQF_R {
-        TFQF_R::new(((self.bits >> 21) & 0x01) != 0)
+        TFQF_R::new(((self.bits >> 21) & 1) != 0)
     }
 }
-#[doc = "Tx FIFO / Queue Status\n\nThis register you can [`read`](crate::reg::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txfqs](index.html) module"]
+#[doc = "Tx FIFO / Queue Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txfqs::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXFQS_SPEC;
 impl crate::RegisterSpec for TXFQS_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [txfqs::R](R) reader structure"]
-impl crate::Readable for TXFQS_SPEC {
-    type Reader = R;
-}
+#[doc = "`read()` method returns [`txfqs::R`](R) reader structure"]
+impl crate::Readable for TXFQS_SPEC {}
 #[doc = "`reset()` method sets TXFQS to value 0"]
 impl crate::Resettable for TXFQS_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/mcan/src/reg/txfqs.rs
+++ b/mcan/src/reg/txfqs.rs
@@ -30,7 +30,7 @@ impl R {
         TFQF_R::new(((self.bits >> 21) & 1) != 0)
     }
 }
-#[doc = "Tx FIFO / Queue Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`txfqs::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Tx FIFO / Queue Status\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`txfqs::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct TXFQS_SPEC;
 impl crate::RegisterSpec for TXFQS_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/xidam.rs
+++ b/mcan/src/reg/xidam.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Extended ID AND Mask\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`xidam::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`xidam::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Extended ID AND Mask\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`xidam::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`xidam::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct XIDAM_SPEC;
 impl crate::RegisterSpec for XIDAM_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/xidam.rs
+++ b/mcan/src/reg/xidam.rs
@@ -1,66 +1,11 @@
 #[doc = "Register `XIDAM` reader"]
-pub struct R(crate::R<XIDAM_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<XIDAM_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<XIDAM_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<XIDAM_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<XIDAM_SPEC>;
 #[doc = "Register `XIDAM` writer"]
-pub struct W(crate::W<XIDAM_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<XIDAM_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<XIDAM_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<XIDAM_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<XIDAM_SPEC>;
 #[doc = "Field `EIDM` reader - Extended ID Mask"]
-pub struct EIDM_R(crate::FieldReader<u32, u32>);
-impl EIDM_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u32) -> Self {
-        EIDM_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for EIDM_R {
-    type Target = crate::FieldReader<u32, u32>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type EIDM_R = crate::FieldReader<u32>;
 #[doc = "Field `EIDM` writer - Extended ID Mask"]
-pub struct EIDM_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> EIDM_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u32) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0x1fff_ffff) | (value & 0x1fff_ffff);
-        self.w
-    }
-}
+pub type EIDM_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 29, O, u32>;
 impl R {
     #[doc = "Bits 0:28 - Extended ID Mask"]
     #[inline(always)]
@@ -71,33 +16,34 @@ impl R {
 impl W {
     #[doc = "Bits 0:28 - Extended ID Mask"]
     #[inline(always)]
-    pub fn eidm(&mut self) -> EIDM_W {
-        EIDM_W { w: self }
+    #[must_use]
+    pub fn eidm(&mut self) -> EIDM_W<XIDAM_SPEC, 0> {
+        EIDM_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Extended ID AND Mask\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [xidam](index.html) module"]
+#[doc = "Extended ID AND Mask\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`xidam::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`xidam::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct XIDAM_SPEC;
 impl crate::RegisterSpec for XIDAM_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [xidam::R](R) reader structure"]
-impl crate::Readable for XIDAM_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [xidam::W](W) writer structure"]
+#[doc = "`read()` method returns [`xidam::R`](R) reader structure"]
+impl crate::Readable for XIDAM_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`xidam::W`](W) writer structure"]
 impl crate::Writable for XIDAM_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets XIDAM to value 0x1fff_ffff"]
 impl crate::Resettable for XIDAM_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0x1fff_ffff
-    }
+    const RESET_VALUE: Self::Ux = 0x1fff_ffff;
 }

--- a/mcan/src/reg/xidfc.rs
+++ b/mcan/src/reg/xidfc.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Extended ID Filter Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`xidfc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`xidfc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Extended ID Filter Configuration\n\nYou can [`read`](crate::reg::generic::Reg::read) this register and get [`xidfc::R`](R).  You can [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero) this register using [`xidfc::W`](W). You can also [`modify`](crate::reg::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct XIDFC_SPEC;
 impl crate::RegisterSpec for XIDFC_SPEC {
     type Ux = u32;

--- a/mcan/src/reg/xidfc.rs
+++ b/mcan/src/reg/xidfc.rs
@@ -1,93 +1,15 @@
 #[doc = "Register `XIDFC` reader"]
-pub struct R(crate::R<XIDFC_SPEC>);
-impl core::ops::Deref for R {
-    type Target = crate::R<XIDFC_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl From<crate::R<XIDFC_SPEC>> for R {
-    #[inline(always)]
-    fn from(reader: crate::R<XIDFC_SPEC>) -> Self {
-        R(reader)
-    }
-}
+pub type R = crate::R<XIDFC_SPEC>;
 #[doc = "Register `XIDFC` writer"]
-pub struct W(crate::W<XIDFC_SPEC>);
-impl core::ops::Deref for W {
-    type Target = crate::W<XIDFC_SPEC>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl core::ops::DerefMut for W {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl From<crate::W<XIDFC_SPEC>> for W {
-    #[inline(always)]
-    fn from(writer: crate::W<XIDFC_SPEC>) -> Self {
-        W(writer)
-    }
-}
+pub type W = crate::W<XIDFC_SPEC>;
 #[doc = "Field `FLESA` reader - Filter List Extended Start Address"]
-pub struct FLESA_R(crate::FieldReader<u16, u16>);
-impl FLESA_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u16) -> Self {
-        FLESA_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for FLESA_R {
-    type Target = crate::FieldReader<u16, u16>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type FLESA_R = crate::FieldReader<u16>;
 #[doc = "Field `FLESA` writer - Filter List Extended Start Address"]
-pub struct FLESA_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> FLESA_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u16) -> &'a mut W {
-        self.w.bits = (self.w.bits & !0xffff) | (value as u32 & 0xffff);
-        self.w
-    }
-}
+pub type FLESA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
 #[doc = "Field `LSE` reader - List Size Extended"]
-pub struct LSE_R(crate::FieldReader<u8, u8>);
-impl LSE_R {
-    #[inline(always)]
-    pub(crate) fn new(bits: u8) -> Self {
-        LSE_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for LSE_R {
-    type Target = crate::FieldReader<u8, u8>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type LSE_R = crate::FieldReader;
 #[doc = "Field `LSE` writer - List Size Extended"]
-pub struct LSE_W<'a> {
-    w: &'a mut W,
-}
-impl<'a> LSE_W<'a> {
-    #[doc = r"Writes raw bits to the field"]
-    #[inline(always)]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
-        self.w.bits = (self.w.bits & !(0x7f << 16)) | ((value as u32 & 0x7f) << 16);
-        self.w
-    }
-}
+pub type LSE_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
 impl R {
     #[doc = "Bits 0:15 - Filter List Extended Start Address"]
     #[inline(always)]
@@ -103,38 +25,40 @@ impl R {
 impl W {
     #[doc = "Bits 0:15 - Filter List Extended Start Address"]
     #[inline(always)]
-    pub fn flesa(&mut self) -> FLESA_W {
-        FLESA_W { w: self }
+    #[must_use]
+    pub fn flesa(&mut self) -> FLESA_W<XIDFC_SPEC, 0> {
+        FLESA_W::new(self)
     }
     #[doc = "Bits 16:22 - List Size Extended"]
     #[inline(always)]
-    pub fn lse(&mut self) -> LSE_W {
-        LSE_W { w: self }
+    #[must_use]
+    pub fn lse(&mut self) -> LSE_W<XIDFC_SPEC, 16> {
+        LSE_W::new(self)
     }
-    #[doc = "Writes raw bits to the register."]
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
     #[inline(always)]
     pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
-        self.0.bits(bits);
+        self.bits = bits;
         self
     }
 }
-#[doc = "Extended ID Filter Configuration\n\nThis register you can [`read`](crate::reg::generic::Reg::read), [`write_with_zero`](crate::reg::generic::Reg::write_with_zero), [`reset`](crate::reg::generic::Reg::reset), [`write`](crate::reg::generic::Reg::write), [`modify`](crate::reg::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [xidfc](index.html) module"]
+#[doc = "Extended ID Filter Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`xidfc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`xidfc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct XIDFC_SPEC;
 impl crate::RegisterSpec for XIDFC_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [xidfc::R](R) reader structure"]
-impl crate::Readable for XIDFC_SPEC {
-    type Reader = R;
-}
-#[doc = "`write(|w| ..)` method takes [xidfc::W](W) writer structure"]
+#[doc = "`read()` method returns [`xidfc::R`](R) reader structure"]
+impl crate::Readable for XIDFC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`xidfc::W`](W) writer structure"]
 impl crate::Writable for XIDFC_SPEC {
-    type Writer = W;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
 #[doc = "`reset()` method sets XIDFC to value 0"]
 impl crate::Resettable for XIDFC_SPEC {
-    #[inline(always)]
-    fn reset_value() -> Self::Ux {
-        0
-    }
+    const RESET_VALUE: Self::Ux = 0;
 }


### PR DESCRIPTION
## Why do we want to do this?
In the past we have introduced build and/or clippy fixes ourselfs 
through individual patches. Some of these include:

https://github.com/GrepitAB/mcan/commit/fa62200bd8ee6d2899148147318b323583043917 Fix clippy::unnecessary_cast, added in svd2rust 0.27.0)
https://github.com/GrepitAB/mcan/commit/e50754a187ff6594544a8a5f2666bbb6c3d871af Fix clippy::explicit_auto_deref, added in svd2rust 0.27.0)
https://github.com/GrepitAB/mcan/commit/c4a89062d6905f2f5893d83d7caf05aa41f92fdc Added Eq implementation, added in svd2rust 0.26.0

But since all these have been added up until `svd2rust 0.30.2`, and beacuse `clippy::missing_safety_doc` has started causing our PR's to fail CI, it makes sense to step up the mappings and make use of the new changes.

## What is changing?
Since we are stepping the version of the generating tool of the register mappings themselfs, we can expect there to be some breaking changes here.
One example is in `mcan::reg::psr::LEC_A` which changes name to `LECSELECT_A`.

The API for the main functionality of the mcan crate will be left unchanged and hopefully this will mean that most users don't need to spend much time to update their codebase.

## How do we accomplish this?
Since we have modified some structures in the generated code to fit with our use case there are some manual additions we need to make after we use `svd2rust` and `form`.

So the full process becomes:
1. Create a SVD export using `svd2rust 0.30.2` and `form 0.10.0`
2. Copy `generic.rs` to `mcan/src/reg/`
3. Copy `generic/` to `mcan/src/reg/`
4. Overwrite `rxf{a,c,s}.rs` with `rxf0{a,c,s}.rs`
5. Re-apply the merge the two FIFO queues (https://github.com/GrepitAB/mcan/commit/57d1266b938e0be31b32e5aef49a5da65a556c39)
6. Re-apply fix for docs relating to the move into reg module, along
  with wrong docs for tdcr (https://github.com/GrepitAB/mcan/commit/2dcd7a37f73a8ba6de4ef87a89e251b386b6c9e0)
7. Re-apply the item-level docs for `generics.rs`
8. Remove customer specific register information from `cust.rs`
9. Fix build errors that was caused by the svd2rust update

Note: This update is based on the [SVD file](https://github.com/atsamd-rs/atsamd/blob/b138702539afa9ec12f17aa5b2765f59289b83ce/svd/ATSAME51N19A.svd) used by the atsame51n pac
crate (0.13.0).
There are newer files available, but these does not contain changes that concerns the MCAN peripheral.

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All tests pass and in the best case you also added new tests.
- [x] `cargo +stable fmt` was run.
- [x] `cargo +stable clippy` yields no `warnings`.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You add a description of your work to this PR.
- [x] You added proper docs (in code, rustdoc and README.md) for your
      newly added features and code.
