### PR TITLE
Allow for fractional baudrates (Closes #58)

### DIFF
--- a/mcan/CHANGELOG.md
+++ b/mcan/CHANGELOG.md
@@ -3,6 +3,7 @@
 Tagging in git follows a pattern: `mcan/<version>`.
 
 ## [Unreleased]
+- Added support for fractional baudrates (#59)
 
 ## [0.7.0] - 2025-04-23
 

--- a/mcan/src/config.rs
+++ b/mcan/src/config.rs
@@ -209,13 +209,11 @@ impl BitTiming {
                     Ok(prescaler as u16)
                 }
             }
-            _ => {
-                Err(BitTimingError::NoValidPrescaler {
-                    can_clock: f_can,
-                    bitrate: f_out,
-                    bit_time_quanta,
-                })
-            }
+            _ => Err(BitTimingError::NoValidPrescaler {
+                can_clock: f_can,
+                bitrate: f_out,
+                bit_time_quanta,
+            }),
         }
     }
 }

--- a/mcan/src/config.rs
+++ b/mcan/src/config.rs
@@ -199,19 +199,23 @@ impl BitTiming {
         let f_out = self.bitrate;
         let bit_time_quanta = self.time_quanta_per_bit();
         let f_q = f_out * bit_time_quanta;
-        if let Some(0) = f_can.to_Hz().checked_rem(f_q.to_Hz()) {
-            let prescaler = f_can / f_q;
-            if !valid.prescaler.contains(&prescaler) {
-                Err(BitTimingError::PrescalerOutOfRange(valid.prescaler.clone()))
-            } else {
-                Ok(prescaler as u16)
+        let max_tolerance = self.bitrate.to_Hz() / 2000; // 0.05% tolerance
+        match f_can.to_Hz().checked_rem(f_q.to_Hz()) {
+            Some(x) if x <= max_tolerance => {
+                let prescaler = f_can / f_q;
+                if !valid.prescaler.contains(&prescaler) {
+                    Err(BitTimingError::PrescalerOutOfRange(valid.prescaler.clone()))
+                } else {
+                    Ok(prescaler as u16)
+                }
             }
-        } else {
-            Err(BitTimingError::NoValidPrescaler {
-                can_clock: f_can,
-                bitrate: f_out,
-                bit_time_quanta,
-            })
+            _ => {
+                Err(BitTimingError::NoValidPrescaler {
+                    can_clock: f_can,
+                    bitrate: f_out,
+                    bit_time_quanta,
+                })
+            }
         }
     }
 }

--- a/mcan/src/config.rs
+++ b/mcan/src/config.rs
@@ -69,7 +69,7 @@ pub struct BitTiming {
     /// determined by `phase_seg_1` and `phase_seg_2` is a whole number of time
     /// quanta.
     ///
-    /// When [`allow_fractional`] is selected, the real bitrate
+    /// When [`Self::allow_fractional`] is selected, the real bitrate
     /// is allowed to be up to 0.05% off (Which is within tolerance)
     pub bitrate: HertzU32,
     /// Allows for fractional bitrates where there may be no perfect

--- a/mcan/src/config.rs
+++ b/mcan/src/config.rs
@@ -68,14 +68,14 @@ pub struct BitTiming {
     /// MCAN peripheral is divisible into time quanta such that the bit time
     /// determined by `phase_seg_1` and `phase_seg_2` is a whole number of time
     /// quanta.
-    /// 
+    ///
     /// When [`allow_fractional`] is selected, the real bitrate
     /// is allowed to be up to 0.05% off (Which is within tolerance)
     pub bitrate: HertzU32,
     /// Allows for fractional bitrates where there may be no perfect
     /// combination of bit-timing parameters. This is useful for bitrates
     /// like 83.3kbps where some tolerance is allowed (Up to 0.05%).
-    pub allow_fractional: bool
+    pub allow_fractional: bool,
 }
 
 impl BitTiming {
@@ -91,7 +91,7 @@ impl BitTiming {
             phase_seg_1: 0xB,
             phase_seg_2: 0x4,
             bitrate,
-            allow_fractional: false
+            allow_fractional: false,
         }
     }
 }


### PR DESCRIPTION
This PR resolves calculating prescaler when a fractional baud rate is requested (IE: 83333bps or 666666bps)

The prescaler function errors out if `f_can/f_out*tq` does not equal 0. This means for fractional baudrates, the MCAN's clock would also need to be fractional, which is very hard to achieve on most MCUs.

Therefore, this PR adjusts the prescaler function to allow for a maximum error of 0.05% (CAN has a tolerance of 0.75% on CAN FD and ~1% on normal CAN), rather than requiring a perfect clock combination.
