### PR TITLE
Add method to check if bus is dominant

### DIFF
--- a/mcan/CHANGELOG.md
+++ b/mcan/CHANGELOG.md
@@ -3,6 +3,7 @@
 Tagging in git follows a pattern: `mcan/<version>`.
 
 ## [Unreleased]
+- Add method to check if bus is dominant (#51)
 
 ## [0.5.0] - 2024-03-04
 

--- a/mcan/src/bus.rs
+++ b/mcan/src/bus.rs
@@ -199,6 +199,9 @@ pub trait DynAux {
     ///
     /// If timestamping is disabled, its value is zero.
     fn timestamp(&self) -> u16;
+
+    /// Returns `true` if the CAN bus is dominant.
+    fn is_dominant(&self) -> bool;
 }
 
 impl<Id: mcan_core::CanId, D: mcan_core::Dependencies<Id>> Aux<'_, Id, D> {
@@ -241,6 +244,10 @@ impl<Id: mcan_core::CanId, D: mcan_core::Dependencies<Id>> DynAux for Aux<'_, Id
 
     fn timestamp(&self) -> u16 {
         self.reg.tscv.read().tsc().bits()
+    }
+
+    fn is_dominant(&self) -> bool {
+        self.reg.test.read().rx().bit_is_clear()
     }
 }
 


### PR DESCRIPTION
Checking if the bus is dominant (i.e., the RX pin value is low) can be particularly useful in scenarios where the transceiver is put into sleep mode. Some transceivers (such as TCAN1043-Q1[1]) signals wake-up by setting the RX pin (and nFAULT) to low while being in sleep mode. To accurately tell if the transceiver requests a wake-up, the RX pin state needs to be accessible from the application.

Fortunately MCAN exposes a way to read the state of the RX pin through its `TEST` register. Extend the `DynAux` trait with an additional method that reads the `RX` bit from that register.

[1]: https://www.ti.com/product/TCAN1043-Q1

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All tests pass and in the best case you also added new tests.
- [x] `cargo +stable fmt` was run.
- [x] `cargo +stable clippy` yields no `warnings`.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You add a description of your work to this PR.
- [x] You added proper docs (in code, rustdoc and README.md) for your
      newly added features and code.
