### PR TITLE
Add method to finalize config into initialization mode

### DIFF
--- a/mcan/CHANGELOG.md
+++ b/mcan/CHANGELOG.md
@@ -5,6 +5,7 @@ Tagging in git follows a pattern: `mcan/<version>`.
 ## [Unreleased]
 - *Breaking* Update the register mappings with svd2rust 0.30.2 and form 0.10.0 (#46)
 - Add safe way to shutdown the bus when actively transmitting/receiving (#45)
+- Add method to finalize configuration into initialization mode (#47)
 
 ## [0.4.0] - 2023-10-24
 

--- a/mcan/src/bus.rs
+++ b/mcan/src/bus.rs
@@ -575,6 +575,16 @@ impl<'a, Id: mcan_core::CanId, D: mcan_core::Dependencies<Id>, C: Capacities>
         Ok(can)
     }
 
+    /// Locks the configuration and enters initialization mode.
+    pub fn finalize_initialized(mut self) -> Result<Can<'a, Id, D, C>, ConfigurationError> {
+        self.apply_configuration()?;
+
+        let can = self.0;
+        can.aux.initialization_mode();
+
+        Ok(can)
+    }
+
     /// Locks the configuration and enters normal operation.
     pub fn finalize(mut self) -> Result<Can<'a, Id, D, C>, ConfigurationError> {
         self.apply_configuration()?;


### PR DESCRIPTION
It is useful for applications to be able to decide when to bring MCAN into operational mode. Therefore, add the option for user to finalize the configuration into initialization mode rather than operational mode directly.

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All tests pass and in the best case you also added new tests.
- [x] `cargo +stable fmt` was run.
- [x] `cargo +stable clippy` yields no `warnings`.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You add a description of your work to this PR.
- [x] You added proper docs (in code, rustdoc and README.md) for your
      newly added features and code.
