### PR TITLE
Release mcan/0.5.0

### DIFF
--- a/mcan/CHANGELOG.md
+++ b/mcan/CHANGELOG.md
@@ -3,9 +3,15 @@
 Tagging in git follows a pattern: `mcan/<version>`.
 
 ## [Unreleased]
-- *Breaking* Update the register mappings with svd2rust 0.30.2 and form 0.10.0 (#46)
+
+## [0.5.0] - 2024-03-04
+
+### Added
 - Add safe way to shutdown the bus when actively transmitting/receiving (#45)
 - Add method to finalize configuration into initialization mode (#47)
+
+### Changed
+- *Breaking* Update the register mappings with svd2rust 0.30.2 and form 0.10.0 (#46)
 
 ## [0.4.0] - 2023-10-24
 

--- a/mcan/Cargo.toml
+++ b/mcan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcan"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Unofficial MCAN Hardware Abstraction Layer"
 keywords = ["no-std", "can"]


### PR DESCRIPTION
# Release 0.5.0
### Added
- Add safe way to shutdown the bus when actively transmitting/receiving (#45)
- Add method to finalize configuration into initialization mode (#47)

### Changed
- *Breaking* Update the register mappings with svd2rust 0.30.2 and form 0.10.0 (#46)

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All tests pass and in the best case you also added new tests.
- [x] `cargo +stable fmt` was run.
- [x] `cargo +stable clippy` yields no `warnings`.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You add a description of your work to this PR.
- [x] You added proper docs (in code, rustdoc and README.md) for your
      newly added features and code.
