### PR TITLE
Fix new clippy warnings from Rust 1.84.0

### DIFF
--- a/mcan/src/bus.rs
+++ b/mcan/src/bus.rs
@@ -201,13 +201,13 @@ pub trait DynAux {
     fn timestamp(&self) -> u16;
 }
 
-impl<'a, Id: mcan_core::CanId, D: mcan_core::Dependencies<Id>> Aux<'a, Id, D> {
+impl<Id: mcan_core::CanId, D: mcan_core::Dependencies<Id>> Aux<'_, Id, D> {
     fn configuration_mode(&self) {
         self.reg.configuration_mode()
     }
 }
 
-impl<'a, Id: mcan_core::CanId, D: mcan_core::Dependencies<Id>> DynAux for Aux<'a, Id, D> {
+impl<Id: mcan_core::CanId, D: mcan_core::Dependencies<Id>> DynAux for Aux<'_, Id, D> {
     type Id = Id;
     type Deps = D;
 

--- a/mcan/src/config.rs
+++ b/mcan/src/config.rs
@@ -43,6 +43,7 @@ pub struct TxConfig {
 /// - the time quantum `t_q`, which is a fraction of the peripheral clock
 /// - the number of time quanta in a bit time, determined by `phase_seg_1` and
 ///   `phase_seg_2`
+///
 /// The configurable ranges of the parameters depend on which timing is changed.
 ///
 /// This struct expects *real* values, extra subtractions and additions expected

--- a/mcan/src/interrupt.rs
+++ b/mcan/src/interrupt.rs
@@ -458,7 +458,7 @@ impl<Id: mcan_core::CanId, State> OwnedInterruptSet<Id, State> {
     ///
     /// # Safety
     /// - Each interrupt of a CAN peripheral can only be contained in one
-    /// `OwnedInterruptSet`, otherwise registers will be mutably aliased.
+    ///   `OwnedInterruptSet`, otherwise registers will be mutably aliased.
     /// - The reserved bits must not be included.
     /// - `State` type parameter must match the state in runtime.
     unsafe fn new(interrupts: InterruptSet) -> Self {

--- a/mcan/src/message/tx.rs
+++ b/mcan/src/message/tx.rs
@@ -107,7 +107,7 @@ pub struct MessageBuilder<'a> {
     pub store_tx_event: Option<u8>,
 }
 
-impl<'a> MessageBuilder<'a> {
+impl MessageBuilder<'_> {
     /// Create the message in the format required by the peripheral.
     pub fn build<const N: usize>(self) -> Result<Message<N>, TooMuchData> {
         let mut data = [0; N];

--- a/mcan/src/messageram.rs
+++ b/mcan/src/messageram.rs
@@ -91,3 +91,9 @@ impl<C: Capacities> SharedMemory<C> {
         eligible_message_ram_start <= start && end_exclusive - eligible_message_ram_start <= 1 << 16
     }
 }
+
+impl<C: Capacities> Default for SharedMemory<C> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/mcan/src/rx_dedicated_buffers.rs
+++ b/mcan/src/rx_dedicated_buffers.rs
@@ -111,9 +111,7 @@ impl<'a, P: mcan_core::CanId, M: rx::AnyMessage> RxDedicatedBuffer<'a, P, M> {
     }
 }
 
-impl<'a, P: mcan_core::CanId, M: rx::AnyMessage> DynRxDedicatedBuffer
-    for RxDedicatedBuffer<'a, P, M>
-{
+impl<P: mcan_core::CanId, M: rx::AnyMessage> DynRxDedicatedBuffer for RxDedicatedBuffer<'_, P, M> {
     type Id = P;
     type Message = M;
 
@@ -138,7 +136,7 @@ impl<'a, P: mcan_core::CanId, M: rx::AnyMessage> DynRxDedicatedBuffer
     }
 }
 
-impl<'a, P: mcan_core::CanId, M: rx::AnyMessage> Iterator for RxDedicatedBuffer<'a, P, M> {
+impl<P: mcan_core::CanId, M: rx::AnyMessage> Iterator for RxDedicatedBuffer<'_, P, M> {
     type Item = M;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/mcan/src/rx_fifo.rs
+++ b/mcan/src/rx_fifo.rs
@@ -54,12 +54,12 @@ pub trait GetRxFifoRegs {
     unsafe fn registers(&self) -> &reg::RxFifoRegs;
 }
 
-impl<'a, P: mcan_core::CanId, M: rx::AnyMessage> GetRxFifoRegs for RxFifo<'a, Fifo0, P, M> {
+impl<P: mcan_core::CanId, M: rx::AnyMessage> GetRxFifoRegs for RxFifo<'_, Fifo0, P, M> {
     unsafe fn registers(&self) -> &reg::RxFifoRegs {
         &(*P::register_block()).rxf0
     }
 }
-impl<'a, P: mcan_core::CanId, M: rx::AnyMessage> GetRxFifoRegs for RxFifo<'a, Fifo1, P, M> {
+impl<P: mcan_core::CanId, M: rx::AnyMessage> GetRxFifoRegs for RxFifo<'_, Fifo1, P, M> {
     unsafe fn registers(&self) -> &reg::RxFifoRegs {
         &(*P::register_block()).rxf1
     }
@@ -90,7 +90,7 @@ where
     }
 }
 
-impl<'a, F, P: mcan_core::CanId, M: rx::AnyMessage> DynRxFifo for RxFifo<'a, F, P, M>
+impl<F, P: mcan_core::CanId, M: rx::AnyMessage> DynRxFifo for RxFifo<'_, F, P, M>
 where
     Self: GetRxFifoRegs,
 {
@@ -128,7 +128,7 @@ where
     }
 }
 
-impl<'a, F, P: mcan_core::CanId, M: rx::AnyMessage> Iterator for RxFifo<'a, F, P, M>
+impl<F, P: mcan_core::CanId, M: rx::AnyMessage> Iterator for RxFifo<'_, F, P, M>
 where
     Self: GetRxFifoRegs,
 {

--- a/mcan/src/tx_buffers.rs
+++ b/mcan/src/tx_buffers.rs
@@ -260,7 +260,7 @@ impl<'a, P: mcan_core::CanId, C: Capacities> Tx<'a, P, C> {
     }
 }
 
-impl<'a, P: mcan_core::CanId, C: Capacities> DynTx for Tx<'a, P, C> {
+impl<P: mcan_core::CanId, C: Capacities> DynTx for Tx<'_, P, C> {
     type Id = P;
     type Message = C::TxMessage;
 

--- a/mcan/src/tx_event_fifo.rs
+++ b/mcan/src/tx_event_fifo.rs
@@ -61,7 +61,7 @@ impl<'a, P: mcan_core::CanId> TxEventFifo<'a, P> {
     }
 }
 
-impl<'a, P: mcan_core::CanId> DynTxEventFifo for TxEventFifo<'a, P> {
+impl<P: mcan_core::CanId> DynTxEventFifo for TxEventFifo<'_, P> {
     type Id = P;
 
     fn len(&self) -> usize {


### PR DESCRIPTION
* Elide lifetimes as suggested by `clippy::needless_lifetimes`[1]

* Fix doc list indentation warnings, `clippy::doc_lazy_continuation`[2], as appropriate

* Add `Default` implementation for `SharedMemory` as suggested by `clippy::new_without_default`[3]

[1]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
[2]: https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation
[3]: https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All tests pass and in the best case you also added new tests.
- [x] `cargo +stable fmt` was run.
- [x] `cargo +stable clippy` yields no `warnings`.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You add a description of your work to this PR.
- [x] You added proper docs (in code, rustdoc and README.md) for your
      newly added features and code.
