### PR TITLE
Add method to disable automatic retransmission

### DIFF
--- a/mcan/CHANGELOG.md
+++ b/mcan/CHANGELOG.md
@@ -3,7 +3,10 @@
 Tagging in git follows a pattern: `mcan/<version>`.
 
 ## [Unreleased]
-- Added support for fractional baudrates (#59)
+
+### Added
+- Add support for fractional baudrates (#59)
+- Add method to disable automatic retransmission (#60)
 
 ## [0.7.0] - 2025-04-23
 

--- a/mcan/src/bus.rs
+++ b/mcan/src/bus.rs
@@ -205,6 +205,12 @@ pub trait DynAux {
 
     /// Returns `true` if the TX FIFO/Queue is full.
     fn tx_buffer_full(&self) -> bool;
+
+    /// Enable or disable automatic retransmission of messages that are not
+    /// transmitted successfully.
+    ///
+    /// Note: This is enabled by default.
+    fn automatic_retransmission(&self, enabled: bool);
 }
 
 impl<Id: mcan_core::CanId, D: mcan_core::Dependencies<Id>> Aux<'_, Id, D> {
@@ -255,6 +261,10 @@ impl<Id: mcan_core::CanId, D: mcan_core::Dependencies<Id>> DynAux for Aux<'_, Id
 
     fn tx_buffer_full(&self) -> bool {
         self.reg.txfqs.read().tfqf().bit_is_set()
+    }
+
+    fn automatic_retransmission(&self, enabled: bool) {
+        self.reg.cccr.modify(|_, w| w.dar().variant(!enabled));
     }
 }
 


### PR DESCRIPTION
To support time-triggered communication as described in ISO 11898-1:2015, automatic retransmission can be disabled through the DynAux trait.

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [ ] The code compiles without `errors` or `warnings`.
- [ ] All tests pass and in the best case you also added new tests.
- [ ] `cargo +stable fmt` was run.
- [ ] `cargo +stable clippy` yields no `warnings`.
- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You add a description of your work to this PR.
- [ ] You added proper docs (in code, rustdoc and README.md) for your
      newly added features and code.
