### PR TITLE
Add method to check if Tx FIFO/QUEUE is full

### DIFF
--- a/mcan/CHANGELOG.md
+++ b/mcan/CHANGELOG.md
@@ -4,6 +4,9 @@ Tagging in git follows a pattern: `mcan/<version>`.
 
 ## [Unreleased]
 
+### Added
+- Add method to query the Tx FIFO/Queue full status (#56)
+
 ## [0.6.0] - 2025-02-04
 
 ### Added

--- a/mcan/src/bus.rs
+++ b/mcan/src/bus.rs
@@ -202,6 +202,9 @@ pub trait DynAux {
 
     /// Returns `true` if the CAN bus is dominant.
     fn is_dominant(&self) -> bool;
+
+    /// Returns `true` if the TX FIFO/Queue is full.
+    fn tx_buffer_full(&self) -> bool;
 }
 
 impl<Id: mcan_core::CanId, D: mcan_core::Dependencies<Id>> Aux<'_, Id, D> {
@@ -248,6 +251,10 @@ impl<Id: mcan_core::CanId, D: mcan_core::Dependencies<Id>> DynAux for Aux<'_, Id
 
     fn is_dominant(&self) -> bool {
         self.reg.test.read().rx().bit_is_clear()
+    }
+
+    fn tx_buffer_full(&self) -> bool {
+        self.reg.txfqs.read().tfqf().bit_is_set()
     }
 }
 


### PR DESCRIPTION
To help when diagnosing the reason for a failed transmission, the TFQF, Tx FIFO/Queue Full, status is exposed through the DynAux trait.

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All tests pass and in the best case you also added new tests.
- [x] `cargo +stable fmt` was run.
- [x] (Not related to this change, see other PR) `cargo +stable clippy` yields no `warnings`.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You add a description of your work to this PR.
- [x] You added proper docs (in code, rustdoc and README.md) for your
      newly added features and code.
