### PR TITLE
Add method to check if Tx FIFO/QUEUE is full

### DIFF
--- a/mcan/CHANGELOG.md
+++ b/mcan/CHANGELOG.md
@@ -4,6 +4,9 @@ Tagging in git follows a pattern: `mcan/<version>`.
 
 ## [Unreleased]
 
+### Added
+- Add method to query the Tx FIFO/Queue full status.
+
 ## [0.6.0] - 2025-02-04
 
 ### Added

--- a/mcan/src/bus.rs
+++ b/mcan/src/bus.rs
@@ -202,6 +202,9 @@ pub trait DynAux {
 
     /// Returns `true` if the CAN bus is dominant.
     fn is_dominant(&self) -> bool;
+
+    /// Returns `true` if the TX FIFO/Queue is full.
+    fn tx_buffer_full(&self) -> bool;
 }
 
 impl<Id: mcan_core::CanId, D: mcan_core::Dependencies<Id>> Aux<'_, Id, D> {
@@ -248,6 +251,9 @@ impl<Id: mcan_core::CanId, D: mcan_core::Dependencies<Id>> DynAux for Aux<'_, Id
 
     fn is_dominant(&self) -> bool {
         self.reg.test.read().rx().bit_is_clear()
+    }
+    fn tx_buffer_full(&self) -> bool {
+        self.reg.txfqs.read().tfqf().bit_is_set()
     }
 }
 

--- a/mcan/src/filter.rs
+++ b/mcan/src/filter.rs
@@ -230,7 +230,12 @@ impl From<Filter> for FilterStandardId {
                 id,
                 msg_type,
                 offset,
-            } => (id.as_raw() as u32) << 16 | (msg_type as u32) << 9 | offset as u32 | (0x7 << 27),
+            } => {
+                ((id.as_raw() as u32) << 16)
+                    | ((msg_type as u32) << 9)
+                    | offset as u32
+                    | (0x7 << 27)
+            }
         };
 
         FilterStandardId(v)
@@ -244,12 +249,12 @@ impl From<ExtFilter> for FilterExtendedId {
             ExtFilter::MaskedRange { action, high, low } => {
                 let action: u32 = action.into();
 
-                ((action << 29 | low.as_raw()), high.as_raw())
+                ((action << 29) | low.as_raw(), high.as_raw())
             }
             ExtFilter::Dual { action, id1, id2 } => {
                 let action: u32 = action.into();
 
-                ((action << 29 | id1.as_raw()), (1 << 30 | id2.as_raw()))
+                ((action << 29) | id1.as_raw(), (1 << 30) | id2.as_raw())
             }
             ExtFilter::Classic {
                 action,
@@ -258,20 +263,20 @@ impl From<ExtFilter> for FilterExtendedId {
             } => {
                 let action: u32 = action.into();
 
-                ((action << 29 | filter.as_raw()), (2 << 30 | mask.as_raw()))
+                ((action << 29) | filter.as_raw(), (2 << 30) | mask.as_raw())
             }
             ExtFilter::Range { action, high, low } => {
                 let action: u32 = action.into();
 
-                ((action << 29 | low.as_raw()), (3 << 30 | high.as_raw()))
+                ((action << 29) | low.as_raw(), (3 << 30) | high.as_raw())
             }
             ExtFilter::StoreBuffer {
                 id,
                 msg_type,
                 offset,
             } => (
-                (0x7 << 29 | id.as_raw()),
-                (msg_type as u32) << 9 | offset as u32,
+                (0x7 << 29) | id.as_raw(),
+                ((msg_type as u32) << 9) | offset as u32,
             ),
         };
         FilterExtendedId([v1, v2])

--- a/mcan/src/message/tx.rs
+++ b/mcan/src/message/tx.rs
@@ -149,7 +149,7 @@ impl MessageBuilder<'_> {
         let efc = self.store_tx_event.is_some();
         let mm = self.store_tx_event.unwrap_or(0);
 
-        let t0 = id_field | (rtr as u32) << 29 | (xtd as u32) << 30 | (esi as u32) << 31;
+        let t0 = id_field | ((rtr as u32) << 29) | ((xtd as u32) << 30) | ((esi as u32) << 31);
         let t1 = (((dlc & 0xf) as u32) << 16)
             | ((brs as u32) << 20)
             | ((fdf as u32) << 21)


### PR DESCRIPTION
To help when diagnosing the reason for a failed transmission, the TFQF, Tx FIFO/Queue Full, status is exposed through the `DynAux` trait.

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All tests pass and in the best case you also added new tests.
- [x] `cargo +stable fmt` was run.
- [x] `cargo +stable clippy` yields no `warnings`.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You add a description of your work to this PR.
- [x] You added proper docs (in code, rustdoc and README.md) for your
      newly added features and code.
