### PR TITLE
receive_any: Use trailing_zeros to improve performance

### DIFF
--- a/mcan/CHANGELOG.md
+++ b/mcan/CHANGELOG.md
@@ -3,6 +3,7 @@
 Tagging in git follows a pattern: `mcan/<version>`.
 
 ## [Unreleased]
+- Improve performance of RxDedicatedBuffer::receive_any (#50)
 
 ## [0.5.0] - 2024-03-04
 

--- a/mcan/src/rx_dedicated_buffers.rs
+++ b/mcan/src/rx_dedicated_buffers.rs
@@ -124,17 +124,12 @@ impl<'a, P: mcan_core::CanId, M: rx::AnyMessage> DynRxDedicatedBuffer
     }
 
     fn receive_any(&mut self) -> nb::Result<Self::Message, Infallible> {
-        self.memory
-            .iter()
-            .enumerate()
-            .filter(|&(i, _)| self.has_new_data(i))
-            .map(|(i, m)| (i, m.get()))
-            .min_by_key(|(_, m)| m.id())
-            .map(|(i, m)| {
-                self.mark_buffer_read(i);
-                m
-            })
-            .ok_or(nb::Error::WouldBlock)
+        let ndat =
+            (self.ndat1().read().bits() as u64) | ((self.ndat2().read().bits() as u64) << 32);
+        let idx = ndat.trailing_zeros() as usize;
+        let m = self.memory.get(idx).ok_or(nb::Error::WouldBlock)?;
+        self.mark_buffer_read(idx);
+        Ok(m.get())
     }
 }
 


### PR DESCRIPTION
In current code, `receive_any` needs to do loop operation to iterate over memory buffer to check whether there's new data which can consume a lot of CPU time.

This code changes this operation to use `trailing_zeros` to get the first available message directly from NDAT register without any loops.

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All tests pass and in the best case you also added new tests.
- [x] `cargo +stable fmt` was run.
- [ ] (No, but it does not relate to my code) `cargo +stable clippy` yields no `warnings`.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You add a description of your work to this PR.
- [x] You added proper docs (in code, rustdoc and README.md) for your
      newly added features and code.
