### PR TITLE
Allow mismatched_lifetime_syntaxes lint on reg code

### DIFF
--- a/mcan/src/reg.rs
+++ b/mcan/src/reg.rs
@@ -1,6 +1,7 @@
 //! Low-level access to peripheral registers
 
 #![allow(non_camel_case_types)]
+#![allow(mismatched_lifetime_syntaxes)]
 pub mod generic;
 
 /// Blanket implementation trait that provides convenience method for recasting


### PR DESCRIPTION
Due to updated Rust toolchain the new `mismatched_lifetime_syntaxes`[1] lint is temporarily allowed on the generated svd2rust code for all the MCAN registers until the code has been regenerated and customized with a newer svd2rust version.

[1]: https://doc.rust-lang.org/beta/nightly-rustc/rustc_lint/lifetime_syntax/static.MISMATCHED_LIFETIME_SYNTAXES.html

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All tests pass and in the best case you also added new tests.
- [x] `cargo +stable fmt` was run.
- [x] `cargo +stable clippy` yields no `warnings`.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You add a description of your work to this PR.
- [x] You added proper docs (in code, rustdoc and README.md) for your
      newly added features and code.
